### PR TITLE
Add SPARQL check for never_in_taxon annotation values which are not IRIs.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -416,7 +416,7 @@ imports/go-taxon-groupings.obo: imports/go-taxon-groupings.owl
 # these live in the ../sparql directory, and have suffix -violation.sparql
 # adding the name here will make the violation check live
 
-VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym
+VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym never-in-taxon-non-IRI-value
 
 # run all violation checks
 VARGS = $(foreach V,$(VCHECKS), $(SPARQLDIR)/$V-violation.sparql)

--- a/src/sparql/never-in-taxon-non-IRI-value-violation.sparql
+++ b/src/sparql/never-in-taxon-non-IRI-value-violation.sparql
@@ -1,0 +1,15 @@
+PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
+
+# This could be generalized to check any annotation properties that 
+# are meant to have term (IRI) values, and sometimes accidentally get 
+# filled with strings.
+SELECT ?goTerm ?taxon
+WHERE {
+  ?goTerm never_in_taxon: ?taxon .
+  FILTER (!isIRI(?taxon))
+}


### PR DESCRIPTION
This is to watch for issues such as https://github.com/owlcollab/owltools/issues/262.