### PR TITLE
Pipeline issue 35 neo queries

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -296,7 +296,7 @@ seed.txt: enhanced.owl imports/go_taxon_constraints.owl imports/go-taxon-groupin
 imports/pr_terms_combined.txt: imports/pr_terms.txt seed.txt
 	cat $^ | grep 'PR_' > $@
 
-# Specialize seed terms for OPL. 
+# Specialize seed terms for OPL.
 imports/opl_terms_combined.txt: imports/opl_terms.txt seed.txt
 	cat $^ | grep 'OPL_' > $@
 
@@ -510,6 +510,10 @@ reports/%-violation.csv: $(SRC)
 
 check-obsolete-references-including-imports: reasoned.owl
 	$(ROBOT) merge --input reasoned.owl verify --queries $(SPARQLDIR)/obsolete-reference-violation.sparql -O reports/
+
+
+reports/neo-violations.report: $(GO_LEGO).owl
+	$(ROBOT) report --input $(GO_LEGO).owl -p ../sparql/neo/profile.txt -o $@ --print 50 -v
 
 # ----------------------------------------
 # REPORTS

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -513,7 +513,7 @@ check-obsolete-references-including-imports: reasoned.owl
 
 
 reports/neo-violations.report: $(GO_LEGO).owl
-	$(ROBOT) report --input $(GO_LEGO).owl -p ../sparql/neo/profile.txt -o $@ --print 50 -v
+	$(ROBOT) report --input $(GO_LEGO).owl --tdb true --tdb-directory tdb/ -k true -p ../sparql/neo/profile.txt -o $@ --print 50 -v
 
 # ----------------------------------------
 # REPORTS

--- a/src/sparql/neo/eco-root.sparql
+++ b/src/sparql/neo/eco-root.sparql
@@ -1,0 +1,12 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://purl.obolibrary.org/obo/ECO_0000314> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value {<http://purl.obolibrary.org/obo/ECO_0000000> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf* ?value .
+  }
+
+}

--- a/src/sparql/neo/go_0000776-supers.sparql
+++ b/src/sparql/neo/go_0000776-supers.sparql
@@ -1,0 +1,19 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://purl.obolibrary.org/obo/GO_0000776 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/GO_0110165
+# ?super should contain http://purl.obolibrary.org/obo/GO_0005575
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://purl.obolibrary.org/obo/GO_0000776> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value {<http://purl.obolibrary.org/obo/GO_0110165> <http://purl.obolibrary.org/obo/GO_0005575> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}

--- a/src/sparql/neo/go_0022607-superclass.sparql
+++ b/src/sparql/neo/go_0022607-superclass.sparql
@@ -1,0 +1,17 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://purl.obolibrary.org/obo/GO_0022607 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/GO_0008150
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://purl.obolibrary.org/obo/GO_0022607> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value { <http://purl.obolibrary.org/obo/GO_0008150> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}

--- a/src/sparql/neo/go_0060090-superclass.sparql
+++ b/src/sparql/neo/go_0060090-superclass.sparql
@@ -1,0 +1,18 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://purl.obolibrary.org/obo/GO_0060090 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/GO_0003674
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://purl.obolibrary.org/obo/GO_0060090> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value { <http://purl.obolibrary.org/obo/GO_0003674> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}

--- a/src/sparql/neo/profile.txt
+++ b/src/sparql/neo/profile.txt
@@ -1,0 +1,8 @@
+ERROR	file:./../sparql/neo/eco-root.sparql
+ERROR	file:./../sparql/neo/wb-superclasses.sparql
+ERROR	file:./../sparql/neo/go_0000776-supers.sparql
+ERROR	file:./../sparql/neo/go_0022607-superclass.sparql
+ERROR	file:./../sparql/neo/go_0060090-superclass.sparql
+ERROR	file:./../sparql/neo/uniprot-chebi-superclasses.sparql
+ERROR	file:./../sparql/neo/zfin-chebi-superclasses.sparql
+ERROR	file:./../sparql/neo/wb-gene-chebi-superclasses.sparql

--- a/src/sparql/neo/uniprot-chebi-superclasses.sparql
+++ b/src/sparql/neo/uniprot-chebi-superclasses.sparql
@@ -1,0 +1,24 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://identifiers.org/uniprot/Q13253 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/PR_000000001
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_36080
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_33695
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_24431
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://identifiers.org/uniprot/Q13253> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value { <http://purl.obolibrary.org/obo/PR_000000001>
+                <http://purl.obolibrary.org/obo/CHEBI_36080>
+                <http://purl.obolibrary.org/obo/CHEBI_33695>
+                <http://purl.obolibrary.org/obo/CHEBI_24431> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}

--- a/src/sparql/neo/wb-gene-chebi-superclasses.sparql
+++ b/src/sparql/neo/wb-gene-chebi-superclasses.sparql
@@ -1,0 +1,20 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://identifiers.org/wormbase/WBGene00000275 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_33695
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_24431
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://identifiers.org/wormbase/WBGene00000275> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value { <http://purl.obolibrary.org/obo/CHEBI_33695>
+                <http://purl.obolibrary.org/obo/CHEBI_24431> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}

--- a/src/sparql/neo/wb-superclasses.sparql
+++ b/src/sparql/neo/wb-superclasses.sparql
@@ -1,0 +1,20 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://purl.obolibrary.org/obo/WBbt_0005753 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/CL_0000003
+# ?super should contain http://purl.obolibrary.org/obo/CARO_0000000
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?entity ?property ?value
+WHERE {
+    VALUES ?entity { <http://purl.obolibrary.org/obo/WBbt_0005753> }
+    VALUES ?property { "NOT rdfs:subClassOf" }
+    VALUES ?value { <http://purl.obolibrary.org/obo/CL_0000003>
+                    <http://purl.obolibrary.org/obo/CARO_0000000> }
+
+    FILTER NOT EXISTS {
+        ?entity rdfs:subClassOf+ ?value
+    }
+}

--- a/src/sparql/neo/zfin-chebi-superclasses.sparql
+++ b/src/sparql/neo/zfin-chebi-superclasses.sparql
@@ -1,0 +1,20 @@
+# PREFIX rdfs: http://www.w3.org/2000/01/rdf-schema#
+# SELECT ?super WHERE
+# { http://identifiers.org/zfin/ZDB-GENE-010410-3 rdfs:subClassOf* ?super . }
+#
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_33695
+# ?super should contain http://purl.obolibrary.org/obo/CHEBI_24431
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?property ?value WHERE
+{
+  VALUES ?entity { <http://identifiers.org/zfin/ZDB-GENE-010410-3> }
+  VALUES ?property { "NOT rdfs:subClassOf" }
+  VALUES ?value { <http://purl.obolibrary.org/obo/CHEBI_33695>
+                <http://purl.obolibrary.org/obo/CHEBI_24431> }
+
+  FILTER NOT EXISTS {
+  ?entity rdfs:subClassOf+ ?value .
+  }
+
+}


### PR DESCRIPTION
For https://github.com/geneontology/pipeline/issues/35#issuecomment-601410116

This adds a make target to run `robot profile`. There's a set of queries at src/sparql/neo along with the profile text file, listing what queries to run. This will produce a report at src/ontology/reports/neo-violations.report. 

This command exits with `1` if it fails.