### PR TITLE
Removed GO:0019933	& Dictyostelids

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -531,7 +531,6 @@ GO:0043202	lysosomal lumen	NCBITaxon:4751	Fungi
 GO:0005765	lysosomal membrane	NCBITaxon:4751	Fungi	
 GO:0071588	hydrogen peroxide mediated signaling pathway	NCBITaxon:4751	Fungi	
 GO:0071818	BAT3 complex	NCBITaxon:4890 	Ascomycota	
-GO:0019933	cAMP-mediated signaling	NCBITaxon:33083	Dictyostelids	
 GO:0016922	nuclear receptor binding	NCBITaxon:Union_0000023	Fungi or Bacteria or Archaea	
 GO:0048309	endoplasmic reticulum inheritance	NCBITaxon:4896	Schizosaccharomyces pombe	
 GO:0044728	DNA methylation or demethylation	NCBITaxon:4896	Schizosaccharomyces pombe	


### PR DESCRIPTION
cAMP-mediated signaling SubClassOf in taxon some (not (Dictyostelia)) is WRONG 
"adenylate cyclase-activating G protein-coupled cAMP receptor signaling pathway " uses cAMP as both intra and extracellular signaling