### PR TITLE
Add EC to one-to-one-xrefs-by-subject-violation.sparql

### DIFF
--- a/src/sparql/one-to-one-xrefs-by-subject-violation.sparql
+++ b/src/sparql/one-to-one-xrefs-by-subject-violation.sparql
@@ -7,7 +7,7 @@ PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT ?c ?one_to_one_prefix WHERE 
 {
-  VALUES ?one_to_one_prefix { "RHEA:" }
+  VALUES ?one_to_one_prefix { "RHEA:" "EC:" }
   ?c oio:hasDbXref ?x .
   FILTER(isIRI(?c))
   FILTER(STRSTARTS(STR(?x), ?one_to_one_prefix))


### PR DESCRIPTION
These terms currently have more than one EC xref (and are causing this PR to fail checks):

<details>
<summary>Original list</summary>
http://purl.obolibrary.org/obo/GO_0047751
http://purl.obolibrary.org/obo/GO_0030266
http://purl.obolibrary.org/obo/GO_0052904
http://purl.obolibrary.org/obo/GO_0052902
http://purl.obolibrary.org/obo/GO_0052903
http://purl.obolibrary.org/obo/GO_0052901
http://purl.obolibrary.org/obo/GO_0004471
http://purl.obolibrary.org/obo/GO_0106029
http://purl.obolibrary.org/obo/GO_0015612
http://purl.obolibrary.org/obo/GO_0052730
http://purl.obolibrary.org/obo/GO_0120159
http://purl.obolibrary.org/obo/GO_0046353
http://purl.obolibrary.org/obo/GO_0052729
http://purl.obolibrary.org/obo/GO_0043842
http://purl.obolibrary.org/obo/GO_0008948
http://purl.obolibrary.org/obo/GO_0004764
http://purl.obolibrary.org/obo/GO_0019152
http://purl.obolibrary.org/obo/GO_0008725
http://purl.obolibrary.org/obo/GO_0008239
http://purl.obolibrary.org/obo/GO_0047952
http://purl.obolibrary.org/obo/GO_0008240
http://purl.obolibrary.org/obo/GO_0015451
http://purl.obolibrary.org/obo/GO_0052883
http://purl.obolibrary.org/obo/GO_0045548
</details>