### PR TITLE
Pre-build ontology for AmiGO loader.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -81,7 +81,7 @@ REPORTDIR = $(RELEASEDIR)/reports
 # TOP LEVEL TARGETS
 # ----------------------------------------
 
-stage_release: imports/reactome_xrefs_import.owl test $(ONT).owl $(ONT).obo $(ONT).json.gz $(GO_PLUS).owl $(GO_PLUS).json.gz go-base.owl $(GO_GAF).owl $(GO_LEGO).owl $(GO_LEGO_REACTO).owl go-basic.obo go-basic.json.gz extensions/rhea-reactions.ttl subset-owls subset-reports generate-mappings
+stage_release: imports/reactome_xrefs_import.owl test $(ONT).owl $(ONT).obo $(ONT).json.gz $(GO_PLUS).owl $(GO_PLUS).json.gz go-base.owl $(GO_GAF).owl $(GO_AMIGO).owl $(GO_LEGO).owl $(GO_LEGO_REACTO).owl go-basic.obo go-basic.json.gz extensions/rhea-reactions.ttl subset-owls subset-reports generate-mappings
 
 test: $(SRC)-check sparql_test change-report.txt reasoned.owl unsatisfiable present_in_taxon_check.ofn chebi_pH_7_3_check
 

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -70,6 +70,7 @@ GO_MAIN_RELATIONS = $(GO_BASIC_RELATIONS) BFO:0000051 BFO:0000066 RO:0002091 RO:
 
 GO_PLUS = extensions/go-plus
 GO_GAF = extensions/go-gaf
+GO_AMIGO = extensions/go-amigo
 GO_LEGO = extensions/go-lego
 GO_LEGO_REACTO = extensions/go-lego-reacto
 
@@ -219,8 +220,11 @@ go-base.owl: enhanced.owl
 $(GO_GAF).owl: extensions/go-gaf-edit.ofn $(GO_PLUS).owl extensions/gorel.owl mirror/cl.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl
 	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 
+$(GO_AMIGO).owl: extensions/go-amigo-edit.ofn $(GO_GAF).owl extensions/go-modules-annotations.owl extensions/go-taxon-subsets.owl mirror/eco.owl mirror/pato.owl mirror/po.owl mirror/chebi.owl mirror/uberon.owl mirror/wbbt.owl
+	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
+
 # Not all imports are being pre-mirrored; the ones that are should be dependencies
-$(GO_LEGO).owl: extensions/go-lego-edit.ofn $(GO_PLUS).owl mirror/ro-download.owl extensions/legorel.owl extensions/go-bfo-bridge.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl mirror/cl.owl mirror/uberon.owl imports/go-lego-chebi-import.owl
+$(GO_LEGO).owl: extensions/go-lego-edit.ofn $(GO_PLUS).owl mirror/ro-download.owl extensions/legorel.owl extensions/go-bfo-bridge.owl mirror/taxslim.owl mirror/taxslim-disjoint-over-in-taxon.owl mirror/cl.owl mirror/uberon.owl imports/go-lego-chebi-import.owl mirror/wbbt.owl mirror/eco.owl
 	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural relax reduce --named-classes-only true annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 
 extensions/reacto.owl: $(GO_LEGO).owl mirror/chebi.owl
@@ -387,6 +391,8 @@ imports/%_import.obo: imports/%_import.owl
 CHEBI_SOURCE=http://purl.obolibrary.org/obo/chebi.owl.gz
 CL_SOURCE=http://purl.obolibrary.org/obo/cl/cl-base.owl
 UBERON_SOURCE=http://purl.obolibrary.org/obo/uberon/uberon-base.owl
+WBBT_SOURCE=http://purl.obolibrary.org/obo/wbbt/wbbt-base.owl
+ECO_SOURCE=http://purl.obolibrary.org/obo/eco/eco-basic.owl
 
 WGET_OUT = -O $@.tmp && cp $@.tmp $@ && touch $@
 
@@ -437,6 +443,14 @@ mirror/oba-download.owl: $(SRC)
 mirror/cl-download.owl: $(SRC)
 	wget --no-check-certificate $(CL_SOURCE) $(WGET_OUT)
 .PRECIOUS: mirror/cl-download.owl
+
+mirror/wbbt-download.owl: $(SRC)
+	wget --no-check-certificate $(WBBT_SOURCE) $(WGET_OUT)
+.PRECIOUS: mirror/wbbt-download.owl
+
+mirror/eco-download.owl: $(SRC)
+	wget --no-check-certificate $(ECO_SOURCE) $(WGET_OUT)
+.PRECIOUS: mirror/eco-download.owl
 
 mirror/ro-download.owl: $(SRC)
 	wget --no-check-certificate $(OBO)/ro/ro-base.owl $(WGET_OUT)

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -3,6 +3,7 @@
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/ro_pending.owl" uri="extensions/ro_pending.owl"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/go/extensions/go-bridge.owl" uri="extensions/go-bridge.owl"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/go/extensions/go-gci.owl" uri="extensions/go-gci.owl"/>
+    <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/go/extensions/go-modules-annotations.owl" uri="extensions/go-modules-annotations.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/bio-chebi.owl" uri="imports/bio-chebi.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go_inferences.owl" uri="go_inferences_null.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/substance_by_role.owl" uri="imports/substance_by_role.owl"/>
@@ -27,6 +28,10 @@
    	<uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro-download.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/annotation_properties.owl" uri="imports/annotation_properties.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/pato_import.owl" uri="imports/pato_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/pato.owl" uri="mirror/pato.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/eco/eco-basic.owl" uri="mirror/eco.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/wbbt/wbbt-base.owl" uri="mirror/wbbt.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/po.owl" uri="mirror/po.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl" uri="mirror/taxslim.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl" uri="mirror/taxslim-disjoint-over-in-taxon.owl"/>
@@ -39,13 +44,13 @@
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go-pattern-conformance.ttl" uri="imports/go-pattern-conformance.ttl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go-taxon-groupings.owl" uri="imports/go-taxon-groupings.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go_taxon_constraints.owl" uri="imports/go_taxon_constraints.owl"/>
-    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go-taxon-subsets.owl" uri="imports/go-taxon-subsets.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/go-taxon-subsets.owl" uri="extensions/go-taxon-subsets.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/go-catalytic-activities-participants.owl" uri="imports/go-catalytic-activities-participants.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/gorel.owl" uri="imports/gorel.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/gorel.owl" uri="extensions/gorel.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/x-disjoint.owl" uri="imports/x-disjoint.owl"/>
-	<uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/reactome_xrefs_import.owl" uri="imports/reactome_xrefs_import.owl"/>
-  <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/go-lego.owl" uri="extensions/go-lego.owl"/>
-  <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/reacto.owl" uri="extensions/reacto.owl"/>
-  <uri id="go-lego-chebi-import" name="http://purl.obolibrary.org/obo/go/imports/go-lego-chebi-import.owl" uri="imports/go-lego-chebi-import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/imports/reactome_xrefs_import.owl" uri="imports/reactome_xrefs_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/go-lego.owl" uri="extensions/go-lego.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/go/extensions/reacto.owl" uri="extensions/reacto.owl"/>
+    <uri id="go-lego-chebi-import" name="http://purl.obolibrary.org/obo/go/imports/go-lego-chebi-import.owl" uri="imports/go-lego-chebi-import.owl"/>
 </catalog>

--- a/src/ontology/extensions/go-amigo-edit.ofn
+++ b/src/ontology/extensions/go-amigo-edit.ofn
@@ -1,0 +1,21 @@
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/go/extensions/go-amigo.owl>
+# When adding an import, ensure this dependency is captured in the go-amigo makefile target
+Import(<http://purl.obolibrary.org/obo/go/extensions/go-gaf.owl>)
+Import(<http://purl.obolibrary.org/obo/go/extensions/go-modules-annotations.owl>)
+Import(<http://purl.obolibrary.org/obo/go/extensions/go-taxon-subsets.owl>)
+Import(<http://purl.obolibrary.org/obo/eco/eco-basic.owl>)
+Import(<http://purl.obolibrary.org/obo/pato.owl>)
+Import(<http://purl.obolibrary.org/obo/po.owl>)
+Import(<http://purl.obolibrary.org/obo/chebi.owl>)
+Import(<http://purl.obolibrary.org/obo/uberon.owl>)
+Import(<http://purl.obolibrary.org/obo/wbbt/wbbt-base.owl>)
+
+Annotation(rdfs:comment "This ontology was created to handle the specific imports required for the use in AmiGO.")
+)


### PR DESCRIPTION
This allows us to check reasoning compatibility within the ontology pipeline instead of the AmiGO pipeline, and also reuses downloaded imports across ontology products.

For #19120.