### PR TITLE
adds an equivalent class check, allowing asserted equivalent classes

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -161,7 +161,7 @@ enhanced.owl: $(SRC) disjoint_in_taxon.owl
 # reasoned.owl is equivalent to editors source, after reason-relax-reduce pipeline
 # note: we keep this as a distinct intermediate target as the ontology IRI needs to be 'go' for Oort to work...
 reasoned.owl: enhanced.owl $(SRC)-check
-	$(ROBOT)  reason -i $< -r ELK relax reduce  annotate -V $(RELEASE_URIBASE)/$(ONT).owl -o $@
+	$(ROBOT)  reason -i $< -r ELK -e asserted-only relax reduce  annotate -V $(RELEASE_URIBASE)/$(ONT).owl -o $@
 
 # equivalent to reasoned, but we rename
 $(GO_PLUS).owl: reasoned.owl


### PR DESCRIPTION
This changes the makefile so that when building `reasoned.owl` it checks for non-asserted equivalent classes, and fails (exits) if it finds any. I think this is what you're looking for.