### PR TITLE
Remove asserted taxon constraints from go-plus, leaving computed ones only.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -208,7 +208,7 @@ present_in_taxon_check.ofn: enhanced.owl ../taxon_constraints/present_in_taxon.o
 # TODO cleanup redundancies with merge here and with go-base
 # note: do not run 'reason' after go-computed-taxon-constraints.owl is merged; some desired logical redundancy may be lost
 $(GO_PLUS).owl: reasoned.owl imports/go-computed-taxon-constraints.owl
-	$(ROBOT) merge -i $< --collapse-import-closure true --include-annotations false merge -i imports/go-computed-taxon-constraints.owl annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
+	$(ROBOT) unmerge -i $< -i imports/go_taxon_constraints.owl merge --collapse-import-closure true --include-annotations false merge -i imports/go-computed-taxon-constraints.owl annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 .PRECIOUS: $(GO_PLUS).owl
 
 # Create release file containing GO-asserted axioms, no external axioms, and no inferences.


### PR DESCRIPTION
Fixes #26417.