### PR TITLE
Update ncbitaxon_terms.txt

### DIFF
--- a/src/ontology/imports/ncbitaxon_terms.txt
+++ b/src/ontology/imports/ncbitaxon_terms.txt
@@ -2,3 +2,188 @@ NCBITaxon:9606
 NCBITaxon:6073 ## Cnidaria
 NCBITaxon:5653 ## Kinetoplastida
 NCBITaxon:47570 ## Schizotrypanum
+NCBITaxon:4565 ## Triticum aestivum
+NCBITaxon:28377 ## Anolis carolinensis
+NCBITaxon:4232 ## Helianthus annuus
+NCBITaxon:9913 ## Bos taurus
+NCBITaxon:5204 ## Basidiomycota
+NCBITaxon:9031 ## Gallus gallus
+NCBITaxon:243230 ## Deinococcus radiodurans
+NCBITaxon:81824 ## Monosiga brevicollis
+NCBITaxon:559292 ## Saccharomyces cerevisiae
+NCBITaxon:91061 ## Bacilli
+NCBITaxon:214687 ## Musa acuminata subsp. malaccensis
+NCBITaxon:91835 ## fabids
+NCBITaxon:3702 ## Arabidopsis thaliana
+NCBITaxon:10228 ## Trichoplax adhaerens
+NCBITaxon:243273 ## mycoplasma genitalium
+NCBITaxon:71240 ## eudicotyledons
+NCBITaxon:3659 ## Cucumis sativus
+NCBITaxon:42345 ## Phoenix dactylifera
+NCBITaxon:1236 ## Gammaproteobacteria
+NCBITaxon:185431 ## Trypanosoma brucei
+NCBITaxon:91888 ## lamiids
+NCBITaxon:3562 ## Spinacia oleracea
+NCBITaxon:7739 ## Branchiostoma floridae
+NCBITaxon:243232 ## Methanocaldococcus jannaschii
+NCBITaxon:71139 ## Eucalyptus grandis
+NCBITaxon:243090 ## Rhodopirellula baltica
+NCBITaxon:7955 ## Danio rerio
+NCBITaxon:3880 ## Medicago truncatula
+NCBITaxon:515635 ## Dictyoglomus turgidum
+NCBITaxon:4072 ## Capsicum annuum
+NCBITaxon:164328 ## Phytophthora ramorum
+NCBITaxon:9598 ## Pan troglodytes
+NCBITaxon:147389 ## Triticeae
+NCBITaxon:88036 ## Selaginella moellendorffii
+NCBITaxon:1386 ## Bacillus
+NCBITaxon:10116 ## Rattus norvegicus
+NCBITaxon:45351 ## Nematostella vectensis
+NCBITaxon:4447 ## Liliopsida
+NCBITaxon:54126 ## Pristionchus pacificus
+NCBITaxon:112509 ## Hordeum vulgare subsp. vulgare
+NCBITaxon:3700 ## Brassicaceae
+NCBITaxon:5786 ## Dictyostelium purpureum
+NCBITaxon:2037 ## Actinomycetales
+NCBITaxon:64091 ## Halobacterium salinarum
+NCBITaxon:272561 ## Chlamydia trachomatis
+NCBITaxon:665079 ## Sclerotinia sclerotiorum
+NCBITaxon:147368 ## Pooideae
+NCBITaxon:3708 ## Brassica napus
+NCBITaxon:9685 ## Felis catus
+NCBITaxon:10090 ## Mus musculus
+NCBITaxon:6945 ## Ixodes scapularis
+NCBITaxon:284812 ## Schizosaccharomyces pombe
+NCBITaxon:632 ## Yersinia pestis
+NCBITaxon:6238 ## Caenorhabditis briggsae
+NCBITaxon:3988 ## Ricinus communis
+NCBITaxon:9615 ## Canis lupus familiaris
+NCBITaxon:183924 ## Thermoprotei
+NCBITaxon:6669 ## Daphnia pulex
+NCBITaxon:243231 ## Geobacter sulfurreducens
+NCBITaxon:3814 ## Papilionoideae
+NCBITaxon:4558 ## Sorghum bicolor
+NCBITaxon:3983 ## Manihot esculenta
+NCBITaxon:227321 ## Emericella nidulans
+NCBITaxon:7668 ## Strongylocentrotus purpuratus
+NCBITaxon:6412 ## helobdella robusta
+NCBITaxon:4070 ## Solanaceae
+NCBITaxon:4555 ## Setaria italica
+NCBITaxon:9787 ## Perissodactyla
+NCBITaxon:3977 ## Euphorbiaceae
+NCBITaxon:226186 ## Bacteroides thetaiotaomicron
+NCBITaxon:4097 ## Nicotiana tabacum
+NCBITaxon:71421 ## Haemophilus influenzae
+NCBITaxon:147538 ## Pezizomycotina
+NCBITaxon:367110 ## Neurospora crassa
+NCBITaxon:3629 ## Malvaceae
+NCBITaxon:1385 ## Bacillales
+NCBITaxon:13333 ## Amborella trichopoda
+NCBITaxon:3760 ## Prunus persica
+NCBITaxon:3055 ## Chlamydomonas reinhardtii
+NCBITaxon:51240 ## Juglans regia
+NCBITaxon:171101 ## Streptococcus pneumoniae
+NCBITaxon:4577 ## Zea mays
+NCBITaxon:4210 ## Asteraceae
+NCBITaxon:13616 ## Monodelphis domestica
+NCBITaxon:15368 ## Brachypodium distachyon
+NCBITaxon:71275 ## rosids
+NCBITaxon:9595 ## Gorilla gorilla gorilla
+NCBITaxon:91836 ## malvids
+NCBITaxon:3041 ## Chlorophyta
+NCBITaxon:3847 ## Glycine max
+NCBITaxon:4236 ## Lactuca sativa
+NCBITaxon:214684 ## Cryptococcus neoformans
+NCBITaxon:8364 ## Xenopus tropicalis
+NCBITaxon:374847 ## Korarchaeum cryptofilum
+NCBITaxon:8090 ## Oryzias latipes
+NCBITaxon:441771 ## Clostridium botulinum
+NCBITaxon:189518 ## Leptospira interrogans
+NCBITaxon:147429 ## Andropogoneae
+NCBITaxon:39947 ## Oryza sativa
+NCBITaxon:424551 ## Solanoideae
+NCBITaxon:5722 ## Trichomonas vaginalis
+NCBITaxon:33554 ## Carnivora
+NCBITaxon:314145 ## Laurasiatheria
+NCBITaxon:436308 ## Nitrosopumilus maritimus
+NCBITaxon:284591 ## Yarrowia lipolytica
+NCBITaxon:5052 ## Aspergillus
+NCBITaxon:543 ## Enterobacteriaceae
+NCBITaxon:44689 ## Dictyostelium discoideum
+NCBITaxon:9796 ## Equus caballus
+NCBITaxon:99287 ## Salmonella typhimurium
+NCBITaxon:237561 ## Candida albicans
+NCBITaxon:29655 ## Zostera marina
+NCBITaxon:324602 ## Chloroflexus aurantiacus
+NCBITaxon:4479 ## Poaceae
+NCBITaxon:184922 ## Giardia intestinalis
+NCBITaxon:227377 ## Coxiella burnetii
+NCBITaxon:4081 ## Solanum lycopersicum
+NCBITaxon:224324 ## Aquifex aeolicus
+NCBITaxon:237631 ## Ustilago maydis
+NCBITaxon:29760 ## Vitis vinifera
+NCBITaxon:2711 ## Citrus sinensis
+NCBITaxon:211586 ## Shewanella oneidensis
+NCBITaxon:226900 ## Bacillus cereus
+NCBITaxon:251221 ## Gloeobacter violaceus
+NCBITaxon:7918 ## lepisosteus oculatus
+NCBITaxon:188937 ## Methanosarcina acetivorans
+NCBITaxon:83333 ## Escherichia coli
+NCBITaxon:3694 ## Populus trichocarpa
+NCBITaxon:70448 ## Ostreococcus tauri
+NCBITaxon:243277 ## Vibrio cholerae
+NCBITaxon:684364 ## Batrachochytrium dendrobatidis
+NCBITaxon:4107 ## Solanum
+NCBITaxon:715989 ## Sordariomyceta
+NCBITaxon:243274 ## Thermotoga maritima
+NCBITaxon:208964 ## Pseudomonas aeruginosa
+NCBITaxon:5664 ## Leishmania major
+NCBITaxon:4432 ## Nelumbo nucifera
+NCBITaxon:321614 ## Phaeosphaeria nodorum
+NCBITaxon:7165 ## Anopheles gambiae
+NCBITaxon:1111708 ## Synechocystis
+NCBITaxon:7070 ## Tribolium castaneum
+NCBITaxon:289376 ## Thermodesulfovibrio yellowstonii
+NCBITaxon:69014 ## Thermococcus kodakaraensis
+NCBITaxon:39107 ## Murinae
+NCBITaxon:147369 ## Panicoideae
+NCBITaxon:9823 ## Sus scrofa
+NCBITaxon:418459 ## Puccinia graminis
+NCBITaxon:224308 ## Bacillus subtilis
+NCBITaxon:273057 ## Sulfolobus solfataricus
+NCBITaxon:7719 ## Ciona intestinalis
+NCBITaxon:169963 ## Listeria monocytogenes
+NCBITaxon:3641 ## Theobroma cacao
+NCBITaxon:83332 ## Mycobacterium tuberculosis
+NCBITaxon:1224 ## Proteobacteria
+NCBITaxon:190485 ## Xanthomonas campestris
+NCBITaxon:5759 ## Entamoeba histolytica
+NCBITaxon:4155 ## Erythranthe guttata
+NCBITaxon:3705 ## Brassica
+NCBITaxon:3646 ## Malpighiales
+NCBITaxon:9544 ## Macaca mulatta
+NCBITaxon:6239 ## Caenorhabditis elegans
+NCBITaxon:1437183 ## Mesangiosperma
+NCBITaxon:93061 ## Staphylococcus aureus
+NCBITaxon:1239 ## Firmicutes
+NCBITaxon:71274 ## asterids
+NCBITaxon:178306 ## Pyrobaculum aerophilum
+NCBITaxon:3635 ## Gossypium hirsutum
+NCBITaxon:359160 ## BEP_clade
+NCBITaxon:4113 ## Solanum tuberosum
+NCBITaxon:85962 ## Helicobacter pylori
+NCBITaxon:28890 ## Euryarchaeota
+NCBITaxon:330879 ## Neosartorya fumigata
+NCBITaxon:36329 ## Plasmodium falciparum
+NCBITaxon:122586 ## Neisseria meningitidis serogroup b
+NCBITaxon:190304 ## Fusobacterium nucleatum
+NCBITaxon:9258 ## Ornithorhynchus anatinus
+NCBITaxon:284811 ## Ashbya gossypii
+NCBITaxon:100226 ## Streptomyces coelicolor
+NCBITaxon:35128 ## Thalassiosira pseudonana
+NCBITaxon:51351 ## Brassica rapa subsp. pekinensis
+NCBITaxon:1437201 ## Pentapetalae
+NCBITaxon:5888 ## Paramecium tetraurelia
+NCBITaxon:3218 ## Physcomitrella patens
+NCBITaxon:4734 ## commelinids
+NCBITaxon:224911 ## Bradyrhizobium diazoefficiens


### PR DESCRIPTION
Adding the 185 missing taxons needed for PAINT taxon constraints generation via gaferencer. The effect of adding these should fix this issue:

> Given the taxon constraint "GO:0051640 only_in_taxon Eukaryota (NCBITaxon:2759)", gaferencer should mark this term `0` (not allowed) for NCBITaxon:1111708 since it is not a descendant of Eukaryota.

These additions were calculated by diffing the taxons currently in http://current.geneontology.org/ontology/imports/ncbitaxon_import.owl vs. the taxons in our PANTHER 16.0 DB `organism` table.