### PR TITLE
Add check for one-to-one xrefs, e.g. RHEA.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -544,7 +544,7 @@ imports/go-taxon-groupings.obo: imports/go-taxon-groupings.owl
 # these live in the ../sparql directory, and have suffix -violation.sparql
 # adding the name here will make the violation check live
 
-VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym non-IRI-value non-anyURI-value obsolete-definition definition-constraints one-to-one-xrefs
+VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym non-IRI-value non-anyURI-value obsolete-definition definition-constraints one-to-one-xrefs-by-subject one-to-one-xrefs-by-value
 
 # run all violation checks
 VARGS = $(foreach V,$(VCHECKS), $(SPARQLDIR)/$V-violation.sparql)

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -544,7 +544,7 @@ imports/go-taxon-groupings.obo: imports/go-taxon-groupings.owl
 # these live in the ../sparql directory, and have suffix -violation.sparql
 # adding the name here will make the violation check live
 
-VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym non-IRI-value non-anyURI-value obsolete-definition definition-constraints
+VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match replacedby-obsolete duplicate-exact-synonym duplicate-synonym non-IRI-value non-anyURI-value obsolete-definition definition-constraints one-to-one-xrefs
 
 # run all violation checks
 VARGS = $(foreach V,$(VCHECKS), $(SPARQLDIR)/$V-violation.sparql)

--- a/src/sparql/one-to-one-xrefs-by-subject-violation.sparql
+++ b/src/sparql/one-to-one-xrefs-by-subject-violation.sparql
@@ -1,0 +1,15 @@
+# Find terms that have more than one xref having a given prefix
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?c ?one_to_one_prefix WHERE 
+{
+  VALUES ?one_to_one_prefix { "RHEA:" }
+  ?c oio:hasDbXref ?x .
+  FILTER(isIRI(?c))
+  FILTER(STRSTARTS(STR(?x), ?one_to_one_prefix))
+}
+GROUP BY ?c ?one_to_one_prefix
+HAVING(COUNT(DISTINCT STR(?x)) > 1)

--- a/src/sparql/one-to-one-xrefs-by-value-violation.sparql
+++ b/src/sparql/one-to-one-xrefs-by-value-violation.sparql
@@ -1,14 +1,15 @@
-# Find terms that have more than one xref having a given prefix
+# Find xrefs having a given prefix that are used with more than one term
 
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
 
-SELECT ?c ?one_to_one_prefix WHERE 
+SELECT ?x ?one_to_one_prefix (GROUP_CONCAT(?c ; separator=";") AS ?cs) WHERE 
 {
   VALUES ?one_to_one_prefix { "RHEA:" }
   ?c oio:hasDbXref ?x .
+  FILTER(isIRI(?c))
   FILTER(STRSTARTS(STR(?x), ?one_to_one_prefix))
 }
-GROUP BY ?c ?one_to_one_prefix
-HAVING(COUNT(DISTINCT STR(?x)) > 1)
+GROUP BY ?x ?one_to_one_prefix
+HAVING(COUNT(DISTINCT ?c) > 1)

--- a/src/sparql/one-to-one-xrefs-violation.sparql
+++ b/src/sparql/one-to-one-xrefs-violation.sparql
@@ -1,0 +1,14 @@
+# Find terms that have more than one xref having a given prefix
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?c ?one_to_one_prefix WHERE 
+{
+  VALUES ?one_to_one_prefix { "RHEA:" }
+  ?c oio:hasDbXref ?x .
+  FILTER(STRSTARTS(STR(?x), ?one_to_one_prefix))
+}
+GROUP BY ?c ?one_to_one_prefix
+HAVING(COUNT(DISTINCT STR(?x)) > 1)


### PR DESCRIPTION
@hdrabkin this check currently has two violations:

- http://purl.obolibrary.org/obo/GO_0033735
- http://purl.obolibrary.org/obo/GO_0120204
