### PR TITLE
Strip 'regulates o part_of' chains after reasoning, before releasing ontology.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -183,8 +183,8 @@ enhanced.owl: $(SRC) imports/go_taxon_constraints.owl imports/reactome_xrefs_imp
 
 # reasoned.owl is equivalent to editors source, after reason-relax-reduce pipeline
 # note: we keep this as a distinct intermediate target as the ontology IRI needs to be 'go' for Oort to work...
-reasoned.owl: enhanced.owl $(SRC)-check
-	$(ROBOT) reason -i $< -r ELK -e asserted-only relax reduce annotate -V $(RELEASE_URIBASE)/$(ONT).owl -o $@
+reasoned.owl: enhanced.owl $(SRC)-check regulates_chains.ofn
+	$(ROBOT) reason -i $< -r ELK -e asserted-only relax reduce annotate -V $(RELEASE_URIBASE)/$(ONT).owl unmerge -i regulates_chains.ofn -o $@
 
 # equivalent to reasoned, but we rename
 $(GO_PLUS).owl: reasoned.owl

--- a/src/ontology/regulates_chains.ofn
+++ b/src/ontology/regulates_chains.ofn
@@ -1,0 +1,14 @@
+Prefix(:=<http://example.org/regulates_chains#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://example.org/regulates_chains>
+
+SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/RO_0002211> <http://purl.obolibrary.org/obo/BFO_0000050>) <http://purl.obolibrary.org/obo/RO_0002211>)
+SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/RO_0002212> <http://purl.obolibrary.org/obo/BFO_0000050>) <http://purl.obolibrary.org/obo/RO_0002212>)
+SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/RO_0002213> <http://purl.obolibrary.org/obo/BFO_0000050>) <http://purl.obolibrary.org/obo/RO_0002213>)
+)


### PR DESCRIPTION
We will soon be removing 'regulates o part_of -> regulates' chains from the ontology: #12344

Unfortunately I over eagerly [added some rules to RO](https://github.com/oborel/obo-relations/pull/300) which illustrate the problem with these chains; @goodb has pointed out that having both now in Noctua is causing many logical inconsistencies, especially with models imported from Reactome.

Since the regulates chains are on their way out, but waiting for @ukemi to review the existing subsumptions they were providing, I would like to filter them from the release after they have been used to compute the classification. This way the GO hierarchy remains the same but we don't get the consequences of the chains in Noctua models.

This is a little hacky but it's causing an acute disruption in Noctua at the moment.