### PR TITLE
Added new sparql query that checks syncs between gene resources

### DIFF
--- a/src/sparql/go-sync-check.sparql
+++ b/src/sparql/go-sync-check.sparql
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+# The original query
+# SELECT ?x ?r ?clsIdentifier WHERE {
+#	 ?cls a owl:Class;	    
+#	      owl:deprecated "true"^^xsd:boolean .       
+#  	 ?x ?r ?clsIdentifier       
+#	 FILTER (str(?clsIdentifier) = replace(str(?cls),"http://purl.obolibrary.org/obo/GO_","GO:"))
+# }
+
+# Executed the rewritten query as "time ./robot query --input go-edit.obo --select go-sync-check.sparql go-sync-check.tsv".
+# Using the bind function and the inner filter condition allows reducing the execution time up to approx. 1 mins (mostly loading time).
+# Thank you for your tips, Jim!
+
+SELECT ?x ?r ?clsIdentifier WHERE {
+	{
+		SELECT ?x ?r ?cls ?clsIdentifier {
+			?x ?r ?clsIdentifier .
+			FILTER (STRSTARTS(str(?clsIdentifier), "GO:"))
+			BIND( IRI(REPLACE(str(?clsIdentifier),"GO:","http://purl.obolibrary.org/obo/GO_")) AS ?cls)
+		}
+	}
+	?cls a owl:Class;
+	     owl:deprecated "true"^^xsd:boolean .
+}


### PR DESCRIPTION
* Chris drafted the initial query to cover [this issue](https://github.com/geneontology/go-ontology/issues/14432) and I additionally rewrote the query based on Jim's suggestion for optimizations. I included the initial query as comments as well.