### PR TITLE
Remove reports queries from travis check.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -86,7 +86,7 @@ test: $(SRC)-check sparql_test change-report.txt reasoned.owl unsatisfiable
 # note: until we go live, the travis test must omit change-report. This is because as a demo repo,
 # we naturally fall behind the actual live PURL. **DELETE THIS TARGET WHEN WE GO LIVE**
 #travis_test: $(SRC)-check sparql_test reasoned.owl
-travis_test: imports/reactome_xrefs_import.owl reasoned.owl $(SRC)-check sparql_test change-report.txt all_reports
+travis_test: imports/reactome_xrefs_import.owl reasoned.owl $(SRC)-check sparql_test change-report.txt
 
 unsatisfiable: $(GO_GAF).owl
 	$(ROBOT) reason --reasoner ELK --input extensions/go-gaf.owl -D $(RELEASEDIR)/core_dump.owl || true


### PR DESCRIPTION
We can remove 1/3 of the Travis time by not querying these reports. As far as I can see they don't provide any check that could fail the build.

Removing them shortens Travis from 33 minutes to 22 minutes.