### PR TITLE
TCs for echolocation

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -226,6 +226,8 @@ GO:0048010	vascular endothelial growth factor receptor signaling pathway	NCBITax
 GO:0048104	establishment of body hair or bristle planar orientation	NCBITaxon:8782	Aves
 GO:0050764	regulation of phagocytosis	NCBITaxon:147537	Saccharomycotina
 GO:0050873	brown fat cell differentiation	NCBITaxon:8782	Aves
+GO:0050959	echolocation	NCBITaxon:10090	Mus musculus
+GO:0050959	echolocation	NCBITaxon:9443	Primates
 GO:0051644	plastid localization	NCBITaxon:28009	Choanoflagellida
 GO:0051644	plastid localization	NCBITaxon:33208	Metazoa
 GO:0051644	plastid localization	NCBITaxon:4751	Fungi

--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -467,6 +467,7 @@ GO:0048838	release of seed from dormancy	NCBITaxon:33090	Viridiplantae
 GO:0048840	otolith development	NCBITaxon:7742	Vertebrata <Metazoa>
 GO:0050845	teichuronic acid biosynthetic process	NCBITaxon:2	Bacteria
 GO:0050877	nervous system process	NCBITaxon:33208	Metazoa
+GO:0050959	echolocation	NCBITaxon:40674	Mammalia
 GO:0051077	secondary cell septum	NCBITaxon:2759	Eukaryota
 GO:0051300	spindle pole body organization	NCBITaxon:4751	Fungi
 GO:0051321	meiotic cell cycle	NCBITaxon:2759	Eukaryota

--- a/src/taxon_constraints/present_in_taxon.tsv
+++ b/src/taxon_constraints/present_in_taxon.tsv
@@ -1,3 +1,5 @@
 term	term_label	taxon	taxon_label
 GO:0007507	heart development	NCBITaxon:7227	Drosophila melanogaster
 GO:0050881	musculoskeletal movement	NCBITaxon:7227	Drosophila melanogaster
+GO:0050959	echolocation	NCBITaxon:687454	Typhlomys
+GO:0050959	echolocation	NCBITaxon:9397	Chiroptera


### PR DESCRIPTION
TCs for echolocation

 - only in mammals
 - adding never-ins to ensure these don't appear in M musculus and primate subsets
 - adding present ins for bats and toothed whales (well known) and soft-furred tree mices (new: https://doi.org/10.1126/science.aay1513)

question: how do we record provenence in TCs now we use TSVs?﻿
