### PR TITLE
Update x_maturation.yaml

### DIFF
--- a/src/design_patterns/x_maturation.yaml
+++ b/src/design_patterns/x_maturation.yaml
@@ -5,7 +5,7 @@ classes:
   developmental maturation: "GO:0021700"
 
 relations: 
-  results in developmental progression of: "RO:0002295"
+  results in maturation of: "RO:0002299"
 
 vars:
  target: "'anatomical structure'"

--- a/src/design_patterns/x_maturation.yaml
+++ b/src/design_patterns/x_maturation.yaml
@@ -21,6 +21,6 @@ def:
      - target
 
 equivalentTo:
-  text: " 'developmental maturation' and 'results in developmental progression of' some %s"
+  text: " 'developmental maturation' and 'results in maturation of' some %s"
   vars:
     - target


### PR DESCRIPTION
I see 'results in maturation of: "RO:000229" used in the ontology, not "results in developmental progression"
Also, the tsv file is empty, suggesting that this design pattern is not correct. 