### PR TITLE
Include CL and Uberon in go-lego.owl.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -210,11 +210,11 @@ go-base.owl: enhanced.owl
 	$(OWLTOOLS) $(USECAT) $< --remove-imports-declarations -o -f ofn $@.tmp &&\
 	$(ROBOT) merge -i $@.tmp -i extensions/go-gci.owl -i extensions/go-bridge.owl -i extensions/ro_pending.owl -i imports/x-disjoint.owl annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@ && rm $@.tmp
 
-$(GO_GAF).owl: extensions/go-gaf-edit.ofn $(GO_PLUS).owl extensions/gorel.owl mirror/cl-download.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl
+$(GO_GAF).owl: extensions/go-gaf-edit.ofn $(GO_PLUS).owl extensions/gorel.owl mirror/cl.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl
 	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 
 # Not all imports are being pre-mirrored; the ones that are should be dependencies
-$(GO_LEGO).owl: extensions/go-lego-edit.ofn $(GO_PLUS).owl mirror/ro-download.owl extensions/legorel.owl extensions/go-bfo-bridge.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl
+$(GO_LEGO).owl: extensions/go-lego-edit.ofn $(GO_PLUS).owl mirror/ro-download.owl extensions/legorel.owl extensions/go-bfo-bridge.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl mirror/cl.owl mirror/uberon.owl
 	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural relax reduce --named-classes-only true annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 
 extensions/reacto.owl: $(GO_LEGO).owl mirror/chebi.owl
@@ -367,6 +367,7 @@ imports/%_import.obo: imports/%_import.owl
 # Fix external ontologies to specific versions. These should be updated regularly!
 CHEBI_SOURCE=http://purl.obolibrary.org/obo/chebi/177/chebi.obo
 CL_SOURCE=http://purl.obolibrary.org/obo/cl/releases/2020-01-06/cl-basic.owl
+UBERON_SOURCE=http://purl.obolibrary.org/obo/uberon/releases/2019-11-22/uberon-base.owl
 
 WGET_OUT = -O $@.tmp && cp $@.tmp $@ && touch $@
 

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -13,7 +13,8 @@
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/chebi_import.owl" uri="imports/chebi_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/cl_import.owl" uri="imports/cl_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/ddanat_import.owl" uri="imports/ddanat_import.owl"/>
-    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/cl/cl-basic.owl" uri="mirror/cl-download.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/cl.owl" uri="mirror/cl.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/po_import.owl" uri="imports/po_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/caro_import.owl" uri="imports/caro_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/fao_import.owl" uri="imports/fao_import.owl"/>

--- a/src/ontology/extensions/go-gaf-edit.ofn
+++ b/src/ontology/extensions/go-gaf-edit.ofn
@@ -8,7 +8,7 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 Ontology(<http://purl.obolibrary.org/obo/go/extensions/go-gaf.owl>
 # When adding an import, ensure this dependency is captured in the go-gaf makefile target
 Import(<http://purl.obolibrary.org/obo/go/extensions/gorel.owl>)
-Import(<http://purl.obolibrary.org/obo/cl/cl-basic.owl>)
+Import(<http://purl.obolibrary.org/obo/cl.owl>)
 Import(<http://purl.obolibrary.org/obo/go/extensions/go-plus.owl>)
 Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl>)
 Import(<http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl>)

--- a/src/ontology/extensions/go-lego-edit.ofn
+++ b/src/ontology/extensions/go-lego-edit.ofn
@@ -7,10 +7,13 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/go/extensions/go-lego.owl>
+Import(<http://purl.obolibrary.org/obo/cl.owl>)
 Import(<http://purl.obolibrary.org/obo/ddanat.owl>)
 Import(<http://purl.obolibrary.org/obo/emapa.owl>)
 Import(<http://purl.obolibrary.org/obo/ro.owl>)
+Import(<http://purl.obolibrary.org/obo/uberon.owl>)
 Import(<http://purl.obolibrary.org/obo/wbbt.owl>)
+Import(<http://purl.obolibrary.org/obo/xao.owl>)
 Import(<http://purl.obolibrary.org/obo/zfa.owl>)
 Import(<http://purl.obolibrary.org/obo/eco/eco-basic.owl>)
 Import(<http://purl.obolibrary.org/obo/go/extensions/go-bfo-bridge.owl>)
@@ -23,7 +26,6 @@ Import(<http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-caro.owl>)
 Import(<http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-wbbt.owl>)
 Import(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-base.owl>)
 Import(<http://purl.obolibrary.org/obo/wbphenotype/imports/wbls_import.owl>)
-Import(<http://purl.obolibrary.org/obo/xao.owl>)
 Import(<http://snapshot.geneontology.org/metadata/groups.ttl>)
 Import(<http://snapshot.geneontology.org/metadata/users.ttl>)
 Annotation(rdfs:comment "This ontology was created to handle the imports, required for a complex annotation model (a.k.a. LEGO). The starting point is the go-plus, which contains all of GO plus the modules from external ontologies, such as ChEBI, CL, or PO. In the future this may include other ontologies.")
@@ -31,6 +33,7 @@ Annotation(rdfs:comment "This ontology was created to handle the imports, requir
 Declaration(Class(<http://purl.obolibrary.org/obo/IAO_0000311>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/IAO_0000136>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/SEPIO_0000124>))
+Declaration(AnnotationProperty(<http://purl.org/dc/elements/1.1/type>))
 
 ############################
 #   Object Properties


### PR DESCRIPTION
Fixes https://github.com/geneontology/noctua/issues/673.