### PR TITLE
WIP: never-in-taxon axioms

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -141,9 +141,15 @@ change-report.txt: $(SRC) $(PREVIOUS)
 # OWL
 # ----------------------------------------
 
+disjoint_in_taxon.owl: $(SRC)
+	robot query -i $< --construct ../sparql/constructDisjointInTaxon.sparql $@ -f ttl
+
+enhanced.owl: $(SRC) disjoint_in_taxon.owl
+	$(OWLTOOLS) $(USECAT) $^ --merge-support-ontologies -o $@
+
 # reasoned.owl is equivalent to editors source, after reason-relax-reduce pipeline
 # note: we keep this as a distinct intermediate target as the ontology IRI needs to be 'go' for Oort to work...
-reasoned.owl: $(SRC) $(SRC)-check
+reasoned.owl: enhanced.owl $(SRC)-check
 	$(ROBOT)  reason -i $< -r ELK relax  annotate -V $(RELEASE_URIBASE)/$(ONT).owl -o $@
 
 # equivalent to reasoned, but we rename
@@ -208,7 +214,7 @@ all_imports: $(IMPORTS_OWL)
 clean_imports:
 	rm mirror/*
 
-seed.txt: $(SRC)
+seed.txt: enhanced.owl
 	owltools --use-catalog $< --export-table $@.tmp && cut -f1 $@.tmp > $@
 
 imports/%_terms_combined.txt: imports/%_terms.txt seed.txt

--- a/src/sparql/constructDisjointInTaxon.sparql
+++ b/src/sparql/constructDisjointInTaxon.sparql
@@ -1,0 +1,16 @@
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix GO: <http://purl.obolibrary.org/obo/GO_>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix in_taxon: <http://purl.obolibrary.org/obo/RO_0002162>
+prefix never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
+
+CONSTRUCT
+  {?c owl:disjointWith [
+    a owl:Restriction ;
+    owl:onProperty in_taxon: ;
+    owl:someValuesFrom ?t
+   ]
+  }
+WHERE {?c never_in_taxon: ?t }


### PR DESCRIPTION
This change uses a SPARQL CONSTRUCT to make the logically visible axiom
(e.g. GO:nn DisjointWith in-taxon some NCBITaxon:yy) and merge it in.
This will be visible to reasoning; and to module extraction.

Note that it would be simpler to directly include the disjointness axiom
in the ontology, but this is outside the scope of obof.

Also some tools downstream may depend on the simple annotation assertion
being present.

This may bear some relationship to #13658