### PR TITLE
Fixes for Ljungdahl-Wood pathway #17435

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -148,6 +148,7 @@ GO:0030141	secretory granule	NCBITaxon:4890	Ascomycota
 GO:0030436	asexual sporulation	NCBITaxon:33083	Dictyostelids
 GO:0030492	hemoglobin binding	NCBITaxon:4751	Fungi
 GO:0030579	ubiquitin-dependent SMAD protein catabolic process	NCBITaxon:4751	Fungi
+GO:0030634	carbon fixation by acetyl-CoA pathway	NCBITaxon:2759	Eukaryota
 GO:0030881	beta-2-microglobulin binding	NCBITaxon:4751	Fungi
 GO:0030984	kininogen binding	NCBITaxon:4751	Fungi
 GO:0031048	chromatin silencing by small RNA	NCBITaxon:4930	Saccharomyces


### PR DESCRIPTION
Adding taxon constraint, never in Eukaryotes
(we need a way to give a PMID for TCs!)

Added synonyms with provenance

Moved MetaCyc xref, see #17435

(but we may still want to obsolete the CO form, see ticket)