### PR TITLE
outputing times for each command automatically

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -3,6 +3,7 @@ all: stage_release
 # ----------------------------------------
 # CORE VARIABLES
 # ----------------------------------------
+SHELL = ./report_time.sh
 
 # base URI for all OBO library ontologies
 OBO=http://purl.obolibrary.org/obo

--- a/src/ontology/report_time.sh
+++ b/src/ontology/report_time.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+shift
+time sh -c "$*"


### PR DESCRIPTION
In the service of understanding which commands take the longest _on travis_ 

Locally (on my computer), the travis_check does take just 10 minutes. If we see something that takes a super long time, we'll see it in the travis logs.