### PR TITLE
updated Reactome xrefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ target/
 # Mac specific weirdness
 .DS_Store
 src/.DS_Store
+src/ontology/imports/catalog-v001.xml


### PR DESCRIPTION
Using mapping file provided by Reactome, executed a script that replaced the old REACT_ ids with their corresponding current HSA_..  ids.  Also removed xrefs to non-human reactome ids as these are not stable and are generated automatically from the human ids.  Removed old xrefs to REACT_ids that have no current mapping.  See issue comments https://github.com/geneontology/go-ontology/pull/15921 for more information.