### PR TITLE
place go-basic in top level on release, not in subsets. 

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -88,7 +88,7 @@ prepare_release: build
 	cp imports/*.owl $(RELEASEDIR_IMPORTS) &&\
 	cp imports/*.obo $(RELEASEDIR_IMPORTS) &&\
 	cp extensions/* $(RELEASEDIR)/extensions &&\
-	cp go-basic.* $(RELEASEDIR)/subsets &&\
+	cp go-basic.* $(RELEASEDIR) &&\
 	cp subsets/* $(RELEASEDIR)/subsets &&\
 	echo "Release files are now in $(RELEASEDIR)"
 


### PR DESCRIPTION
Fixes #13364 