### PR TITLE
adding subproperties and xrefs for two RO exists relations

### DIFF
--- a/src/ontology/extensions/gorel-edit.owl
+++ b/src/ontology/extensions/gorel-edit.owl
@@ -1722,6 +1722,17 @@ SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0002453> <http://purl.obo
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/RO_0002454> <http://purl.obolibrary.org/obo/go#taxon_extension>)
 SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0002454> <http://purl.obolibrary.org/obo/GOREL_0000000>)
 
+# Object Property: <http://purl.obolibrary.org/obo/RO_0002490> (existence overlaps)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/RO_0002490> "RO:0002490")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/RO_0002490> <http://purl.obolibrary.org/obo/go#valid_for_annotation_extension>)
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0002490> <http://purl.obolibrary.org/obo/GOREL_0000000>)
+
+# Object Property: <http://purl.obolibrary.org/obo/RO_0002491> (existence starts and ends during)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/RO_0002491> "RO:0002491")
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0002491> <http://purl.obolibrary.org/obo/GOREL_0000000>)
+
 # Object Property: <http://purl.obolibrary.org/obo/RO_0002556> (pathogen of)
 
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/RO_0002556> <http://purl.obolibrary.org/obo/go#taxon_extension>)


### PR DESCRIPTION
Adding this metadata so these relations will be available in Protein2GO to update 'exists during' AE relations.

@alexsign 