### PR TITLE
[DO NOT MERGE] Declare GO cellular_component to be a subclass of CARO anatomical entity.

### DIFF
--- a/src/ontology/extensions/go-bridge.owl
+++ b/src/ontology/extensions/go-bridge.owl
@@ -15,6 +15,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/BFO_0000017>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BFO_0000020>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BFO_0000023>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BFO_0000040>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CARO_0000000>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_17843>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_18111>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_24431>))
@@ -41,7 +42,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/SO_0000833>))
 #   Classes
 ############################
 
-# Class: <http://purl.obolibrary.org/obo/BFO_0000023> (<http://purl.obolibrary.org/obo/BFO_0000023>)
+# Class: <http://purl.obolibrary.org/obo/BFO_0000023> (role)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/BFO_0000023> <http://purl.obolibrary.org/obo/CHEBI_50906>)
 
@@ -71,7 +72,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0003674> <http://purl.obolibrary.o
 
 # Class: <http://purl.obolibrary.org/obo/GO_0005575> (cellular_component)
 
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0005575> <http://purl.obolibrary.org/obo/BFO_0000040>)
+SubClassOf(<http://purl.obolibrary.org/obo/GO_0005575> <http://purl.obolibrary.org/obo/CARO_0000000>)
 
 # Class: <http://purl.obolibrary.org/obo/GO_0008150> (biological_process)
 


### PR DESCRIPTION
Required for GO-CAM schema checking.