### PR TITLE
Rebuild gorel.

### DIFF
--- a/src/ontology/extensions/gorel.obo
+++ b/src/ontology/extensions/gorel.obo
@@ -12,7 +12,7 @@ subsetdef: taxon_extension ""
 subsetdef: valid_for_annotation_extension ""
 synonymtypedef: RO:0008000 "display label for users"
 default-namespace: external
-remark: Includes Ontology(OntologyID(Anonymous-3)) [Axioms: 1776 Logical Axioms: 474]
+remark: Includes Ontology(OntologyID(Anonymous-3)) [Axioms: 1925 Logical Axioms: 480]
 ontology: go/extensions/gorel
 property_value: http://purl.org/dc/elements/1.1/description "This ontology combines RO together with GO-specific relations in the GOREL namespace, used for annotation extensions. See;\n\nHuntley, R. P., Harris, M. a, Alam-Faruque, Y., et al (2014). A method for increasing expressivity of Gene Ontology annotations using a compositional approach. BMC Bioinformatics, 15(1), 155. doi:10.1186/1471-2105-15-155\n\nNotes on release edition (gorel.owl):\n\nThis ontology is created by merging the relevant subset of RO together with GO-specific annotations of RO relations, and GOREL relations\n\nNotes on editors version (gorel-edit.owl): \nThe editors version imports ro.owl, and allows addition of new relations (GOREL ID space) and annotation of existing RO relations. Note for editors: if an RO relation is to be made visible in the final gorel product, then make the relation a SubProperty of 'go annotation extension relation'. Anything with a logical axiom is included in the final module. Consult Makefile for details" xsd:string
 
@@ -21,20 +21,12 @@ id: activated_by
 name: activated_by
 namespace: go/extensions/gorel
 comment: This relation should not be used to annotate one gene product regulating another's activity; a regulator MF or regulation BP should be used in such cases.
-subset: AE_chemical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "activated by" EXACT RO:0008000 [PomBase:curators]
 synonym: "activated_by_chemical" EXACT [GOC:mah]
 synonym: "activated_by_substance" EXACT [GOC:mah]
 synonym: "activity_increased_by" EXACT [GOC:mah]
 xref: GOREL:0000507
-property_value: local_domain GO:0003674 xsd:string
-property_value: local_range CHEBI:24431 xsd:string
 property_value: usage "Identifies a chemical substance that increases the activity of the gene product." xsd:string
-domain: GO:0003674
-range: CHEBI:24431
-is_a: go_annotation_extension_relation ! go annotation extension relation
 
 [Typedef]
 id: acts_on_population_of
@@ -74,7 +66,7 @@ def: "c 'acts upstream of, negative effect' p if c is enables f, and f is causal
 subset: http://purl.obolibrary.org/obo/valid_for_go_gp2term
 xref: RO:0004035
 property_value: RO:0004050 RO:0002263
-property_value: seeAlso http://wiki.geneontology.org/index.php/Acts_upstream_of,_negative_effect
+property_value: seeAlso https://wiki.geneontology.org/Acts_upstream_of,_negative_effect xsd:anyURI
 holds_over_chain: enables causally_upstream_of,_negative_effect
 is_a: acts_upstream_of ! acts upstream of
 is_a: acts_upstream_of_or_within,_negative_effect ! acts upstream of or within, negative effect
@@ -88,7 +80,7 @@ def: "c 'acts upstream of, positive effect' p if c is enables f, and f is causal
 subset: http://purl.obolibrary.org/obo/valid_for_go_gp2term
 xref: RO:0004034
 property_value: RO:0004049 RO:0002263
-property_value: seeAlso http://wiki.geneontology.org/index.php/Acts_upstream_of,_positive_effect
+property_value: seeAlso https://wiki.geneontology.org/Acts_upstream_of,_positive_effect xsd:anyURI
 holds_over_chain: enables causally_upstream_of,_positive_effect
 is_a: acts_upstream_of ! acts upstream of
 is_a: acts_upstream_of_or_within,_positive_effect ! acts upstream of or within, positive effect
@@ -103,7 +95,7 @@ subset: http://purl.obolibrary.org/obo/valid_for_go_gp2term
 synonym: "affects" RELATED []
 xref: RO:0002264
 property_value: IAO:0000112 "A gene product that has some activity, where that activity may be a part of a pathway or upstream of the pathway." xsd:string
-property_value: seeAlso http://wiki.geneontology.org/index.php/Acts_upstream_of_or_within
+property_value: seeAlso https://wiki.geneontology.org/Acts_upstream_of_or_within xsd:anyURI
 holds_over_chain: enables causally_upstream_of_or_within
 is_a: causal_agent_in_process ! causal agent in process
 
@@ -113,6 +105,7 @@ name: acts upstream of or within, negative effect
 subset: http://purl.obolibrary.org/obo/valid_for_go_gp2term
 xref: RO:0004033
 property_value: RO:0004050 RO:0002264
+property_value: seeAlso https://wiki.geneontology.org/Acts_upstream_of_or_within,_negative_effect xsd:anyURI
 holds_over_chain: enables causally_upstream_of_or_within,_negative_effect
 is_a: acts_upstream_of_or_within ! acts upstream of or within
 created_by: https://orcid.org/0000-0002-6601-2165
@@ -124,7 +117,7 @@ name: acts upstream of or within, positive effect
 subset: http://purl.obolibrary.org/obo/valid_for_go_gp2term
 xref: RO:0004032
 property_value: RO:0004049 RO:0002264
-property_value: seeAlso http://wiki.geneontology.org/index.php/Acts_upstream_of_or_within,_positive_effect
+property_value: seeAlso https://wiki.geneontology.org/Acts_upstream_of_or_within,_positive_effect xsd:anyURI
 holds_over_chain: enables causally_upstream_of_or_within,_positive_effect
 is_a: acts_upstream_of_or_within ! acts upstream of or within
 created_by: https://orcid.org/0000-0002-6601-2165
@@ -368,6 +361,7 @@ subset: http://purl.obolibrary.org/obo/valid_for_gocam
 xref: RO:0002305
 property_value: http://purl.org/dc/terms/creator https://orcid.org/0000-0002-6601-2165
 property_value: RO:0004050 RO:0002411
+property_value: seeAlso https://wiki.geneontology.org/Causally_upstream_of,_negative_effect
 is_a: causally_upstream_of ! causally upstream of
 is_a: causally_upstream_of_or_within,_negative_effect ! causally upstream of or within, negative effect
 
@@ -381,6 +375,7 @@ subset: http://purl.obolibrary.org/obo/valid_for_gocam
 xref: RO:0002304
 property_value: http://purl.org/dc/terms/creator https://orcid.org/0000-0002-6601-2165
 property_value: RO:0004049 RO:0002411
+property_value: seeAlso https://wiki.geneontology.org/Causally_upstream_of,_positive_effect
 is_a: causally_upstream_of ! causally upstream of
 is_a: causally_upstream_of_or_within,_positive_effect ! causally upstream of or within, positive effect
 
@@ -402,6 +397,7 @@ id: causally_upstream_of_or_within,_negative_effect
 name: causally upstream of or within, negative effect
 xref: RO:0004046
 property_value: RO:0004050 RO:0002418
+property_value: seeAlso https://wiki.geneontology.org/Causally_upstream_of_or_within,_negative_effect xsd:anyURI
 is_a: causally_upstream_of_or_within ! causally upstream of or within
 created_by: https://orcid.org/0000-0002-6601-2165
 creation_date: 2018-03-13T23:55:05Z
@@ -411,6 +407,7 @@ id: causally_upstream_of_or_within,_positive_effect
 name: causally upstream of or within, positive effect
 xref: RO:0004047
 property_value: RO:0004049 RO:0002418
+property_value: seeAlso https://wiki.geneontology.org/Causally_upstream_of_or_within,_positive_effect
 is_a: causally_upstream_of_or_within ! causally upstream of or within
 created_by: https://orcid.org/0000-0002-6601-2165
 creation_date: 2018-03-13T23:55:19Z
@@ -508,6 +505,7 @@ property_value: IAO:0000112 "Subunits of nuclear RNA polymerases: none of the in
 property_value: IAO:0000116 "We would like to say\n\nif and only if\n exists c', p'\n  c part_of c' and c' capable_of p\n   and\n  c capable_of p' and p' part_of p\nthen\n c contributes_to p\n\nHowever, this is not possible in OWL. We instead make this relation a sub-relation of the two chains, which gives us the inference in the one direction." xsd:string
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000232 "In the context of the Gene Ontology, contributes_to may be used only with classes from the molecular function ontology. " xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Contributes_to xsd:anyURI
 is_a: capable_of_part_of ! capable of part of
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: part_of_structure_that_is_capable_of ! part of structure that is capable of
@@ -555,11 +553,11 @@ creation_date: 2021-11-08T12:00:00Z
 [Typedef]
 id: directly_negatively_regulated_by
 name: directly negatively regulated by
-def: "Process(P2) is directly negatively regulated by process(P1) iff: P1 negatively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  negatively regulates the kinase activity (P2) of protein B then P2 directly negatively regulated by P1." [GOC:dos]
+def: "Process(P2) is directly negatively regulated by process(P1) iff: P1 negatively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  negatively regulates the kinase activity (P2) of protein B then P2 directly negatively regulated by P1." [https://orcid.org/0000-0002-7073-9172]
 xref: RO:0002023
 is_a: directly_regulated_by ! directly regulated by
 inverse_of: directly_negatively_regulates ! directly negatively regulates
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-09-17T13:52:38Z
 
 [Typedef]
@@ -579,6 +577,7 @@ property_value: IAO:0000589 "directly negatively regulates (process to process)"
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range BFO:0000015 xsd:string
 property_value: RO:0004050 RO:0002578
+property_value: seeAlso https://wiki.geneontology.org/Directly_negatively_regulates xsd:anyURI
 is_a: directly_regulates ! directly regulates
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: negatively_regulates ! negatively regulates
@@ -599,11 +598,11 @@ is_a: directly_regulates_activity_of ! directly regulates activity of
 [Typedef]
 id: directly_positively_regulated_by
 name: directly positively regulated by
-def: "Process(P2) is directly postively regulated by process(P1) iff: P1 positively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding positively regulates the kinase activity (P2) of protein B then P2 is directly postively regulated by P1." [GOC:dos]
+def: "Process(P2) is directly postively regulated by process(P1) iff: P1 positively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding positively regulates the kinase activity (P2) of protein B then P2 is directly postively regulated by P1." [https://orcid.org/0000-0002-7073-9172]
 xref: RO:0002024
 is_a: directly_regulated_by ! directly regulated by
 inverse_of: directly_positively_regulates ! directly positively regulates
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-09-17T13:52:47Z
 
 [Typedef]
@@ -623,6 +622,7 @@ property_value: IAO:0000589 "directly positively regulates (process to process)"
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range BFO:0000015 xsd:string
 property_value: RO:0004049 RO:0002578
+property_value: seeAlso https://wiki.geneontology.org/Directly_positively_regulates xsd:anyURI
 is_a: directly_regulates ! directly regulates
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: positively_regulates ! positively regulates
@@ -643,11 +643,11 @@ is_a: directly_regulates_activity_of ! directly regulates activity of
 [Typedef]
 id: directly_regulated_by
 name: directly regulated by
-comment: Process(P2) is directly regulated by process(P1) iff: P1 regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  regulates the kinase activity (P2) of protein B then P1 directly regulates P2. {xref="GOC:dos"}
+comment: Process(P2) is directly regulated by process(P1) iff: P1 regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  regulates the kinase activity (P2) of protein B then P1 directly regulates P2. {xref="https://orcid.org/0000-0002-7073-9172"}
 xref: RO:0002022
 is_a: regulated_by ! regulated by
 inverse_of: directly_regulates ! directly regulates
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-09-17T13:52:24Z
 
 [Typedef]
@@ -742,6 +742,7 @@ def: "inverse of enables" []
 subset: http://purl.obolibrary.org/obo/valid_for_gocam
 xref: RO:0002333
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
+property_value: seeAlso https://wiki.geneontology.org/Enabled_by xsd:anyURI
 is_a: functionally_related_to ! functionally related to
 is_a: has_participant ! has participant
 
@@ -759,6 +760,7 @@ property_value: IAO:0000118 "has" xsd:string
 property_value: IAO:0000118 "is catalyzing" xsd:string
 property_value: IAO:0000118 "is executing" xsd:string
 property_value: IAO:0000232 "This relation differs from the parent relation 'capable of' in that the parent is weaker and only expresses a capability that may not be actually realized, whereas this relation is always realized." xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Enables xsd:anyURI
 is_a: capable_of ! capable of
 is_a: go_annotation_extension_relation ! go annotation extension relation
 inverse_of: enabled_by ! enabled by
@@ -1005,6 +1007,7 @@ property_value: IAO:0000118 "d" xsd:string
 property_value: IAO:0000118 "during" xsd:string
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range "GO:0008150 WBls:0000075 ZFS:0100000 UBERON:0000105" xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Happens_during xsd:anyURI
 property_value: usage "Identifies a process or life stage during which a molecular function or biological process occurs. This is weaker than parthood. So, for example, various processes occur during gastrulation without being part of it." xsd:string
 is_transitive: true
 is_a: during ! during
@@ -1061,7 +1064,7 @@ name: has component activity
 comment: A 'has component activity' B if A is A and B are molecular functions (GO_0003674) and A has_component B.
 xref: RO:0002017
 is_a: has_component_process ! has component process
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-05-24T09:44:33Z
 
 [Typedef]
@@ -1072,7 +1075,7 @@ xref: RO:0002018
 domain: BFO:0000015
 range: BFO:0000015
 is_a: has_component ! has component
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-05-24T09:49:21Z
 
 [Typedef]
@@ -1116,12 +1119,12 @@ is_obsolete: true
 [Typedef]
 id: has_effector_activity
 name: has effector activity
-def: "A 'has effector activity' B if A and B are GO molecular functions (GO_0003674),  A 'has component activity' B and B is the effector (output function) of B.  Each compound function has only one effector activity." [GOC:dos]
+def: "A 'has effector activity' B if A and B are GO molecular functions (GO_0003674),  A 'has component activity' B and B is the effector (output function) of B.  Each compound function has only one effector activity." [https://orcid.org/0000-0002-7073-9172]
 comment: This relation is designed for constructing compound molecular functions, typically in combination with one or more regulatory component activity relations.
 xref: RO:0002025
 is_functional: true
 is_a: has_component_activity ! has component activity
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-09-22T14:14:36Z
 
 [Typedef]
@@ -1227,6 +1230,7 @@ property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "consumes" xsd:string
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range "CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697 SO:0000839 SO:0001683 NCBITaxon:1" xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Has_input xsd:anyURI
 property_value: usage "Use this relation to relate a biological process or molecular function to an entity that participates in the process/function, is present at the start of the process/function and whose state is affected by that process/function.  Change of state includes being transported, modified, consumed or destroyed.  An input may be any continuant: chemical; gene product; cell component;  cells type; organism.  For inputs to MFs that are bound by the gene product that executes the MF, the more specific relation 'has_direct_input' may be used." xsd:string
 domain: BFO:0000015
 is_a: go_annotation_extension_relation ! go annotation extension relation
@@ -1241,7 +1245,7 @@ comment: By convention GO molecular functions are classified by their effector f
 xref: RO:0002014
 is_a: has_regulatory_component_activity ! has regulatory component activity
 is_a: negatively_regulated_by ! negatively regulated by
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-05-24T09:31:01Z
 
 [Typedef]
@@ -1264,6 +1268,7 @@ property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "produces" xsd:string
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range "CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697" xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Has_output xsd:anyURI
 property_value: usage "Identifies an entity that is changed or created after participation in a molecular function or biological process" xsd:string
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: has_participant ! has participant
@@ -1344,7 +1349,7 @@ comment: Do not use this relation directly
 subset: display_for_curators
 subset: valid_for_annotation_extension
 xref: RO:0000057
-property_value: http://purl.org/dc/elements/1.1/source http://www.obofoundry.org/ro/#OBO_REL:has_participant xsd:string
+property_value: http://purl.org/dc/terms/source http://www.obofoundry.org/ro/#OBO_REL:has_participant xsd:string
 property_value: IAO:0000111 "has participant" xsd:string
 property_value: IAO:0000112 "this blood coagulation has participant this blood clot" xsd:string
 property_value: IAO:0000112 "this investigation has participant this investigator" xsd:string
@@ -1377,7 +1382,7 @@ comment: By convention GO molecular functions are classified by their effector f
 xref: RO:0002015
 is_a: has_regulatory_component_activity ! has regulatory component activity
 is_a: positively_regulated_by ! positively regulated by
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-05-24T09:31:17Z
 
 [Typedef]
@@ -1415,7 +1420,7 @@ def: "A 'has regulatory component activity' B if A and B are GO molecular functi
 xref: RO:0002013
 is_a: has_component_activity ! has component activity
 is_a: regulated_by ! regulated by
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-05-24T09:30:46Z
 
 [Typedef]
@@ -1697,7 +1702,7 @@ name: indirectly causally upstream of
 def: "p is indirectly causally upstream of q iff p is causally upstream of q and there exists some process r such that p is causally upstream of r and r is causally upstream of q." []
 xref: RO:0012011
 is_a: causally_upstream_of ! causally upstream of
-created_by: pg
+created_by: https://orcid.org/0000-0003-1813-6857
 creation_date: 2022-09-26T06:07:17Z
 
 [Typedef]
@@ -1708,6 +1713,7 @@ xref: RO:0002409
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "indirectly inhibits" xsd:string
 property_value: RO:0002579 RO:0002212
+property_value: seeAlso https://wiki.geneontology.org/Indirectly_negatively_regulates xsd:anyURI
 holds_over_chain: directly_negatively_regulates directly_negatively_regulates
 holds_over_chain: directly_negatively_regulates indirectly_negatively_regulates
 is_transitive: true
@@ -1723,6 +1729,7 @@ xref: RO:0002407
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "indirectly activates" xsd:string
 property_value: RO:0002579 RO:0002213
+property_value: seeAlso https://wiki.geneontology.org/Indirectly_positively_regulates xsd:anyURI
 holds_over_chain: directly_positively_regulates directly_positively_regulates
 holds_over_chain: directly_positively_regulates indirectly_positively_regulates
 holds_over_chain: indirectly_negatively_regulates indirectly_negatively_regulates
@@ -1738,7 +1745,7 @@ def: "p indirectly regulates q iff p is indirectly causally upstream of q and p 
 xref: RO:0012012
 is_a: indirectly_causally_upstream_of ! indirectly causally upstream of
 is_a: regulates ! regulates
-created_by: pg
+created_by: https://orcid.org/0000-0003-1813-6857
 creation_date: 2022-09-26T06:08:01Z
 
 [Typedef]
@@ -1747,20 +1754,12 @@ name: inhibited_by
 namespace: go/extensions/gorel
 def: "Identifies a chemical substance that decreases the activity of the gene product." [GOC:mah]
 comment: This relation should not be used to annotate one gene product regulating another's activity; a regulator MF or regulation BP should be used in such cases.
-subset: AE_chemical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "activity_decreased_by" EXACT [GOC:mah]
 synonym: "inhibited by" EXACT RO:0008000 [PomBase:curators]
 synonym: "inhibited_by_chemical" EXACT [GOC:mah]
 synonym: "inhibited_by_substance" EXACT [GOC:mah]
 xref: GOREL:0000508
-property_value: local_domain GO:0003674 xsd:string
-property_value: local_range CHEBI:24431 xsd:string
 property_value: usage "Identifies a chemical substance that decreases the activity of the gene product." xsd:string
-domain: GO:0003674
-range: CHEBI:24431
-is_a: go_annotation_extension_relation ! go annotation extension relation
 
 [Typedef]
 id: inhibits_protease
@@ -1831,7 +1830,7 @@ xref: RO:0002331
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "actively involved in" xsd:string
 property_value: IAO:0000118 "enables part of" xsd:string
-property_value: seeAlso Involved:in
+property_value: seeAlso https://wiki.geneontology.org/Involved_in xsd:anyURI
 holds_over_chain: enables part_of
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: involved_in_or_involved_in_regulation_of ! involved in or involved in regulation of
@@ -1886,12 +1885,13 @@ is_a: involved_in_or_involved_in_regulation_of ! involved in or involved in regu
 [Typedef]
 id: is_active_in
 name: is active in
-def: "c executes activity in d if and only if c enables p and p occurs_in d.  Assuming no action at a distance by gene products, if a gene product enables (is capable of) a process that occurs in some structure, it must have at least some part in that structure." [GOC:cjm, GOC:dos]
+def: "c executes activity in d if and only if c enables p and p occurs_in d.  Assuming no action at a distance by gene products, if a gene product enables (is capable of) a process that occurs in some structure, it must have at least some part in that structure." [https://orcid.org/0000-0002-6601-2165, https://orcid.org/0000-0002-7073-9172]
 synonym: "enables activity in" EXACT []
 xref: RO:0002432
 property_value: IAO:0000112 "A protein that enables activity in a cytosol." xsd:string
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: IAO:0000118 "executes activity in" xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Is_active_in xsd:anyURI
 holds_over_chain: enables occurs_in {http://purl.obolibrary.org/obo/RO_0002581="true"}
 is_a: functionally_related_to ! functionally related to
 is_a: overlaps ! overlaps
@@ -2150,6 +2150,7 @@ property_value: IAO:0000118 "unfolds_in" xsd:string
 property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 property_value: local_domain BFO:0000015 xsd:string
 property_value: local_range "CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766 NCBITaxon:1 FBbt:10000000" xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Occurs_in xsd:anyURI
 property_value: usage "Identifies the cell, tissue, cellular component or anatomical entity within which all parts of the molecular function or biological process occurs" xsd:string
 domain: BFO:0000003
 range: BFO:0000004
@@ -2254,6 +2255,7 @@ property_value: RO:0040042 BFO:0000031
 property_value: seeAlso http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections
 property_value: seeAlso http://ontologydesignpatterns.org/wiki/Submissions:PartOf
 property_value: seeAlso http://www.obofoundry.org/ro/#OBO_REL:part_of xsd:string
+property_value: seeAlso https://wiki.geneontology.org/Part_of xsd:anyURI
 property_value: usage "This relation has two uses in annotation extension.  It may be used to relate a cellular component to some cellular component, cell or anatomical structure that it is part of.  It may also be used to relate a molecular function or biological process to a biological process or developmental stage of which it is a part.  It may not be used to relate cellular components to functions, processes or stages, or to relate processes or functions to cellular components, cells or anatomical structures." xsd:string
 is_transitive: true
 is_a: go_annotation_extension_relation ! go annotation extension relation
@@ -2291,8 +2293,8 @@ subset: ro-eco
 xref: RO:0002574
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: seeAlso http://dx.doi.org/10.1016/j.ecoinf.2014.08.005
-domain: CARO:0001010
-range: CARO:0001010
+domain: OBI:0100026
+range: OBI:0100026
 is_a: biotically_interacts_with ! biotically interacts with
 
 [Typedef]
@@ -2364,7 +2366,7 @@ name: preceded by
 def: "x is preceded by y if and only if the time point at which y ends is before or equivalent to the time point at which x starts. Formally: x preceded by y iff ω(y) <= α(x), where α is a function that maps a process to a start point, and ω is a function that maps a process to an end point." []
 subset: ro-eco
 xref: BFO:0000062
-property_value: http://purl.org/dc/elements/1.1/source http://www.obofoundry.org/ro/#OBO_REL:preceded_by xsd:string
+property_value: http://purl.org/dc/terms/source http://www.obofoundry.org/ro/#OBO_REL:preceded_by xsd:string
 property_value: IAO:0000111 "preceded by" xsd:string
 property_value: IAO:0000116 "An example is: translation preceded_by transcription; aging preceded_by development (not however death preceded_by aging). Where derives_from links classes of continuants, preceded_by links classes of processes. Clearly, however, these two relations are not independent of each other. Thus if cells of type C1 derive_from cells of type C, then any cell division involving an instance of C1 in a given lineage is preceded_by cellular processes involving an instance of C.    The assertion P preceded_by P1 tells us something about Ps in general: that is, it tells us something about what happened earlier, given what we know about what happened later. Thus it does not provide information pointing in the opposite direction, concerning instances of P1 in general; that is, that each is such as to be succeeded by some instance of P. Note that an assertion to the effect that P preceded_by P1 is rather weak; it tells us little about the relations between the underlying instances in virtue of which the preceded_by relation obtains. Typically we will be interested in stronger relations, for example in the relation immediately_preceded_by, or in relations which combine preceded_by with a condition to the effect that the corresponding instances of P and P1 share participants, or that their participants are connected by relations of derivation, or (as a first step along the road to a treatment of causality) that the one process in some way affects (for example, initiates or regulates) the other." xsd:string
 property_value: IAO:0000118 "is preceded by" xsd:string
@@ -2605,17 +2607,10 @@ id: regulates_o_occurs_in
 name: regulates process that occurs in
 namespace: go/extensions/gorel
 def: "A relation that holds between a regulatory process and the entity which the regulated biological process or molecular function occurs in." [GOC:cjm, GOC:dph, GOC:mtg_berkeley_2012_08_27]
-subset: AE_cell_or_anatomical
-subset: AE_cellular_component
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "regulates_o_occurs_in" EXACT []
 xref: GOREL:0001004
 property_value: IAO:0000112 "'negative regulation of chromosome segregation' that  regulates_o_occurs_in some spermatocyte." xsd:string
-property_value: local_domain GO:0065007 xsd:string
-property_value: local_range "CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766" xsd:string
 property_value: usage "Use this relation to link a regulatory process or function to the structure that the regulated process or function occurs in." xsd:string
-is_a: go_annotation_extension_relation ! go annotation extension relation
 equivalent_to_chain: regulates occurs_in ! occurs in
 
 [Typedef]
@@ -2623,18 +2618,10 @@ id: regulates_o_results_in_acquisition_of_features_of
 name: regulates acquisition of features of
 namespace: go/extensions/gorel
 def: "This is the combination of the regulates relation with the results_in_acquisition_of_features_of relation." [GOC:mtg_berkeley_2013]
-subset: AE_cell_or_anatomical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "regulates differentiation of" EXACT []
 synonym: "regulates_o_results_in_acquisition_of_features_of" EXACT []
 xref: GOREL:0001010
-property_value: local_domain GO:0008150 xsd:string
-property_value: local_range "CL:0000000 PO:0009002 1 WBbt:0004017 WBbt:0005766" xsd:string
 property_value: usage "Use this relation to relate a process that regulates the differentiation of a cell type or anatomical structure to the specific cell type or anatomical structure in question." xsd:string
-domain: BFO:0000015
-range: CL:0000000
-is_a: go_annotation_extension_relation ! go annotation extension relation
 equivalent_to_chain: regulates results_in_acquisition_of_features_of ! results in acquisition of features of
 
 [Typedef]
@@ -2652,16 +2639,9 @@ id: regulates_o_results_in_development_of
 name: regulates development of
 namespace: go/extensions/gorel
 def: "This is the combination of the regulates relation with the results_in_development_of relation." [GOC:mtg_berkeley_2013]
-subset: AE_cell_or_anatomical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "regulates_o_results_in_development_of" EXACT []
 xref: GOREL:0001023
-property_value: local_domain GO:0008150 xsd:string
-property_value: local_range "CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766" xsd:string
 property_value: usage "Use this relation to relate 'regulation of developmental process' or one of its subclasses to the structure that the regulated developmental process results in the development of." xsd:string
-domain: GO:0050793
-is_a: go_annotation_extension_relation ! go annotation extension relation
 equivalent_to_chain: regulates results_in_development_of ! results in development of
 
 [Typedef]
@@ -2705,16 +2685,10 @@ name: regulates process that results in movement of
 namespace: go/extensions/gorel
 def: "A relation that holds between a process that regulates locomotion and the cell or organism whose locomotion is being regulated." [GOC:cjm, GOC:dph, GOC:mtg_berkeley_2012_08_27]
 comment: This is the combination of the regulates relation with the results_in_movement_of relation.  Example of use: an annotation of gene X to 'regulation of cell migration with 'regulates_o_results_in_movement_of(CL:0000653) in column 16 would mean that gene X is involved in the regulation of glomerular visceral epithelial cell migration.
-subset: AE_cell_or_anatomical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "regulates_o_results_in_movement_of" EXACT []
 xref: GOREL:0001005
-property_value: local_domain BFO:0000015 xsd:string
-property_value: local_range "CL:0000000 GO:0005575 WBbt:0004017" xsd:string
 property_value: usage "Use this relation to relate a process that regulates locomotion to the cell or organism whose locomotion is being regulated." xsd:string
 domain: GO:0040012
-is_a: go_annotation_extension_relation ! go annotation extension relation
 equivalent_to_chain: regulates results_in_movement_of ! results in movement of
 
 [Typedef]
@@ -2722,16 +2696,9 @@ id: regulates_o_results_in_specification_of
 name: regulates specification of
 namespace: go/extensions/gorel
 def: "A relation that applies between a process that regulates the specification of some cell type or structure and the specified cell type or structure." [GOC:mtg_berkeley_2013]
-subset: AE_cell_or_anatomical
-subset: display_for_curators
-subset: valid_for_annotation_extension
 synonym: "regulates_o_results_in_specification_of" EXACT []
 xref: GOREL:0001027
-property_value: local_domain BFO:0000015 xsd:string
-property_value: local_range "CL:0000000 WBbt:0004017" xsd:string
 property_value: usage "Use this relation to link a process that regulates the specification of some cell type of anatomical structure, and the structure or cell type specified." xsd:string
-domain: GO:0050789
-is_a: go_annotation_extension_relation ! go annotation extension relation
 equivalent_to_chain: regulates results_in_specification_of ! results in specification of
 
 [Typedef]
@@ -2923,7 +2890,7 @@ property_value: IAO:0000119 GOC:mtg_berkeley_2013 xsd:string
 property_value: local_domain GO:0030154 xsd:string
 property_value: local_range "CL:0000000 PO:0009002 WBbt:0004017" xsd:string
 property_value: usage "Use this relation to link a cell differentiation process to the cell type that the process results in the differentiation of." xsd:string
-range: CARO:0000003
+range: UBERON:0000061
 is_a: go_annotation_extension_relation ! go annotation extension relation
 is_a: results_in_changes_to_anatomical_or_cellular_structure ! results in changes to anatomical or cellular structure
 is_a: results_in_developmental_progression_of ! results in developmental progression of
@@ -3018,7 +2985,7 @@ property_value: IAO:0000116 "This property and its subproperties are being used 
 property_value: IAO:0000117 https://orcid.org/0000-0002-6601-2165
 property_value: seeAlso Ontology:extensions
 domain: GO:0008150
-range: CARO:0000000
+range: UBERON:0001062
 is_a: developmentally_related_to ! developmentally related to
 
 [Typedef]
@@ -3277,7 +3244,7 @@ name: transports
 def: "Holds between p and c when p is a transport process or transporter activity and the outcome of this p is to move c from one location to another." []
 xref: RO:0002020
 is_a: transports_or_maintains_localization_of ! transports or maintains localization of
-created_by: dos
+created_by: https://orcid.org/0000-0002-7073-9172
 creation_date: 2017-07-20T17:11:08Z
 
 [Typedef]

--- a/src/ontology/extensions/gorel.owl
+++ b/src/ontology/extensions/gorel.owl
@@ -1,23 +1,22 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/go/extensions/gorel.owl#"
      xml:base="http://purl.obolibrary.org/obo/go/extensions/gorel.owl"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:swrlb="http://www.w3.org/2003/11/swrlb#"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:go="http://purl.obolibrary.org/obo/go#"
-     xmlns:swrl="http://www.w3.org/2003/11/swrl#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:swrla="http://swrl.stanford.edu/ontologies/3.3/swrla.owl#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:terms="http://purl.org/dc/terms/"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:go_annotation_extension_relations="http://purl.obolibrary.org/obo/go/extensions/go_annotation_extension_relations#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:dc="http://purl.org/dc/elements/1.1/">
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:swrl="http://www.w3.org/2003/11/swrl#"
+     xmlns:swrla="http://swrl.stanford.edu/ontologies/3.3/swrla.owl#"
+     xmlns:swrlb="http://www.w3.org/2003/11/swrlb#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:go_annotation_extension_relations="http://purl.obolibrary.org/obo/go/extensions/go_annotation_extension_relations#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/go/extensions/gorel.owl">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(Anonymous-3)) [Axioms: 1776 Logical Axioms: 474]</rdfs:comment>
         <dc:description>This ontology combines RO together with GO-specific relations in the GOREL namespace, used for annotation extensions. See;
 
 Huntley, R. P., Harris, M. a, Alam-Faruque, Y., et al (2014). A method for increasing expressivity of Gene Ontology annotations using a compositional approach. BMC Bioinformatics, 15(1), 155. doi:10.1186/1471-2105-15-155
@@ -28,7 +27,8 @@ This ontology is created by merging the relevant subset of RO together with GO-s
 
 Notes on editors version (gorel-edit.owl): 
 The editors version imports ro.owl, and allows addition of new relations (GOREL ID space) and annotation of existing RO relations. Note for editors: if an RO relation is to be made visible in the final gorel product, then make the relation a SubProperty of &apos;go annotation extension relation&apos;. Anything with a logical axiom is included in the final module. Consult Makefile for details</dc:description>
-        <oboInOwl:default-namespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">external</oboInOwl:default-namespace>
+        <oboInOwl:default-namespace>external</oboInOwl:default-namespace>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Includes Ontology(OntologyID(Anonymous-3)) [Axioms: 1925 Logical Axioms: 480]</rdfs:comment>
     </owl:Ontology>
     
 
@@ -65,7 +65,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
+        <rdfs:label>definition</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -121,7 +121,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">term replaced by</rdfs:label>
+        <rdfs:label>term replaced by</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -135,6 +135,12 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/RO_0001900 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001900"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002175 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002175"/>
     
 
 
@@ -183,7 +189,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/RO_0008000 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0008000">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">display label for users</rdfs:label>
+        <rdfs:label>display label for users</rdfs:label>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty"/>
     </owl:AnnotationProperty>
     
@@ -198,7 +204,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_biological_process -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_biological_process">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO biological process</rdfs:comment>
+        <rdfs:comment>GO biological process</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -207,7 +213,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cell or anatomical</rdfs:comment>
+        <rdfs:comment>cell or anatomical</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -216,7 +222,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_cellular_component -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_cellular_component">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO cellular component</rdfs:comment>
+        <rdfs:comment>GO cellular component</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -225,7 +231,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_chemical -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_chemical">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chemical</rdfs:comment>
+        <rdfs:comment>Chemical</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -234,7 +240,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_developmental_stages -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_developmental_stages">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Developmental stages</rdfs:comment>
+        <rdfs:comment>Developmental stages</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -243,7 +249,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_molecular_function -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_molecular_function">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO molecular function</rdfs:comment>
+        <rdfs:comment>GO molecular function</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -252,7 +258,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_sequence_feature -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_sequence_feature">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sequence feature</rdfs:comment>
+        <rdfs:comment>Sequence feature</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -261,7 +267,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://purl.obolibrary.org/obo/go#AE_sequence_or_complex -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/go#AE_sequence_or_complex">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein, protein complex, gene or transcript identifier</rdfs:comment>
+        <rdfs:comment>Protein, protein complex, gene or transcript identifier</rdfs:comment>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SubsetProperty"/>
     </owl:AnnotationProperty>
     
@@ -315,12 +321,6 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/source -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
     <!-- http://purl.org/dc/terms/contributor -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
@@ -348,7 +348,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#SubsetProperty -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#SubsetProperty">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subset_property</rdfs:label>
+        <rdfs:label>subset_property</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -356,7 +356,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">synonym_type_property</rdfs:label>
+        <rdfs:label>synonym_type_property</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -370,7 +370,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#consider -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#consider">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consider</rdfs:label>
+        <rdfs:label>consider</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -396,7 +396,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_alternative_id</rdfs:label>
+        <rdfs:label>has_alternative_id</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -404,7 +404,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_broad_synonym</rdfs:label>
+        <rdfs:label>has_broad_synonym</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -412,7 +412,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">database_cross_reference</rdfs:label>
+        <rdfs:label>database_cross_reference</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -420,7 +420,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_exact_synonym</rdfs:label>
+        <rdfs:label>has_exact_synonym</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -428,7 +428,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_narrow_synonym</rdfs:label>
+        <rdfs:label>has_narrow_synonym</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -436,7 +436,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_format_version</rdfs:label>
+        <rdfs:label>has_obo_format_version</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -444,7 +444,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_namespace</rdfs:label>
+        <rdfs:label>has_obo_namespace</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -452,7 +452,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_related_synonym</rdfs:label>
+        <rdfs:label>has_related_synonym</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -460,7 +460,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#hasSynonymType -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasSynonymType">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_synonym_type</rdfs:label>
+        <rdfs:label>has_synonym_type</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -474,7 +474,7 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#inSubset -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_subset</rdfs:label>
+        <rdfs:label>in_subset</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -494,8 +494,14 @@ The editors version imports ro.owl, and allows addition of new relations (GOREL 
     <!-- http://www.geneontology.org/formats/oboInOwl#shorthand -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#shorthand">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shorthand</rdfs:label>
+        <rdfs:label>shorthand</rdfs:label>
     </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#source -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#source"/>
     
 
 
@@ -560,12 +566,12 @@ A continuant cannot be part of an occurrent: use &apos;participates in&apos;. An
         <obo:RO_0040042 rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
         <obo:RO_0040042 rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <obo:RO_0040042 rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 GO:0008150 PO:0009012 PO:0025131 UBERON:0001062 ZFS:0100000 WBls:0000075 WBbt:0004017 WBbt:0005766 NCBITaxon:1</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation has two uses in annotation extension.  It may be used to relate a cellular component to some cellular component, cell or anatomical structure that it is part of.  It may also be used to relate a molecular function or biological process to a biological process or developmental stage of which it is a part.  It may not be used to relate cellular components to functions, processes or stages, or to relate processes or functions to cellular components, cells or anatomical structures.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000050</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 GO:0008150 PO:0009012 PO:0025131 UBERON:0001062 ZFS:0100000 WBls:0000075 WBbt:0004017 WBbt:0005766 NCBITaxon:1</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>This relation has two uses in annotation extension.  It may be used to relate a cellular component to some cellular component, cell or anatomical structure that it is part of.  It may also be used to relate a molecular function or biological process to a biological process or developmental stage of which it is a part.  It may not be used to relate cellular components to functions, processes or stages, or to relate processes or functions to cellular components, cells or anatomical structures.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>BFO:0000050</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>part of</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
@@ -576,17 +582,18 @@ A continuant cannot be part of an occurrent: use &apos;participates in&apos;. An
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_developmental_stages"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part_of</oboInOwl:shorthand>
+        <oboInOwl:shorthand>part_of</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">part of</rdfs:label>
         <rdfs:seeAlso rdf:resource="http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections"/>
         <rdfs:seeAlso rdf:resource="http://ontologydesignpatterns.org/wiki/Submissions:PartOf"/>
         <rdfs:seeAlso>http://www.obofoundry.org/ro/#OBO_REL:part_of</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Part_of</rdfs:seeAlso>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part of</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>part of</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -609,20 +616,20 @@ A continuant cannot be part of an occurrent: use &apos;participates in&apos;. An
 A continuant cannot have an occurrent as part: use &apos;participates in&apos;. An occurrent cannot have a continuant as part: use &apos;has participant&apos;. An immaterial entity cannot have a material entity as part: use &apos;location of&apos;. An independent continuant cannot have a specifically dependent continuant as part: use &apos;bearer of&apos;. A specifically dependent continuant cannot have an independent continuant as part: use &apos;inheres in&apos;.</obo:IAO_0000116>
         <obo:IAO_0000118 xml:lang="en">has_part</obo:IAO_0000118>
         <obo:RO_0001900 rdf:resource="http://purl.obolibrary.org/obo/RO_0001901"/>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000051</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has part</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasDbXref>BFO:0000051</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>has part</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</oboInOwl:shorthand>
+        <oboInOwl:shorthand>has_part</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">has part</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has part</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>has part</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -653,7 +660,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000116 xml:lang="en">An example is: translation preceded_by transcription; aging preceded_by development (not however death preceded_by aging). Where derives_from links classes of continuants, preceded_by links classes of processes. Clearly, however, these two relations are not independent of each other. Thus if cells of type C1 derive_from cells of type C, then any cell division involving an instance of C1 in a given lineage is preceded_by cellular processes involving an instance of C.    The assertion P preceded_by P1 tells us something about Ps in general: that is, it tells us something about what happened earlier, given what we know about what happened later. Thus it does not provide information pointing in the opposite direction, concerning instances of P1 in general; that is, that each is such as to be succeeded by some instance of P. Note that an assertion to the effect that P preceded_by P1 is rather weak; it tells us little about the relations between the underlying instances in virtue of which the preceded_by relation obtains. Typically we will be interested in stronger relations, for example in the relation immediately_preceded_by, or in relations which combine preceded_by with a condition to the effect that the corresponding instances of P and P1 share participants, or that their participants are connected by relations of derivation, or (as a first step along the road to a treatment of causality) that the one process in some way affects (for example, initiates or regulates) the other.</obo:IAO_0000116>
         <obo:IAO_0000118 xml:lang="en">is preceded by</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">preceded_by</obo:IAO_0000118>
-        <dc:source>http://www.obofoundry.org/ro/#OBO_REL:preceded_by</dc:source>
+        <terms:source>http://www.obofoundry.org/ro/#OBO_REL:preceded_by</terms:source>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000062</oboInOwl:hasDbXref>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">preceded_by</oboInOwl:shorthand>
@@ -707,12 +714,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000118 xml:lang="en">occurs_in</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">unfolds in</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">unfolds_in</obo:IAO_0000118>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766 NCBITaxon:1 FBbt:10000000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies the cell, tissue, cellular component or anatomical entity within which all parts of the molecular function or biological process occurs</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000066</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in</oboInOwl:hasRelatedSynonym>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766 NCBITaxon:1 FBbt:10000000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies the cell, tissue, cellular component or anatomical entity within which all parts of the molecular function or biological process occurs</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>BFO:0000066</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>in</oboInOwl:hasRelatedSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -720,17 +727,18 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cellular_component"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">occurs_in</oboInOwl:shorthand>
+        <oboInOwl:shorthand>occurs_in</oboInOwl:shorthand>
         <rdfs:comment>Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant</rdfs:comment>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;p occurs_in c if and only if all of the participants of p are part_of c.&quot; [BFO:cjm]</rdfs:comment>
+        <rdfs:comment>Previous definition &quot;p occurs_in c if and only if all of the participants of p are part_of c.&quot; [BFO:cjm]</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">occurs in</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Occurs_in</rdfs:seeAlso>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000066"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>in</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -765,13 +773,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000002">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a process or life stage during which a molecular function or biological process occurs or a cellular component is present</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000002</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</rdfs:label>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a process or life stage during which a molecular function or biological process occurs or a cellular component is present</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000002</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>during</oboInOwl:shorthand>
+        <rdfs:label>during</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -784,28 +792,28 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0000003"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000003</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localization_destination</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localizes_to</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TODO : check this one. Note Pombe is using different variant.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete localizes_to</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>localization_destination</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>localizes_to</oboInOwl:shorthand>
+        <rdfs:comment>TODO : check this one. Note Pombe is using different variant.</rdfs:comment>
+        <rdfs:label>obsolete localizes_to</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000003"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:cjm</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. c localizes_to d if c executes some function when it is part_of d.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>BFO:cjm</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000003"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localization_destination</owl:annotatedTarget>
+        <owl:annotatedTarget>localization_destination</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -814,27 +822,27 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000004 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000004">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent on</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent_on</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase uses the more specific child relations, and avoids using dependent_on directly.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete dependent_on</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000004</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>dependent on</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>dependent_on</oboInOwl:shorthand>
+        <rdfs:comment>PomBase uses the more specific child relations, and avoids using dependent_on directly.</rdfs:comment>
+        <rdfs:label>obsolete dependent_on</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000004"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:rph</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. Identifies a requirement under which the ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:rph</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000004"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent on</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>dependent on</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -845,16 +853,16 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000006">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <oboInOwl:consider rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_input</oboInOwl:consider>
-        <oboInOwl:consider rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output</oboInOwl:consider>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000006</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_target_cell</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">this relation has been obsoleted it was unclear whether the associated cell type id should correspond to the final mature or precursor cell. If the outcome of a process is a modified cell, then the relationships has_output or has_input along with a CL identifier respectively defining the precursor or mature cell type can be considered instead.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_target_cell</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <oboInOwl:consider>has_input</oboInOwl:consider>
+        <oboInOwl:consider>has_output</oboInOwl:consider>
+        <oboInOwl:hasDbXref>GOREL:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_target_cell</oboInOwl:shorthand>
+        <rdfs:comment>this relation has been obsoleted it was unclear whether the associated cell type id should correspond to the final mature or precursor cell. If the outcome of a process is a modified cell, then the relationships has_output or has_input along with a CL identifier respectively defining the precursor or mature cell type can be considered instead.</rdfs:comment>
+        <rdfs:label>obsolete has_target_cell</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -865,16 +873,16 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000007">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CARO_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000000</go_annotation_extension_relations:local_range>
-        <oboInOwl:consider rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_input</oboInOwl:consider>
-        <oboInOwl:consider rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output</oboInOwl:consider>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000007</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_target_anatomical_entity</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">this relation has been obsoleted it was unclear whether the associated anatomical entity id should correspond to the final form  or precursor anatomical entity. If the outcome of a process is a modified anatomical entity, then relationships has_output or has_input along with a anatomy identifier respectively defining the precursor or mature anatomical entity id can be considered instead.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_target_anatomical_entity</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CARO:0000000</go_annotation_extension_relations:local_range>
+        <oboInOwl:consider>has_input</oboInOwl:consider>
+        <oboInOwl:consider>has_output</oboInOwl:consider>
+        <oboInOwl:hasDbXref>GOREL:0000007</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_target_anatomical_entity</oboInOwl:shorthand>
+        <rdfs:comment>this relation has been obsoleted it was unclear whether the associated anatomical entity id should correspond to the final form  or precursor anatomical entity. If the outcome of a process is a modified anatomical entity, then relationships has_output or has_input along with a anatomy identifier respectively defining the precursor or mature anatomical entity id can be considered instead.</rdfs:comment>
+        <rdfs:label>obsolete has_target_anatomical_entity</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -884,27 +892,27 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000009">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0005575"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a requirement under which the gene product is located at the specified cellular component.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a requirement under which the gene product is located at the specified cellular component.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000009</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localized by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localization_dependent_on</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;Located at CC only if (BP occurs) OR (feature is present in annotated gene product) OR (CC is present) OR (gene product is present)&quot; [GOC:mah]</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete localization_dependent_on</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a requirement under which the gene product is located at the specified cellular component.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Identifies a requirement under which the gene product is located at the specified cellular component.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000009</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>localized by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>localization_dependent_on</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;Located at CC only if (BP occurs) OR (feature is present in annotated gene product) OR (CC is present) OR (gene product is present)&quot; [GOC:mah]</rdfs:comment>
+        <rdfs:label>obsolete localization_dependent_on</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000009"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a requirement under which the gene product is located at the specified cellular component.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:rph</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. Identifies a requirement under which the gene product is located at the specified cellular component.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:rph</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000009"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localized by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>localized by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -915,34 +923,34 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000010">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000007"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_feature</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000010</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_sequence_feature</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">strictly speaking, these fall outside the scope of GO, even with extended annotations</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_sequence_feature</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>requires</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasBroadSynonym>requires_feature</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000010</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_sequence_feature</oboInOwl:shorthand>
+        <rdfs:comment>strictly speaking, these fall outside the scope of GO, even with extended annotations</rdfs:comment>
+        <rdfs:label>obsolete requires_sequence_feature</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000010"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. A sequence feature, such as a protein domain or motif, of the annotated gene product required for its participation in Molecular Function or Biological Process.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000010"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000010"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_feature</owl:annotatedTarget>
+        <owl:annotatedTarget>requires_feature</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -952,26 +960,26 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000011">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000007"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000011</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_regulator</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_regulator</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>requires</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000011</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_regulator</oboInOwl:shorthand>
+        <rdfs:label>obsolete requires_regulator</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000011"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Annotated gene product requires regulation by the gene product or complex for its participation in the Molecular Function or Biological Process.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000011"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -982,26 +990,26 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000012">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000007"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string"> The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000012</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_substance</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_substance</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage> The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>requires</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000012</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_substance</oboInOwl:shorthand>
+        <rdfs:label>obsolete requires_substance</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000012"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. The annotated gene product participates in a Biological Process or executes a Molecular Function only in the presence of a substance</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000012"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1011,41 +1019,41 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000013">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0003674 GO:0005575 GO:0008150 GO:0032991 MI:0315 MOD:00000 PR:000000001 SO:0000110 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_dependent_on</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000013</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">independent_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not dependent on</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0003674 GO:0005575 GO:0008150 GO:0032991 MI:0315 MOD:00000 PR:000000001 SO:0000110 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>not_dependent_on</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>GOREL:0000013</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>independent_of</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>not dependent on</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_biological_process"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_chemical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_molecular_function"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_sequence_feature"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_sequence_or_complex"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">independent_of</oboInOwl:shorthand>
+        <oboInOwl:shorthand>independent_of</oboInOwl:shorthand>
         <rdfs:comment>DEPRECATION WARNING: The GO editors have agreed that this relation should be deprecated. There are two main reasons for this 1. The relation does not extend the meaning of the GO term, as annotation relations are meant to, but instead specifies conditions under which the annotation is true. This can not be expressed in OWL. Annotation extensions using this relation will never fold. 2. The relation includes a hidden negation. This is problematic for a number of reasons, the most important of which is that burying negations in otherwise positive relationships can cause serious problems for inference.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">independent_of</rdfs:label>
+        <rdfs:label>independent_of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000013"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOA:rph</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>Identifies an entity that was shown not to be required for the ontology term to apply to the annotated gene product.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOA:rph</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000013"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">independent_of</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:rph</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>independent_of</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:rph</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000013"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not dependent on</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>not dependent on</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1055,21 +1063,21 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000014">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0010466"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0010466</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000014</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibits_protease</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would probably be direct.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete inhibits_protease</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a specific target of regulation of a MF</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>GO:0010466</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>OBSOLETE. Identifies a specific target of regulation of a MF</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000014</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>inhibits_protease</oboInOwl:shorthand>
+        <rdfs:comment>This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would probably be direct.</rdfs:comment>
+        <rdfs:label>obsolete inhibits_protease</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000014"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies a specific target of regulation of a MF</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1085,22 +1093,22 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000057"/>
         </owl:propertyChainAxiom>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relationship to link a regulatory process or function to an entity that (such as a gene, gene product, or complex) participates in the regulated process.  This is a very general relation.  Use something more specific wherever possible, e.g. &apos;regulates expression of&apos; or &apos;regulates transport of&apos;.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000015</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relationship to link a regulatory process or function to an entity that (such as a gene, gene product, or complex) participates in the regulated process.  This is a very general relation.  Use something more specific wherever possible, e.g. &apos;regulates expression of&apos; or &apos;regulates transport of&apos;.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>regulates</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000015</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_sequence_or_complex"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_regulation_target</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">probably want to add one or two new subtypes that capture something about directness</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_regulation_target</rdfs:label>
+        <oboInOwl:shorthand>has_regulation_target</oboInOwl:shorthand>
+        <rdfs:comment>probably want to add one or two new subtypes that capture something about directness</rdfs:comment>
+        <rdfs:label>has_regulation_target</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000015"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates</owl:annotatedTarget>
+        <owl:annotatedTarget>regulates</owl:annotatedTarget>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1110,21 +1118,21 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000017">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0010952"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0010952</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000017</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protease_activator</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would be direct.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete protease_activator</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a specific target of regulation of a MF</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>GO:0010952</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>OBSOLETE. Identifies a specific target of regulation of a MF</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000017</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>protease_activator</oboInOwl:shorthand>
+        <rdfs:comment>This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would be direct.</rdfs:comment>
+        <rdfs:label>obsolete protease_activator</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000017"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific target of regulation of a MF</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies a specific target of regulation of a MF</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1133,32 +1141,32 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000018 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000018">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0031647</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000018</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stabilizes</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>OBSOLETE. Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>GO:0031647</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000018</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>stabilizes</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_sequence_or_complex"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stabilizes</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Obsoleted, see https://github.com/geneontology/go-ontology/issues/18540.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete stabilizes</rdfs:label>
+        <oboInOwl:shorthand>stabilizes</oboInOwl:shorthand>
+        <rdfs:comment>Obsoleted, see https://github.com/geneontology/go-ontology/issues/18540.</rdfs:comment>
+        <rdfs:label>obsolete stabilizes</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000018"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies specific gene product stabilized in a protein stabilization process (or regulation thereof)</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000018"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stabilizes</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>stabilizes</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1168,13 +1176,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000020">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000020</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_upstream_or_downstream_target</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_upstream_or_downstream_target</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <oboInOwl:hasDbXref>GOREL:0000020</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_upstream_or_downstream_target</oboInOwl:shorthand>
+        <rdfs:label>obsolete has_upstream_or_downstream_target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -1184,13 +1192,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000021">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000021</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_upstream_target</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_upstream_target</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <oboInOwl:hasDbXref>GOREL:0000021</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_upstream_target</oboInOwl:shorthand>
+        <rdfs:label>obsolete has_upstream_target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -1199,12 +1207,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000022 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000022">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000022</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_downstream_target</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_downstream_target</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <oboInOwl:hasDbXref>GOREL:0000022</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_downstream_target</oboInOwl:shorthand>
+        <rdfs:label>obsolete has_downstream_target</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -1214,21 +1222,21 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000023">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0006355"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies gene whose transcription is regulated</obo:IAO_0000115>
-        <obo:IAO_0100001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_regulation_target</obo:IAO_0100001>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0006355</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies gene whose transcription is regulated</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000023</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transcriptionally_regulates</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would be indirect.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete transcriptionally_regulates</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies gene whose transcription is regulated</obo:IAO_0000115>
+        <obo:IAO_0100001>has_regulation_target</obo:IAO_0100001>
+        <go_annotation_extension_relations:local_domain>GO:0006355</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:usage>OBSOLETE. Identifies gene whose transcription is regulated</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000023</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>transcriptionally_regulates</oboInOwl:shorthand>
+        <rdfs:comment>This relation was made obsolete because it is undesirably specific and redundant with any GO term that would be used in col5. Annotations that used this might use a different, to-be-added, child of has_regulation_target that captures something about directness; this one would be indirect.</rdfs:comment>
+        <rdfs:label>obsolete transcriptionally_regulates</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000023"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies gene whose transcription is regulated</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies gene whose transcription is regulated</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1237,31 +1245,31 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000024 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000024">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000024</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>OBSOLETE. A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>except during</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000024</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_during</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">domain can be any process or object or even quality</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete not_during</rdfs:label>
+        <oboInOwl:shorthand>not_during</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
+        <rdfs:comment>domain can be any process or object or even quality</rdfs:comment>
+        <rdfs:label>obsolete not_during</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000024"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. A BP during which an annotation does not apply, e.g. a localization not observed at the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000024"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>except during</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1270,43 +1278,43 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000025 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000025">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000025</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">does_not_happen_during</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_occurs_during</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000007</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>except during</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000025</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>does_not_happen_during</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>not_occurs_during</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_happens_during</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete not_happens_during</rdfs:label>
+        <oboInOwl:shorthand>not_happens_during</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
+        <rdfs:label>obsolete not_happens_during</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Molecular Function or Biological Process does not apply, e.g. involvement in a process not observed during the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000025"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>except during</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000025"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">does_not_happen_during</owl:annotatedTarget>
+        <owl:annotatedTarget>does_not_happen_during</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000025"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_occurs_during</owl:annotatedTarget>
+        <owl:annotatedTarget>not_occurs_during</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1315,37 +1323,37 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000026 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000026">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000026</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">does_not_exist_during</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>BFO:0000007 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>except during</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000026</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>does_not_exist_during</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_exists_during</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete not_exists_during</rdfs:label>
+        <oboInOwl:shorthand>not_exists_during</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
+        <rdfs:label>obsolete not_exists_during</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000026"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. A Molecular Function or Biological Process during which an annotation to a Cellular Component does not apply, e.g.  a localization not observed at the specified cell cycle phase (but observed in other phases).</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000026"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">except during</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>except during</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000026"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">does_not_exist_during</owl:annotatedTarget>
+        <owl:annotatedTarget>does_not_exist_during</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1354,29 +1362,29 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000027 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000027">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000027</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in presence of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_presence_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because it does not follow GO-CAM specifications.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete in_presence_of</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000027</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>in presence of</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>in_presence_of</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because it does not follow GO-CAM specifications.</rdfs:comment>
+        <rdfs:label>obsolete in_presence_of</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000027"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies a chemical, gene product or complex in the presence of which an ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000027"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in presence of</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>in presence of</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1387,33 +1395,33 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000028">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/GO_0005575"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000028</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent_on_localization</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">only when located at</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_localization</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_localization</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000028</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>dependent_on_localization</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>only when located at</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_localization</oboInOwl:shorthand>
+        <rdfs:label>obsolete requires_localization</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000028"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. The annotated gene product participates in a Biological Process only if the gene product is located at a Cellular Component</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000028"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent_on_localization</owl:annotatedTarget>
+        <owl:annotatedTarget>dependent_on_localization</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000028"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">only when located at</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>only when located at</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1423,28 +1431,28 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000029">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000007"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion. Annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000029</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires regulation by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_regulation_by</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_regulation_by</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion. Annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000007</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000029</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>requires regulation by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_regulation_by</oboInOwl:shorthand>
+        <rdfs:label>obsolete requires_regulation_by</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000029"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion. Annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Was not defined before obsoletion. Annotated gene product participates in Biological Process or executes Molecular Function activity only if regulated by action of gene product; regulation is indirect (or unknown whether direct or indirect)</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000029"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires regulation by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires regulation by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1453,29 +1461,29 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000030 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000030">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies the gene product that catalyzes a modification on the annotated gene product</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD:00000</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies the gene product that catalyzes a modification on the annotated gene product</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000030</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modified by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modified_by</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://wiki.geneontology.org/index.php/Annotation_usage_examples_for_each_annotation_extension_relation</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete modified_by</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies the gene product that catalyzes a modification on the annotated gene product</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>MOD:00000</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies the gene product that catalyzes a modification on the annotated gene product</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000030</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>modified by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>modified_by</oboInOwl:shorthand>
+        <rdfs:comment>http://wiki.geneontology.org/index.php/Annotation_usage_examples_for_each_annotation_extension_relation</rdfs:comment>
+        <rdfs:label>obsolete modified_by</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000030"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies the gene product that catalyzes a modification on the annotated gene product</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies the gene product that catalyzes a modification on the annotated gene product</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000030"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modified by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>modified by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1484,32 +1492,32 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000031 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000031">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a condition under which the ontology term is observed to apply to the annotated gene product</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a condition under which the ontology term is observed to apply to the annotated gene product</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000031</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">assay_condition</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">under_condition</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">condition</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete condition</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a condition under which the ontology term is observed to apply to the annotated gene product</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Identifies a condition under which the ontology term is observed to apply to the annotated gene product</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000031</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>assay_condition</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>under_condition</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>condition</oboInOwl:shorthand>
+        <rdfs:label>obsolete condition</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000031"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a condition under which the ontology term is observed to apply to the annotated gene product</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Identifies a condition under which the ontology term is observed to apply to the annotated gene product</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000031"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">assay_condition</owl:annotatedTarget>
+        <owl:annotatedTarget>assay_condition</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000031"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">under_condition</owl:annotatedTarget>
+        <owl:annotatedTarget>under_condition</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1522,25 +1530,25 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000002"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000032</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>during</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0000032</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_biological_process"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_developmental_stages"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exists_during</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;c exists_during p if and only if the temporal extent bounded by the start and end of c is part_of the temporal extent of p.&quot; [BFO:cjm]</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exists_during</rdfs:label>
+        <oboInOwl:shorthand>exists_during</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;c exists_during p if and only if the temporal extent bounded by the start and end of c is part_of the temporal extent of p.&quot; [BFO:cjm]</rdfs:comment>
+        <rdfs:label>exists_during</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000032"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>during</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1550,27 +1558,27 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000033">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0003674"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000033</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires direct regulation by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_direct_regulator</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the gene product in the extension should be annotated to a &quot;regulator&quot; MF (implying that it acts directly to regulate the annotated gp activity)</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_direct_regulator</rdfs:label>
+        <obo:IAO_0000115>Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000033</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>requires direct regulation by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_direct_regulator</oboInOwl:shorthand>
+        <rdfs:comment>the gene product in the extension should be annotated to a &quot;regulator&quot; MF (implying that it acts directly to regulate the annotated gp activity)</rdfs:comment>
+        <rdfs:label>obsolete requires_direct_regulator</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000033"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</owl:annotatedTarget>
+        <owl:annotatedTarget>Annotated gene product requires direct regulation by the gene product or complex identified in the extension. Includes cases where the annotated gene product is a catalytic subunit of a complex and requires a regulatory subunit for activity as well as cases where the regulator acts directly but interacts transiently.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000033"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires direct regulation by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires direct regulation by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1580,7 +1588,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000038">
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pg</oboInOwl:created_by>
+        <oboInOwl:created_by>pg</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-08-28T07:03:28Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000038</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_transports_or_maintains_localization_of</oboInOwl:shorthand>
@@ -1592,19 +1600,19 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000501 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000501">
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies the Cellular Component or sequence feature adjacent to or in the vicinity of which the Molecular Function or Biological Process is executed</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000501</oboInOwl:hasDbXref>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">at</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">occurs_at</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;P occurs_at C : the execution of P is located at C.&quot; [GOC:cjm, GOC:mah] This relation is not constrained with respect to whether C completely surrounds, or is adjacent to, the location where P is executed. Example: chromatin silencing at centromere unfolds_around centromere : Repression of transcription of centromeric DNA by the formation of heterochromatin.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete occurs at</rdfs:label>
+        <go_annotation_extension_relations:usage>Identifies the Cellular Component or sequence feature adjacent to or in the vicinity of which the Molecular Function or Biological Process is executed</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000501</oboInOwl:hasDbXref>
+        <oboInOwl:hasRelatedSynonym>at</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:shorthand>occurs_at</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;P occurs_at C : the execution of P is located at C.&quot; [GOC:cjm, GOC:mah] This relation is not constrained with respect to whether C completely surrounds, or is adjacent to, the location where P is executed. Example: chromatin silencing at centromere unfolds_around centromere : Repression of transcription of centromeric DNA by the formation of heterochromatin.</rdfs:comment>
+        <rdfs:label>obsolete occurs at</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000501"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">at</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>at</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1615,27 +1623,27 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000502">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000007"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOD_00000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000502</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">only with modification</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_modification</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Note this relation is not intended for use in GO annotation.  Discussion about using PR ID in column 17 instead; if we agree on that, this relation will be made obsolete</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_modification</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000502</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>only with modification</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_modification</oboInOwl:shorthand>
+        <rdfs:comment>Note this relation is not intended for use in GO annotation.  Discussion about using PR ID in column 17 instead; if we agree on that, this relation will be made obsolete</rdfs:comment>
+        <rdfs:label>obsolete requires_modification</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000502"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. Annotated gene product must be modified as described by extension to participate in the Molecular Function or Biological Process.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000502"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">only with modification</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>only with modification</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1644,30 +1652,30 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000506 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000506">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000506</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not in</oboInOwl:hasRelatedSynonym>
+        <obo:IAO_0000115>OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000007</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000506</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>not in</oboInOwl:hasRelatedSynonym>
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_occurs_in</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete not_occurs_in</rdfs:label>
+        <oboInOwl:shorthand>not_occurs_in</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
+        <rdfs:label>obsolete not_occurs_in</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000506"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) in which a Biological Process or Molecular Function does not occur. Opposite of occurs_in.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000506"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not in</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>not in</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1676,48 +1684,40 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000507 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000507">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0003674"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0003674</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical substance that increases the activity of the gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000507</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by_chemical</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by_substance</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activity_increased_by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_chemical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation should not be used to annotate one gene product regulating another&apos;s activity; a regulator MF or regulation BP should be used in such cases.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by</rdfs:label>
+        <go_annotation_extension_relations:usage>Identifies a chemical substance that increases the activity of the gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000507</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>activated by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>activated_by_chemical</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>activated_by_substance</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>activity_increased_by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>activated_by</oboInOwl:shorthand>
+        <rdfs:comment>This relation should not be used to annotate one gene product regulating another&apos;s activity; a regulator MF or regulation BP should be used in such cases.</rdfs:comment>
+        <rdfs:label>activated_by</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000507"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>activated by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000507"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by_chemical</owl:annotatedTarget>
+        <owl:annotatedTarget>activated_by_chemical</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000507"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activated_by_substance</owl:annotatedTarget>
+        <owl:annotatedTarget>activated_by_substance</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000507"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activity_increased_by</owl:annotatedTarget>
+        <owl:annotatedTarget>activity_increased_by</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1726,55 +1726,47 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000508 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000508">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0003674"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24431"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical substance that decreases the activity of the gene product.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0003674</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical substance that decreases the activity of the gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000508</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activity_decreased_by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited by</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by_chemical</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by_substance</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_chemical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation should not be used to annotate one gene product regulating another&apos;s activity; a regulator MF or regulation BP should be used in such cases.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by</rdfs:label>
+        <obo:IAO_0000115>Identifies a chemical substance that decreases the activity of the gene product.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Identifies a chemical substance that decreases the activity of the gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000508</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>activity_decreased_by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>inhibited by</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>inhibited_by_chemical</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>inhibited_by_substance</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>inhibited_by</oboInOwl:shorthand>
+        <rdfs:comment>This relation should not be used to annotate one gene product regulating another&apos;s activity; a regulator MF or regulation BP should be used in such cases.</rdfs:comment>
+        <rdfs:label>inhibited_by</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000508"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical substance that decreases the activity of the gene product.</owl:annotatedTarget>
+        <owl:annotatedTarget>Identifies a chemical substance that decreases the activity of the gene product.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000508"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">activity_decreased_by</owl:annotatedTarget>
+        <owl:annotatedTarget>activity_decreased_by</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000508"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited by</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>inhibited by</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000508"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by_chemical</owl:annotatedTarget>
+        <owl:annotatedTarget>inhibited_by_chemical</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000508"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inhibited_by_substance</owl:annotatedTarget>
+        <owl:annotatedTarget>inhibited_by_substance</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1783,30 +1775,30 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000509 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000509">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0005575 SO:0000110</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An entity (e.g. Cellular Component, sequence feature) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000509</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not at</oboInOwl:hasRelatedSynonym>
+        <obo:IAO_0000115>OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000007</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0005575 SO:0000110</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>An entity (e.g. Cellular Component, sequence feature) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000509</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>not at</oboInOwl:hasRelatedSynonym>
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not_occurs_at</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete not_occurs_at</rdfs:label>
+        <oboInOwl:shorthand>not_occurs_at</oboInOwl:shorthand>
+        <rdfs:comment>This relation was obsoleted because GO-CAM specifications does not allow negative relations.</rdfs:comment>
+        <rdfs:label>obsolete not_occurs_at</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000509"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</owl:annotatedTarget>
+        <owl:annotatedTarget>OBSOLETE. An entity (e.g. Cellular Component, cell type or anatomical entity) at which a Biological Process or Molecular Function does not occur. Opposite of occurs_at.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000509"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">not at</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>not at</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1815,33 +1807,33 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000751 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000751">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity indirectly affected (bound, transported, modified, consumed or destroyed) by the gene product&apos;s participation in MF or BP.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000505</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_indirect_target</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_localizes</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000751</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_indirect_target</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_localizes</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_indirect_input</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">If the entity is directly bound/acted upon by the gene product that is the subject of the annotation, then the relation: has_direct_input should be alternatively considered. [GOC:ecd]</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_indirect_input</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000007</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies an entity indirectly affected (bound, transported, modified, consumed or destroyed) by the gene product&apos;s participation in MF or BP.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0000505</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>has_indirect_target</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>indirectly_localizes</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>GOREL:0000751</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>has_indirect_target</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasNarrowSynonym>indirectly_localizes</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_indirect_input</oboInOwl:shorthand>
+        <rdfs:comment>If the entity is directly bound/acted upon by the gene product that is the subject of the annotation, then the relation: has_direct_input should be alternatively considered. [GOC:ecd]</rdfs:comment>
+        <rdfs:label>obsolete has_indirect_input</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000751"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_indirect_target</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>has_indirect_target</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000751"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_localizes</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>indirectly_localizes</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -1849,41 +1841,41 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000752 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000752">
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity directly affected (transported, modified, consumed or destroyed) by the gene product&apos;s participation in a molecular function or biological process. It is expected that the gene product and entity will physically interact, this can be determined either by a direct binding assay or inferred from the activity of the gene product, for example, a gene product with catalytic activity is inferred to bind its substrate.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000019</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000504</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_localizes</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_direct_target</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_substrate</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000752</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_direct_target</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_localizes</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_substrate</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_direct_input</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">If the entity is indirectly bound/acted upon by the gene product that is the subject of an annotation,  then the relation: has_indirect_input should be considered [GOC:ecd]</rdfs:comment>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation is part of the ShEx speficications.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete has_direct_input</rdfs:label>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:usage>Identifies an entity directly affected (transported, modified, consumed or destroyed) by the gene product&apos;s participation in a molecular function or biological process. It is expected that the gene product and entity will physically interact, this can be determined either by a direct binding assay or inferred from the activity of the gene product, for example, a gene product with catalytic activity is inferred to bind its substrate.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0000019</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>GOREL:0000504</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>directly_localizes</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>has_direct_target</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>has_substrate</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>GOREL:0000752</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>has_direct_target</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasNarrowSynonym>directly_localizes</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasNarrowSynonym>has_substrate</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_direct_input</oboInOwl:shorthand>
+        <rdfs:comment>If the entity is indirectly bound/acted upon by the gene product that is the subject of an annotation,  then the relation: has_indirect_input should be considered [GOC:ecd]</rdfs:comment>
+        <rdfs:comment>This relation is part of the ShEx speficications.</rdfs:comment>
+        <rdfs:label>obsolete has_direct_input</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000752"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_direct_target</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>has_direct_target</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000752"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_localizes</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>directly_localizes</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000752"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_substrate</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>has_substrate</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -1893,28 +1885,28 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000754">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SO:0000110</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000754</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires feature in target</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires_target_sequence_feature</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete requires_target_sequence_feature</rdfs:label>
+        <obo:IAO_0000115>OBSOLETE. Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>SO:0000110</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000754</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>requires feature in target</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>requires_target_sequence_feature</oboInOwl:shorthand>
+        <rdfs:label>obsolete requires_target_sequence_feature</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000754"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. Identifies a specific sequence feature required in the interacting gene product to enable the cellular component location or occurance of the function or process</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000754"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">requires feature in target</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>requires feature in target</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     
@@ -1923,23 +1915,23 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0000755 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0000755">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000001</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000755</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_absence_of</oboInOwl:shorthand>
+        <obo:IAO_0000115>OBSOLETE. Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000001</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0000755</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>in_absence_of</oboInOwl:shorthand>
         <rdfs:comment>DEPRECATION WARNING: The GO editors have agreed that this relation should be deprecated. There are two main reasons for this 1. The relation does not extend the meaning of the GO term, as annotation relations are meant to, but instead specifies conditions under which the annotation is true. This can not be expressed in OWL. Annotation extensions using this relation will never fold. 2. The relation includes a hidden negation. This is problematic for a number of reasons, the most important of which is that burying negations in otherwise positive relationships can cause serious problems for inference.</rdfs:comment>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was obsoleted because it does not follow GO-CAM specifications.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete in_absence_of</rdfs:label>
+        <rdfs:comment>This relation was obsoleted because it does not follow GO-CAM specifications.</rdfs:comment>
+        <rdfs:label>obsolete in_absence_of</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000755"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:rph</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. Identifies a chemical, gene product or complex in the absence of which an ontology term is observed to apply to the annotated gene product.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:rph</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -1947,10 +1939,10 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001000 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001000">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001000</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">axis_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">axis_of</rdfs:label>
+        <oboInOwl:hasDbXref>GOREL:0001000</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>axis_of</oboInOwl:shorthand>
+        <rdfs:label>axis_of</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -1962,13 +1954,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001000"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the axis_of relation</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the axis_of relation</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001002</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output_o_axis_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: anterior/posterior pattern specification has_output_o_axis_of lateral plate mesoderm. Note that the output of this process is an *axis*, not the LPM itself. This relation chain allows us to use an anatomical structure as the slot value</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output_o_axis_of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the has_output relation with the axis_of relation</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the has_output relation with the axis_of relation</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001002</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_output_o_axis_of</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: anterior/posterior pattern specification has_output_o_axis_of lateral plate mesoderm. Note that the output of this process is an *axis*, not the LPM itself. This relation chain allows us to use an anatomical structure as the slot value</rdfs:comment>
+        <rdfs:label>has_output_o_axis_of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001002"/>
@@ -1977,15 +1969,15 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001000"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001002"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the axis_of relation</owl:annotatedTarget>
+        <owl:annotatedTarget>This is the combination of the has_output relation with the axis_of relation</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:cjm</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>GOC:dph</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -1997,11 +1989,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_output relation</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_output relation</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001003</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_output</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_output</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the has_output relation</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the has_output relation</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001003</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_has_output</oboInOwl:shorthand>
+        <rdfs:label>regulates_o_has_output</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001003"/>
@@ -2010,15 +2002,15 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001003"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_output relation</owl:annotatedTarget>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the has_output relation</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:cjm</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>GOC:dph</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2026,25 +2018,18 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001004 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001004">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000066"/>
         </owl:propertyChainAxiom>
         <obo:IAO_0000112>&apos;negative regulation of chromosome segregation&apos; that  regulates_o_occurs_in some spermatocyte.</obo:IAO_0000112>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that holds between a regulatory process and the entity which the regulated biological process or molecular function occurs in.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain>GO:0065007</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to link a regulatory process or function to the structure that the regulated process or function occurs in.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001004</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>A relation that holds between a regulatory process and the entity which the regulated biological process or molecular function occurs in.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relation to link a regulatory process or function to the structure that the regulated process or function occurs in.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001004</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_occurs_in</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cellular_component"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_occurs_in</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates process that occurs in</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_occurs_in</oboInOwl:shorthand>
+        <rdfs:label>regulates process that occurs in</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001004"/>
@@ -2053,15 +2038,15 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000066"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001004"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that holds between a regulatory process and the entity which the regulated biological process or molecular function occurs in.</owl:annotatedTarget>
+        <owl:annotatedTarget>A relation that holds between a regulatory process and the entity which the regulated biological process or molecular function occurs in.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:cjm</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>GOC:dph</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2069,25 +2054,19 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001005 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001005">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0040012"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002565"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that holds between a process that regulates locomotion and the cell or organism whose locomotion is being regulated.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to relate a process that regulates locomotion to the cell or organism whose locomotion is being regulated.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001005</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>A relation that holds between a process that regulates locomotion and the cell or organism whose locomotion is being regulated.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relation to relate a process that regulates locomotion to the cell or organism whose locomotion is being regulated.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001005</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_results_in_movement_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_movement_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_movement_of relation.  Example of use: an annotation of gene X to &apos;regulation of cell migration with &apos;regulates_o_results_in_movement_of(CL:0000653) in column 16 would mean that gene X is involved in the regulation of glomerular visceral epithelial cell migration.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates process that results in movement of</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_results_in_movement_of</oboInOwl:shorthand>
+        <rdfs:comment>This is the combination of the regulates relation with the results_in_movement_of relation.  Example of use: an annotation of gene X to &apos;regulation of cell migration with &apos;regulates_o_results_in_movement_of(CL:0000653) in column 16 would mean that gene X is involved in the regulation of glomerular visceral epithelial cell migration.</rdfs:comment>
+        <rdfs:label>regulates process that results in movement of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001005"/>
@@ -2096,15 +2075,15 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002565"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001005"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that holds between a process that regulates locomotion and the cell or organism whose locomotion is being regulated.</owl:annotatedTarget>
+        <owl:annotatedTarget>A relation that holds between a process that regulates locomotion and the cell or organism whose locomotion is being regulated.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:cjm</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>GOC:dph</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2012_08_27</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2114,28 +2093,28 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001006">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The relationship that links an entity with a process in which the process has more than one participant that is of the same entity type.</obo:IAO_0000115>
-        <obo:IAO_0100001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0012003</obo:IAO_0100001>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008283</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to relate a process to a population of cells that it acts on.  The main usage of this relations is to relate GO: cell proliferation to the proliferating cells type. (Individual cells divide, populations of cells proliferate.)</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alters levels of</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001006</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0012003</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>OBSOLETE. The relationship that links an entity with a process in which the process has more than one participant that is of the same entity type.</obo:IAO_0000115>
+        <obo:IAO_0100001>RO:0012003</obo:IAO_0100001>
+        <go_annotation_extension_relations:local_domain>GO:0008283</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relation to relate a process to a population of cells that it acts on.  The main usage of this relations is to relate GO: cell proliferation to the proliferating cells type. (Individual cells divide, populations of cells proliferate.)</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>alters levels of</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>GOREL:0001006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>RO:0012003</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_on_population_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell proliferation with acts_on_population_of CL:0000057 means that gene X is involved in the proliferation of fibroblasts. Note that many annotation extensions use regulates_o_acts_on_population_of - should this be considered regulation of number of cells / cell homeostasis?</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete acts_on_population_of</rdfs:label>
+        <oboInOwl:shorthand>acts_on_population_of</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to cell proliferation with acts_on_population_of CL:0000057 means that gene X is involved in the proliferation of fibroblasts. Note that many annotation extensions use regulates_o_acts_on_population_of - should this be considered regulation of number of cells / cell homeostasis?</rdfs:comment>
+        <rdfs:label>obsolete acts_on_population_of</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001006"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. The relationship that links an entity with a process in which the process has more than one participant that is of the same entity type.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>OBSOLETE. The relationship that links an entity with a process in which the process has more than one participant that is of the same entity type.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2144,11 +2123,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001007">
         <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/RO_0002608"/>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pg</oboInOwl:created_by>
+        <oboInOwl:created_by>pg</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-11-21T19:16:04Z</oboInOwl:creation_date>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001007</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediated_by</oboInOwl:id>
+        <oboInOwl:hasDbXref>GOREL:0001007</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>mediated_by</oboInOwl:id>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete_mediated_by</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">obsolete mediated by</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -2164,13 +2143,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001006"/>
         </owl:propertyChainAxiom>
         <obo:IAO_0000112>&apos;positive regulation of cell proliferation&apos; and &apos;regulates process that acts on population of&apos; some &apos;stem cell&apos;</obo:IAO_0000112>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a regulatory process and a population of entities that a process it regulates acts on.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the acts_on_population_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001008</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>A relation that applies between a regulatory process and a population of entities that a process it regulates acts on.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the acts_on_population_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001008</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_acts_on_population_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_acts_on_population_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete regulates process that acts on population of</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_acts_on_population_of</oboInOwl:shorthand>
+        <rdfs:label>obsolete regulates process that acts on population of</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     <owl:Axiom>
@@ -2180,13 +2159,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001006"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001008"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a regulatory process and a population of entities that a process it regulates acts on.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>A relation that applies between a regulatory process and a population of entities that a process it regulates acts on.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2194,26 +2173,18 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001010 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001010">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002315"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_acquisition_of_features_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 PO:0009002 1 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to relate a process that regulates the differentiation of a cell type or anatomical structure to the specific cell type or anatomical structure in question.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001010</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_acquisition_of_features_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relation to relate a process that regulates the differentiation of a cell type or anatomical structure to the specific cell type or anatomical structure in question.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001010</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates differentiation of</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>regulates_o_results_in_acquisition_of_features_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_acquisition_of_features_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates acquisition of features of</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_results_in_acquisition_of_features_of</oboInOwl:shorthand>
+        <rdfs:label>regulates acquisition of features of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001010"/>
@@ -2222,13 +2193,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002315"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001010"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_acquisition_of_features_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_acquisition_of_features_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2242,9 +2213,9 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002218"/>
         </owl:propertyChainAxiom>
         <obo:IAO_0000115>A relationship between the regulation of a process and the agent that executes that process.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001011</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_agent</oboInOwl:hasExactSynonym>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_agent</oboInOwl:shorthand>
+        <oboInOwl:hasDbXref>GOREL:0001011</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>regulates_o_has_agent</oboInOwl:hasExactSynonym>
+        <oboInOwl:shorthand>regulates_o_has_agent</oboInOwl:shorthand>
         <rdfs:label>regulates_o_has_agent</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
@@ -2254,7 +2225,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002218"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001011"/>
@@ -2274,11 +2245,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002299"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_maturation_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_maturation_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001012</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_maturation_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates maturation of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_maturation_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the results_in_maturation_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001012</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_results_in_maturation_of</oboInOwl:shorthand>
+        <rdfs:label>regulates maturation of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001012"/>
@@ -2287,13 +2258,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002299"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001012"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_maturation_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_maturation_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2301,17 +2272,17 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001016 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001016">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_participant relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relationship to link a regulatory process or function to an entity that participates in the regulated process.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001016</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_participant</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_participant</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the has_participant relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relationship to link a regulatory process or function to an entity that participates in the regulated process.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001016</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_has_participant</oboInOwl:shorthand>
+        <rdfs:label>regulates_o_has_participant</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001016"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_participant relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the has_participant relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2323,24 +2294,24 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001019</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <obo:IAO_0000115>The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001019</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_division_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell division with results_in_division_of CL:0000057 (fibroblast) means that at the end of the process a single fibroblast has divided into two fibroblasts.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_division_of</rdfs:label>
+        <oboInOwl:shorthand>results_in_division_of</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to cell division with results_in_division_of CL:0000057 (fibroblast) means that at the end of the process a single fibroblast has divided into two fibroblasts.</rdfs:comment>
+        <rdfs:label>results_in_division_of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001019"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>The relationship linking a entity and its participation in a process that results in the division of the entity into two entities of the same type.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2353,12 +2324,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002348"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a process that regulates cell fate commitment and the cell type that the regulated process results in commitment to.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_commitment_to relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001022</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>A relation that applies between a process that regulates cell fate commitment and the cell type that the regulated process results in commitment to.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the results_in_commitment_to relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001022</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_results_in_commitment_to</oboInOwl:hasExactSynonym>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_commitment_to</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates commitment to</rdfs:label>
+        <oboInOwl:shorthand>regulates_o_results_in_commitment_to</oboInOwl:shorthand>
+        <rdfs:label>regulates commitment to</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001022"/>
@@ -2367,13 +2338,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002348"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001022"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a process that regulates cell fate commitment and the cell type that the regulated process results in commitment to.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>A relation that applies between a process that regulates cell fate commitment and the cell type that the regulated process results in commitment to.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2381,24 +2352,17 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001023 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001023">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0050793"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002296"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_development_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to relate &apos;regulation of developmental process&apos; or one of its subclasses to the structure that the regulated developmental process results in the development of.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001023</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_development_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relation to relate &apos;regulation of developmental process&apos; or one of its subclasses to the structure that the regulated developmental process results in the development of.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001023</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_results_in_development_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_development_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates development of</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_results_in_development_of</oboInOwl:shorthand>
+        <rdfs:label>regulates development of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001023"/>
@@ -2407,13 +2371,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002296"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001023"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_development_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_development_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2425,11 +2389,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001019"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_division_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_division_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001024</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_division_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates division of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_division_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the results_in_division_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001024</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_results_in_division_of</oboInOwl:shorthand>
+        <rdfs:label>regulates division of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001024"/>
@@ -2438,13 +2402,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GOREL_0001019"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001024"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_division_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_division_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2456,11 +2420,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002297"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_formation_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_formation_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001025</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_formation_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates formation of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_formation_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the results_in_formation_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001025</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_results_in_formation_of</oboInOwl:shorthand>
+        <rdfs:label>regulates formation of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001025"/>
@@ -2469,13 +2433,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002297"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_formation_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_formation_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2488,11 +2452,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002298"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001026</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_morphogenesis_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates morphogenesis of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001026</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_results_in_morphogenesis_of</oboInOwl:shorthand>
+        <rdfs:label>regulates morphogenesis of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001026"/>
@@ -2501,13 +2465,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002298"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001026"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the results_in_morphogenesis_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2515,24 +2479,17 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0001027 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0001027">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0050789"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002356"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a process that regulates the specification of some cell type or structure and the specified cell type or structure.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to link a process that regulates the specification of some cell type of anatomical structure, and the structure or cell type specified.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001027</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>A relation that applies between a process that regulates the specification of some cell type or structure and the specified cell type or structure.</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>Use this relation to link a process that regulates the specification of some cell type of anatomical structure, and the structure or cell type specified.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001027</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>regulates_o_results_in_specification_of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_results_in_specification_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates specification of</rdfs:label>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_o_results_in_specification_of</oboInOwl:shorthand>
+        <rdfs:label>regulates specification of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001027"/>
@@ -2541,13 +2498,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002356"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001027"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relation that applies between a process that regulates the specification of some cell type or structure and the specified cell type or structure.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>A relation that applies between a process that regulates the specification of some cell type or structure and the specified cell type or structure.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2560,14 +2517,14 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002204"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the gene_product_of relation.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the results_in_specification_of relation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001029</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output_o_product_of</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output_o_product_of</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the has_output relation with the gene_product_of relation.</obo:IAO_0000115>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>PR:000000001 SO:0000673</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>This is the combination of the has_output relation with the results_in_specification_of relation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001029</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>has_output_o_product_of</oboInOwl:shorthand>
+        <rdfs:label>has_output_o_product_of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001029"/>
@@ -2576,13 +2533,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002234"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002204"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001029"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the has_output relation with the gene_product_of relation.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>This is the combination of the has_output relation with the gene_product_of relation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -2594,11 +2551,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002233"/>
         </owl:propertyChainAxiom>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_input relation</obo:IAO_0000115>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_input relation</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001030</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_input</oboInOwl:shorthand>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_o_has_input</rdfs:label>
+        <obo:IAO_0000115>This is the combination of the regulates relation with the has_input relation</obo:IAO_0000115>
+        <go_annotation_extension_relations:usage>This is the combination of the regulates relation with the has_input relation</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>GOREL:0001030</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>regulates_o_has_input</oboInOwl:shorthand>
+        <rdfs:label>regulates_o_has_input</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001030"/>
@@ -2607,12 +2564,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002233"/>
         </owl:annotatedTarget>
-        <obo:IAO_isReversiblePropertyChain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</obo:IAO_isReversiblePropertyChain>
+        <obo:IAO_isReversiblePropertyChain>true</obo:IAO_isReversiblePropertyChain>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GOREL_0001030"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is the combination of the regulates relation with the has_input relation</owl:annotatedTarget>
+        <owl:annotatedTarget>This is the combination of the regulates relation with the has_input relation</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:dph</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -2622,10 +2579,10 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0002008">
         <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/RO_0002505"/>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pg</oboInOwl:created_by>
+        <oboInOwl:created_by>pg</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-11-21T16:32:15Z</oboInOwl:creation_date>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0002008</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasDbXref>GOREL:0002008</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete_has_intermediate</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">obsolete has_intermediate</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -2636,12 +2593,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/GOREL_0002010 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0002010">
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pg</oboInOwl:created_by>
+        <oboInOwl:created_by>pg</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-11-21T18:00:03Z</oboInOwl:creation_date>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0002010</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasDbXref>GOREL:0002010</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete_results_in_transport_to_from_or_mediated_by</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation was only used for one class, &apos;endosomal transport&apos; (GO:0016197), which groups together disparate roles the participants can play - it was defined as &apos;The directed movement of substances into, out of *or mediated by* an endosome...&apos; The term has been redefined and the logical definition changed accordingly.</rdfs:comment>
+        <rdfs:comment>This relation was only used for one class, &apos;endosomal transport&apos; (GO:0016197), which groups together disparate roles the participants can play - it was defined as &apos;The directed movement of substances into, out of *or mediated by* an endosome...&apos; The term has been redefined and the logical definition changed accordingly.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete results_in_transport_to_from_or_mediated_by</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
@@ -2652,12 +2609,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0098702">
         <obo:IAO_0000115>OBSOLETE. A relation that holds between the regulation of a molecular function and the agent that executes that function.</obo:IAO_0000115>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0098772 GO:0065009</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0032991 SO:0000374 PR:000000001</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:local_domain>GO:0098772 GO:0065009</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0032991 SO:0000374 PR:000000001</go_annotation_extension_relations:local_range>
         <go_annotation_extension_relations:usage>Use this relation to link either a molecular function, or a biological process that regulates a molecular function, to the gene product or complex that executes the regulated function.</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0098702</oboInOwl:hasDbXref>
         <oboInOwl:shorthand>regulates_activity_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This relation has been obsoleted as it is not part of the GO ShEx specifications.</rdfs:comment>
+        <rdfs:comment>This relation has been obsoleted as it is not part of the GO ShEx specifications.</rdfs:comment>
         <rdfs:label>obsolete regulates activity of</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
@@ -2689,7 +2646,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0098789">
         <obo:IAO_0000115>OBSOLETE. A relationship that holds between a process and a gene whose expression is regulated by that process.</obo:IAO_0000115>
         <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:local_range>PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
         <go_annotation_extension_relations:usage>Relates a regulatory process or function to the gene whose expression it regulates.  Expression encompasses transcription, regulation and processing involved in maturation.</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0098789</oboInOwl:hasDbXref>
         <oboInOwl:shorthand>regulates_expression_of</oboInOwl:shorthand>
@@ -2711,7 +2668,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/GOREL_0098790">
         <obo:IAO_0000115>OBSOLETE. A relationship that holds between a process and a protein coding gene whose translation is regulated by that process.</obo:IAO_0000115>
         <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:local_range>PR:000000001 SO:0000673 SO:0000704</go_annotation_extension_relations:local_range>
         <go_annotation_extension_relations:usage>Relates a regulatory process or function to the gene whose translation it regulates.</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0098790</oboInOwl:hasDbXref>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
@@ -2807,16 +2764,16 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115 xml:lang="en">a relation between a process and a continuant, in which the continuant is somehow involved in the process</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time.</obo:IAO_0000116>
         <obo:IAO_0000118 xml:lang="en">has_participant</obo:IAO_0000118>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CARO:0000000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity affected by the gene product&apos;s participation in a molecular function or biological process</go_annotation_extension_relations:usage>
-        <dc:source>http://www.obofoundry.org/ro/#OBO_REL:has_participant</dc:source>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0000057</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CARO:0000000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies an entity affected by the gene product&apos;s participation in a molecular function or biological process</go_annotation_extension_relations:usage>
+        <terms:source>http://www.obofoundry.org/ro/#OBO_REL:has_participant</terms:source>
+        <oboInOwl:hasDbXref>RO:0000057</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_participant</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Do not use this relation directly</rdfs:comment>
+        <oboInOwl:shorthand>has_participant</oboInOwl:shorthand>
+        <rdfs:comment>Do not use this relation directly</rdfs:comment>
         <rdfs:label xml:lang="en">has participant</rdfs:label>
     </owl:ObjectProperty>
     
@@ -3031,7 +2988,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002017"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002334"/>
         <obo:IAO_0000115>A &apos;has regulatory component activity&apos; B if A and B are GO molecular functions (GO_0003674), A has_component B and A is regulated by B.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-24T09:30:46Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002013</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_regulatory_component_activity</oboInOwl:shorthand>
@@ -3046,7 +3003,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002013"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002335"/>
         <obo:IAO_0000115>A relationship that holds between a GO molecular function and a component of that molecular function that negatively regulates the activity of the whole.  More formally, A &apos;has regulatory component activity&apos; B iff :A and B are GO molecular functions (GO_0003674), A has_component B and A is negatively regulated by B.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-24T09:31:01Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002014</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_negative_regulatory_component_activity</oboInOwl:shorthand>
@@ -3062,7 +3019,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002013"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002336"/>
         <obo:IAO_0000115>A relationship that holds between a GO molecular function and a component of that molecular function that positively regulates the activity of the whole.  More formally, A &apos;has regulatory component activity&apos; B iff :A and B are GO molecular functions (GO_0003674), A has_component B and A is positively regulated by B.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-24T09:31:17Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002015</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_positive_regulatory_component_activity</oboInOwl:shorthand>
@@ -3076,7 +3033,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002017">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002018"/>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-24T09:44:33Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002017</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_component_activity</oboInOwl:shorthand>
@@ -3093,7 +3050,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
         <obo:IAO_0000115>w &apos;has process component&apos; p if p and w are processes,  w &apos;has part&apos; p and w is such that it can be directly disassembled into into n parts p, p2, p3, ..., pn, where these parts are of similar type.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-24T09:49:21Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002018</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_component_process</oboInOwl:shorthand>
@@ -3107,11 +3064,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002020">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002313"/>
         <obo:IAO_0000115>Holds between p and c when p is a transport process or transporter activity and the outcome of this p is to move c from one location to another.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-20T17:11:08Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002020</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transports</oboInOwl:shorthand>
-        <rdfs:label>transports</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transports</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -3121,7 +3078,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002022">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002334"/>
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002578"/>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-17T13:52:24Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002022</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_regulated_by</oboInOwl:shorthand>
@@ -3132,7 +3089,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002022"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
         <owl:annotatedTarget>Process(P2) is directly regulated by process(P1) iff: P1 regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  regulates the kinase activity (P2) of protein B then P1 directly regulates P2.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>GOC:dos</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
     </owl:Axiom>
     
 
@@ -3143,7 +3100,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002022"/>
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002630"/>
         <obo:IAO_0000115>Process(P2) is directly negatively regulated by process(P1) iff: P1 negatively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  negatively regulates the kinase activity (P2) of protein B then P2 directly negatively regulated by P1.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-17T13:52:38Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002023</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_negatively_regulated_by</oboInOwl:shorthand>
@@ -3153,7 +3110,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002023"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>Process(P2) is directly negatively regulated by process(P1) iff: P1 negatively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding  negatively regulates the kinase activity (P2) of protein B then P2 directly negatively regulated by P1.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>GOC:dos</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
     </owl:Axiom>
     
 
@@ -3164,7 +3121,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002022"/>
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002629"/>
         <obo:IAO_0000115>Process(P2) is directly postively regulated by process(P1) iff: P1 positively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding positively regulates the kinase activity (P2) of protein B then P2 is directly postively regulated by P1.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-17T13:52:47Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002024</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_positively_regulated_by</oboInOwl:shorthand>
@@ -3174,7 +3131,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002024"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>Process(P2) is directly postively regulated by process(P1) iff: P1 positively regulates P2 via direct physical interaction between an agent executing P1 (or some part of P1) and an agent executing P2 (or some part of P2).  For example, if protein A has protein binding activity(P1) that targets protein B and this binding positively regulates the kinase activity (P2) of protein B then P2 is directly postively regulated by P1.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>GOC:dos</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
     </owl:Axiom>
     
 
@@ -3185,7 +3142,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002017"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <obo:IAO_0000115>A &apos;has effector activity&apos; B if A and B are GO molecular functions (GO_0003674),  A &apos;has component activity&apos; B and B is the effector (output function) of B.  Each compound function has only one effector activity.</obo:IAO_0000115>
-        <oboInOwl:created_by>dos</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-22T14:14:36Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002025</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_effector_activity</oboInOwl:shorthand>
@@ -3196,7 +3153,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>A &apos;has effector activity&apos; B if A and B are GO molecular functions (GO_0003674),  A &apos;has component activity&apos; B and B is the effector (output function) of B.  Each compound function has only one effector activity.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>GOC:dos</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
     </owl:Axiom>
     
 
@@ -3327,13 +3284,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000117>David Osumi-Sutherland</obo:IAO_0000117>
         <obo:IAO_0000118>d</obo:IAO_0000118>
         <obo:IAO_0000118>during</obo:IAO_0000118>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150 WBls:0000075 ZFS:0100000 UBERON:0000105</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a process or life stage during which a molecular function or biological process occurs. This is weaker than parthood. So, for example, various processes occur during gastrulation without being part of it.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</oboInOwl:hasBroadSynonym>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0008150 WBls:0000075 ZFS:0100000 UBERON:0000105</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a process or life stage during which a molecular function or biological process occurs. This is weaker than parthood. So, for example, various processes occur during gastrulation without being part of it.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasBroadSynonym>during</oboInOwl:hasBroadSynonym>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002092</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">occurs_during</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasExactSynonym>occurs_during</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -3342,22 +3299,23 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">happens_during</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;p happens_during q if and only if the temporal extent of p is part_of the temporal extent of q.&quot; Note that part_of between processes implies happens_during (we must use OWL to express this), but happens_during does not imply part_of. Note also that this relation holds between two processes. To link a physical entity to a process by duration, use exists_during. [BFO:cjm] Note that in order to express that part_of between processes implies during, we must use OWL.</rdfs:comment>
+        <oboInOwl:shorthand>happens_during</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;p happens_during q if and only if the temporal extent of p is part_of the temporal extent of q.&quot; Note that part_of between processes implies happens_during (we must use OWL to express this), but happens_during does not imply part_of. Note also that this relation holds between two processes. To link a physical entity to a process by duration, use exists_during. [BFO:cjm] Note that in order to express that part_of between processes implies during, we must use OWL.</rdfs:comment>
         <rdfs:comment xml:lang="en">X happens_during Y iff: (start(Y) before_or_simultaneous_with start(X)) AND (end(X) before_or_simultaneous_with end(Y))</rdfs:comment>
         <rdfs:label xml:lang="en">happens during</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Happens_during</rdfs:seeAlso>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002092"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">during</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PomBase:curators</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>during</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PomBase:curators</oboInOwl:hasDbXref>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0008000"/>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002092"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">occurs_during</owl:annotatedTarget>
+        <owl:annotatedTarget>occurs_during</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:mah</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -3490,13 +3448,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>definition &quot;x has gene product of y if and only if y is a gene (SO:0000704) that participates in some gene expression process (GO:0010467) where the output of that process is either y or something that is ribosomally translated from x&quot;</obo:IAO_0000115>
         <obo:IAO_0000116>We would like to be able to express the rule: if t transcribed from g, and t is a noncoding RNA and has an evolved function, then t has gene product g.</obo:IAO_0000116>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000002</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">x has gene product of y if and only if y is a gene (SO:0000704) that participates in some gene expression process (GO:0010467) where the output of that process is either y or something that is ribosomally translated from x.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001028</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002204</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene_product_of</oboInOwl:shorthand>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>BFO:0000002</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>x has gene product of y if and only if y is a gene (SO:0000704) that participates in some gene expression process (GO:0010467) where the output of that process is either y or something that is ribosomally translated from x.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001028</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002204</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>gene_product_of</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">gene product of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -3681,13 +3639,13 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000118>has agent</obo:IAO_0000118>
         <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/RO_0002500"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to link a process to an entity that carries out that process. The entity may be a cellular component, a cell type or an anatomical structure. Examples include recording a vesicle type that mediates a transport process, a cell type that is the agent of a secretion process or a cell adhesion process.  Do not use this to extend a molecular function: The agents of molecular functions are gene products and complexes.  Use of this relation with a molecular function therefore consistutes reverse annotation.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001007</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002218</oboInOwl:hasDbXref>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_agent</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cytokine production with has_agent of CL:0000057 (fibroblast) means that the fibroblast is producing the cytokine.</rdfs:comment>
+        <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relation to link a process to an entity that carries out that process. The entity may be a cellular component, a cell type or an anatomical structure. Examples include recording a vesicle type that mediates a transport process, a cell type that is the agent of a secretion process or a cell adhesion process.  Do not use this to extend a molecular function: The agents of molecular functions are gene products and complexes.  Use of this relation with a molecular function therefore consistutes reverse annotation.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001007</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002218</oboInOwl:hasDbXref>
+        <oboInOwl:shorthand>has_agent</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to cytokine production with has_agent of CL:0000057 (fibroblast) means that the fibroblast is producing the cytokine.</rdfs:comment>
         <rdfs:label>obsolete has active participant</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
@@ -3712,9 +3670,9 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:RO_0001900 rdf:resource="http://purl.obolibrary.org/obo/RO_0001901"/>
         <go_annotation_extension_relations:local_domain>GO:0005575</go_annotation_extension_relations:local_domain>
         <go_annotation_extension_relations:local_range>GO:0005575 CL:0000000</go_annotation_extension_relations:local_range>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002220</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adjacent to</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasDbXref>RO:0002220</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>adjacent to</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -3722,7 +3680,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cellular_component"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adjacent_to</oboInOwl:shorthand>
+        <oboInOwl:shorthand>adjacent_to</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">adjacent to</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
@@ -3734,7 +3692,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002220"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adjacent to</owl:annotatedTarget>
+        <owl:annotatedTarget>adjacent to</owl:annotatedTarget>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/RO_0002220"/>
     </owl:Axiom>
     
@@ -3823,19 +3781,19 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>p has input c iff: p is a process, c is a material entity, c is a participant in p, c is present at the start of p, and the state of c is modified during p.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000118>consumes</obo:IAO_0000118>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697 SO:0000839 SO:0001683 NCBITaxon:1</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to relate a biological process or molecular function to an entity that participates in the process/function, is present at the start of the process/function and whose state is affected by that process/function.  Change of state includes being transported, modified, consumed or destroyed.  An input may be any continuant: chemical; gene product; cell component;  cells type; organism.  For inputs to MFs that are bound by the gene product that executes the MF, the more specific relation &apos;has_direct_input&apos; may be used.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000016</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000503</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000753</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_target</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localizes</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000753</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002233</oboInOwl:hasDbXref>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_target</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localizes</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697 SO:0000839 SO:0001683 NCBITaxon:1</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relation to relate a biological process or molecular function to an entity that participates in the process/function, is present at the start of the process/function and whose state is affected by that process/function.  Change of state includes being transported, modified, consumed or destroyed.  An input may be any continuant: chemical; gene product; cell component;  cells type; organism.  For inputs to MFs that are bound by the gene product that executes the MF, the more specific relation &apos;has_direct_input&apos; may be used.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0000016</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>GOREL:0000503</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>GOREL:0000753</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>has_target</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasAlternativeId>localizes</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>GOREL:0000753</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>RO:0002233</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>has_target</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasNarrowSynonym>localizes</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -3844,21 +3802,22 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_input</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;p has_input c if and only c participates_in p at the start of p and c is in some way bound, transported, modified, consumed or destroyed by p.&quot; If it is known whether the entity is directly or indirectly bound/acted upon by the gene product that is the subject of the annotation, then the relations has_direct_input or has_indirect_input should be alternatively considered.</rdfs:comment>
+        <oboInOwl:shorthand>has_input</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;p has_input c if and only c participates_in p at the start of p and c is in some way bound, transported, modified, consumed or destroyed by p.&quot; If it is known whether the entity is directly or indirectly bound/acted upon by the gene product that is the subject of the annotation, then the relations has_direct_input or has_indirect_input should be alternatively considered.</rdfs:comment>
         <rdfs:label xml:lang="en">has input</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Has_input</rdfs:seeAlso>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_target</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>has_target</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">localizes</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:ecd</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>localizes</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:ecd</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -3873,11 +3832,11 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>p has output c iff c is a participant in p, c is present at the end of p, and c is not present in the same state at the beginning of p.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000118>produces</obo:IAO_0000118>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies an entity that is changed or created after participation in a molecular function or biological process</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002234</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CHEBI:24431 GO:0032991 MI:0315 PR:000000001 SO:0000673 SO:0000704 CHEBI:33697</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies an entity that is changed or created after participation in a molecular function or biological process</go_annotation_extension_relations:usage>
+        <oboInOwl:hasDbXref>RO:0002234</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -3886,9 +3845,10 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_output</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Previous definition &quot;p has_output c if c participates_in p at  the end of p and c is in some way changed by p or created by p.&quot; []</rdfs:comment>
+        <oboInOwl:shorthand>has_output</oboInOwl:shorthand>
+        <rdfs:comment>Previous definition &quot;p has_output c if c participates_in p at  the end of p and c is in some way changed by p or created by p.&quot; []</rdfs:comment>
         <rdfs:label xml:lang="en">has output</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Has_output</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -3927,7 +3887,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_upstream_of_or_within</oboInOwl:shorthand>
         <rdfs:label>acts upstream of or within</rdfs:label>
-        <rdfs:seeAlso rdf:resource="http://wiki.geneontology.org/index.php/Acts_upstream_of_or_within"/>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Acts_upstream_of_or_within</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -3937,7 +3897,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002295">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002324"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CARO_0000000"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115>p results in the developmental progression of s iff p is a developmental process and s is an anatomical entity and p causes s to undergo a change in state at some point along its natural developmental cycle (this cycle starts with its formation, through the mature structure, and ends with its loss).</obo:IAO_0000115>
         <obo:IAO_0000116>This property and its subproperties are being used primarily for the definition of GO developmental processes. The property hierarchy mirrors the core GO hierarchy. In future we may be able to make do with a more minimal set of properties, but due to the way GO is currently structured we require highly specific relations to avoid incorrect entailments. To avoid this, the corresponding genus terms in GO should be declared mutually disjoint.</obo:IAO_0000116>
@@ -3961,12 +3921,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>p &apos;results in development of&apos; c if and only if p is a developmental process and p results in the state of c changing from its initial state as a primordium or anlage through its mature state and to its final state.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.geneontology.org/GO.doc.development.shtml</obo:IAO_0000119>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking an entity and its participation in a process that changes it through time from the formation of the entity to the resultant mature state.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001009</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002296</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking an entity and its participation in a process that changes it through time from the formation of the entity to the resultant mature state.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001009</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002296</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -3975,7 +3935,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_development_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell development with results_in_development_of CL:0000540 (neuron) means that gene x is involved in a process where a cell that has an identity of a neuron has gone through a progression from its formation to the resulting mature neuron.</rdfs:comment>
+        <rdfs:comment>Example of use: an annotation of gene X to cell development with results_in_development_of CL:0000540 (neuron) means that gene x is involved in a process where a cell that has an identity of a neuron has gone through a progression from its formation to the resulting mature neuron.</rdfs:comment>
         <rdfs:label xml:lang="en">results in development of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -3991,30 +3951,30 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000112>an annotation of gene X to anatomical structure formation with results_in_formation_of UBERON:0000007 (pituitary gland) means that at the beginning of the process a pituitary gland does not exist and at the end of the process a pituitary gland exists.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">every &quot;endocardial cushion formation&quot; (GO:0003272) results_in_formation_of some &quot;endocardial cushion&quot; (UBERON:0002062)</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</obo:IAO_0000115>
+        <obo:IAO_0000115>The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119>GOC:mtg_berkeley_2013</obo:IAO_0000119>
         <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001020</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002297</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001020</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002297</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_formation_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to anatomical structure formation with results_in_formation_of UBERON:0000007 (pituitary gland) means that at the beginning of the process a pituitary gland does not exist and at the end of the process a pituitary gland exists.</rdfs:comment>
+        <oboInOwl:shorthand>results_in_formation_of</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to anatomical structure formation with results_in_formation_of UBERON:0000007 (pituitary gland) means that at the beginning of the process a pituitary gland does not exist and at the end of the process a pituitary gland exists.</rdfs:comment>
         <rdfs:label xml:lang="en">results in formation of</rdfs:label>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002297"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
+        <owl:annotatedTarget>The relationship linking a entity and its participation in a process whereby at the beginning of the process the entity does not exist and at the end of the process the entity exists.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>GOC:mtg_berkeley_2013</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -4031,12 +3991,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>The relationship that links an entity with the process that results in the formation and shaping of that entity over time from an immature to a mature state.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119>GOC:mtg_berkeley_2013</obo:IAO_0000119>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship that links an entity with the process that results in the formation and shaping of that entity over time from an immature to a mature state.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001015</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002298</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship that links an entity with the process that results in the formation and shaping of that entity over time from an immature to a mature state.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001015</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002298</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -4045,7 +4005,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_morphogenesis_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell morphogenesis with results_in_morphogenesis_of CL:0000540 (neuron) means that at the end of the process an input neuron has attained its shape.</rdfs:comment>
+        <rdfs:comment>Example of use: an annotation of gene X to cell morphogenesis with results_in_morphogenesis_of CL:0000540 (neuron) means that at the end of the process an input neuron has attained its shape.</rdfs:comment>
         <rdfs:label xml:lang="en">results in morphogenesis of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4063,12 +4023,12 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <obo:IAO_0000115>The relationship that links an entity with a process that results in the progression of the entity over time that is independent of changes in it&apos;s shape and results in an end point state of that entity.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119>GOC:mtg_berkeley_2013</obo:IAO_0000119>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 GO:0005575 PO:0009012 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship that links an entity with a process that results in the progression of the entity over time that is independent of changes in it&apos;s shape and results in an end point state of that entity.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001013</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002299</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 GO:0005575 PO:0009012 PO:0025131 UBERON:0001062 WBbt:0004017 WBbt:0005766</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship that links an entity with a process that results in the progression of the entity over time that is independent of changes in it&apos;s shape and results in an end point state of that entity.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001013</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002299</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -4076,9 +4036,9 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cellular_component"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_maturation_of</oboInOwl:shorthand>
+        <oboInOwl:shorthand>results_in_maturation_of</oboInOwl:shorthand>
         <rdfs:comment rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell maturation with results_in_maturation_of CL:0000057 (fibroblast) means that the fibroblast is mature at the end of the process.</rdfs:comment>
+        <rdfs:comment>Example of use: an annotation of gene X to cell maturation with results_in_maturation_of CL:0000057 (fibroblast) means that the fibroblast is mature at the end of the process.</rdfs:comment>
         <rdfs:label xml:lang="en">results in maturation of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4098,6 +4058,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">causally_upstream_of,_positive_effect</oboInOwl:shorthand>
         <rdfs:comment>holds between x and y if and only if x is causally upstream of y and the progression of x increases the frequency, rate or extent of y</rdfs:comment>
         <rdfs:label>causally upstream of, positive effect</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://wiki.geneontology.org/Causally_upstream_of,_positive_effect"/>
     </owl:ObjectProperty>
     
 
@@ -4115,6 +4076,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">causally_upstream_of,_negative_effect</oboInOwl:shorthand>
         <rdfs:label>causally upstream of, negative effect</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://wiki.geneontology.org/Causally_upstream_of,_negative_effect"/>
     </owl:ObjectProperty>
     
 
@@ -4131,9 +4093,9 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
         <go_annotation_extension_relations:local_range>CHEBI:24431 PR:000000001 GO:0005575 SO:0000673 CHEBI:33697</go_annotation_extension_relations:local_range>
         <go_annotation_extension_relations:usage>Use to relate a process or molecular function to a substance that is transported, localized or whose localization is maintained by that process or function.  The substance may be a chemical, gene product or cellular component.  For the movement via locomotion of cells and anatomical structure please use results_in_movement_of.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002313</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates location of</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasDbXref>RO:0002313</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>regulates location of</oboInOwl:hasRelatedSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -4141,7 +4103,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_chemical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transports_or_maintains_localization_of</oboInOwl:shorthand>
+        <oboInOwl:shorthand>transports_or_maintains_localization_of</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">transports or maintains localization of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4188,18 +4150,18 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/GOREL_0000000"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002295"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0040036"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CARO_0000003"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
         <obo:IAO_0000112>an annotation of gene X to cell differentiation with results_in_maturation_of CL:0000057 (fibroblast) means that at the end of the process the input cell that did not have features of a fibroblast, now has the features of a fibroblast.</obo:IAO_0000112>
         <obo:IAO_0000115>The relationship that links a specified entity with the process that results in an unspecified entity acquiring the features and characteristics of the specified entity</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119>GOC:mtg_berkeley_2013</obo:IAO_0000119>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0030154</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 PO:0009002 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to link a cell differentiation process to the cell type that the process results in the differentiation of.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001014</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002315</oboInOwl:hasDbXref>
+        <go_annotation_extension_relations:local_domain>GO:0030154</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 PO:0009002 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relation to link a cell differentiation process to the cell type that the process results in the differentiation of.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001014</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002315</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>results in differentiation of</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -4207,7 +4169,7 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_acquisition_of_features_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell differentiation with results_in_acquisition_of_features_of CL:0000057 (fibroblast) means that at the end of the process the input cell that did not have features of a fibroblast, now has the features of a fibroblast.</rdfs:comment>
+        <rdfs:comment>Example of use: an annotation of gene X to cell differentiation with results_in_acquisition_of_features_of CL:0000057 (fibroblast) means that at the end of the process the input cell that did not have features of a fibroblast, now has the features of a fibroblast.</rdfs:comment>
         <rdfs:label xml:lang="en">results in acquisition of features of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4300,6 +4262,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">contributes_to</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">contributes to</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Contributes_to</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4331,6 +4294,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">enables</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">enables</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Enables</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4411,7 +4375,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002331</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">involved_in</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">involved in</rdfs:label>
-        <rdfs:seeAlso rdf:resource="http://wiki.geneontology.org/index.php/Involved_in"/>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Involved_in</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4428,10 +4392,10 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000119 rdf:resource="http://purl.obolibrary.org/obo/ro/docs/causal-relations"/>
         <obo:IAO_0000589>regulates levels of (process to entity)</obo:IAO_0000589>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000036</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002332</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates_level_of</oboInOwl:shorthand>
+        <oboInOwl:hasAlternativeId>GOREL:0000036</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002332</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:shorthand>regulates_level_of</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">regulates levels of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4448,6 +4412,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">enabled_by</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">enabled by</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Enabled_by</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4574,11 +4539,11 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002020"/>
         <obo:IAO_0000115>Holds between p and c when p is a transportation or localization process and the outcome of this process is to move c to a destination that is part of some s, where the start location of c is part of the region that surrounds s.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000034</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002340</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasAlternativeId>GOREL:0000034</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002340</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imports</oboInOwl:shorthand>
+        <oboInOwl:shorthand>imports</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">imports</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4604,11 +4569,11 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002020"/>
         <obo:IAO_0000115>Holds between p and c when p is a transportation or localization process and the outcome of this process is to move c to a destination that is part of some s, where the end location of c is part of the region that surrounds s.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0000035</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002345</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasAlternativeId>GOREL:0000035</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002345</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exports</oboInOwl:shorthand>
+        <oboInOwl:shorthand>exports</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">exports</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4623,20 +4588,20 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <obo:IAO_0000112>an annotation of gene X to cell commitment with results_in_commitment_to CL:0000540 (neuron) means that at the end of the process an unspecified cell has been specified and determined to develop into a neuron.</obo:IAO_0000112>
         <obo:IAO_0000115>p &apos;results in commitment to&apos; c if and only if p is a developmental process and c is a cell and p results in the state of c changing such that is can only develop into a single cell type.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a cell and its participation in a process that results in the transition of a cell such that is can only develop into a single cell type.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001017</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002348</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking a cell and its participation in a process that results in the transition of a cell such that is can only develop into a single cell type.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001017</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002348</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_commitment_to</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell commitment with results_in_commitment_to CL:0000540 (neuron) means that at the end of the process an unspecified cell has been specified and determined to develop into a neuron.</rdfs:comment>
+        <oboInOwl:shorthand>results_in_commitment_to</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to cell commitment with results_in_commitment_to CL:0000540 (neuron) means that at the end of the process an unspecified cell has been specified and determined to develop into a neuron.</rdfs:comment>
         <rdfs:label xml:lang="en">results in commitment to</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4650,20 +4615,20 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
         <obo:IAO_0000115>p &apos;results in determination of&apos; c if and only if p is a developmental process and c is a cell and p results in the state of c changing to be determined. Once a cell becomes determined, it becomes committed to differentiate down a particular pathway regardless of its environment.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a cell and its participation in a process that results in the transition of a cell such that it can only develop into a single cell type independent of its environment.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001018</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002349</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking a cell and its participation in a process that results in the transition of a cell such that it can only develop into a single cell type independent of its environment.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001018</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002349</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_determination_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell determination with results_in_determination_of CL:0000540 (neuron) means that at the end of the process an unspecified cell will develop into a neuron with no additional input.</rdfs:comment>
+        <oboInOwl:shorthand>results_in_determination_of</oboInOwl:shorthand>
+        <rdfs:comment>Example of use: an annotation of gene X to cell determination with results_in_determination_of CL:0000540 (neuron) means that at the end of the process an unspecified cell will develop into a neuron with no additional input.</rdfs:comment>
         <rdfs:label xml:lang="en">results in determination of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4722,21 +4687,21 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
         <obo:IAO_0000115>The relationship linking a cell and its participation in a process that results in the fate of the cell being specified. Once specification has taken place, a cell will be committed to differentiate down a specific pathway if left in its normal environment. </obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The relationship linking a cell and its participation in a process that results in the transition of a cell such that is can only develop into a single cell type when left in its environment.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001021</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002356</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>The relationship linking a cell and its participation in a process that results in the transition of a cell such that is can only develop into a single cell type when left in its environment.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001021</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002356</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_specification_of</oboInOwl:shorthand>
+        <oboInOwl:shorthand>results_in_specification_of</oboInOwl:shorthand>
         <rdfs:comment rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example of use: an annotation of gene X to cell determination with results_in_determination_of CL:0000540 (neuron) means that at the end of the process an unspecified cell will develop into a neuron if left in its environment. If the cell is moved, it may develop into a cell type other than a neuron.</rdfs:comment>
+        <rdfs:comment>Example of use: an annotation of gene X to cell determination with results_in_determination_of CL:0000540 (neuron) means that at the end of the process an unspecified cell will develop into a neuron if left in its environment. If the cell is moved, it may develop into a cell type other than a neuron.</rdfs:comment>
         <rdfs:label xml:lang="en">results in specification of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -4802,6 +4767,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002407</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_positively_regulates</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">indirectly positively regulates</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Indirectly_positively_regulates</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4831,6 +4797,7 @@ However, this is not possible in OWL. We instead make this relation a sub-relati
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002409</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_negatively_regulates</oboInOwl:shorthand>
         <rdfs:label xml:lang="en">indirectly negatively regulates</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Indirectly_negatively_regulates</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -4878,11 +4845,11 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <obo:IAO_0000115>p is causally upstream of q iff p is causally related to q, the end of p precedes the end of q, and p is not an occurrent part of q.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000015</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150 GO:0003674</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Process A is causally_upstream of process B if process A occurs first, and process A causes process B to happen. Processes A and B do not overlap.</go_annotation_extension_relations:usage>
+        <go_annotation_extension_relations:local_domain>BFO:0000015</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0008150 GO:0003674</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Process A is causally_upstream of process B if process A occurs first, and process A causes process B to happen. Processes A and B do not overlap.</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002411</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_biological_process"/>
@@ -5045,6 +5012,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">is_active_in</oboInOwl:shorthand>
         <rdfs:comment></rdfs:comment>
         <rdfs:label>is active in</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Is_active_in</rdfs:seeAlso>
     </owl:ObjectProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002432"/>
@@ -5059,8 +5027,8 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_0002432"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>c executes activity in d if and only if c enables p and p occurs_in d.  Assuming no action at a distance by gene products, if a gene product enables (is capable of) a process that occurs in some structure, it must have at least some part in that structure.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>GOC:cjm</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GOC:dos</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+        <oboInOwl:hasDbXref rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
     </owl:Axiom>
     
 
@@ -5207,7 +5175,7 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000118>An interaction relation between x and y in which x catalyzes a reaction in which a phosphate group is added to y.</obo:IAO_0000118>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002447</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phosphorylates</oboInOwl:shorthand>
-        <rdfs:label>phosphorylates</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phosphorylates</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -5409,9 +5377,9 @@ For example, A and B may be gene products and binding of B by A positively regul
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002487"/>
         <obo:IAO_0000115>x existence overlaps y if and only if either (a) the start of x is part of y or (b) the end of x is part of y. Formally: x existence starts and ends during y iff (α(x) &gt;= α(y) &amp; α(x) &lt;= ω(y)) OR (ω(x) &lt;= ω(y) &amp; ω(x) &gt;= α(y))</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref>RO:0002490</oboInOwl:hasDbXref>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_biological_process"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_developmental_stages"/>
@@ -5432,9 +5400,9 @@ For example, A and B may be gene products and binding of B by A positively regul
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002492"/>
         <obo:IAO_0000115>x exists during y if and only if: 1) the time point at which x begins to exist is after or equal to the time point at which y begins and 2) the time point at which x ceases to exist is before or equal to the point at which y ends. Formally: x existence starts and ends during y iff α(x) &gt;= α(y) &amp; α(x) &lt;= ω(y) &amp; ω(x) &lt;= ω(y) &amp; ω(x) &gt;= α(y)</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000004</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
+        <go_annotation_extension_relations:local_domain>BFO:0000004</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>GO:0008150 WBls:0000075 ZFS:0100000</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Identifies a process or life stage during which a cellular component is present</go_annotation_extension_relations:usage>
         <oboInOwl:hasDbXref>RO:0002491</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>exists during</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_biological_process"/>
@@ -5705,20 +5673,20 @@ For example, A and B may be gene products and binding of B by A positively regul
         <obo:IAO_0000115>Holds between p and c when p is locomotion process and the outcome of this process is the change of location of c</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <obo:IAO_0000232></obo:IAO_0000232>
-        <go_annotation_extension_relations:local_domain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0008150</go_annotation_extension_relations:local_domain>
-        <go_annotation_extension_relations:local_range rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
-        <go_annotation_extension_relations:usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use this relation to link a locomotion process to the type of cell or anatomical structure or organism that the process results in locomotion of.</go_annotation_extension_relations:usage>
-        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GOREL:0001001</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002565</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">go/extensions/gorel</oboInOwl:hasOBONamespace>
+        <go_annotation_extension_relations:local_domain>GO:0008150</go_annotation_extension_relations:local_domain>
+        <go_annotation_extension_relations:local_range>CL:0000000 WBbt:0004017</go_annotation_extension_relations:local_range>
+        <go_annotation_extension_relations:usage>Use this relation to link a locomotion process to the type of cell or anatomical structure or organism that the process results in locomotion of.</go_annotation_extension_relations:usage>
+        <oboInOwl:hasAlternativeId>GOREL:0001001</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>RO:0002565</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>go/extensions/gorel</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_cell_or_anatomical"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
-        <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">results_in_movement_of</oboInOwl:shorthand>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">For movement of chemicals or cell parts, please use transports_or_maintains_localization_of</rdfs:comment>
+        <oboInOwl:shorthand>results_in_movement_of</oboInOwl:shorthand>
+        <rdfs:comment>For movement of chemicals or cell parts, please use transports_or_maintains_localization_of</rdfs:comment>
         <rdfs:label>results in movement of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -5756,8 +5724,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002574">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002437"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CARO_0001010"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CARO_0001010"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002574</oboInOwl:hasDbXref>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
@@ -5919,6 +5887,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_positively_regulates</oboInOwl:shorthand>
         <rdfs:label>directly positively regulates</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Directly_positively_regulates</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -5945,6 +5914,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directly_negatively_regulates</oboInOwl:shorthand>
         <rdfs:label>directly negatively regulates</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Directly_negatively_regulates</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6028,7 +5998,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_upstream_of_or_within,_positive_effect</oboInOwl:shorthand>
         <rdfs:label>acts upstream of or within, positive effect</rdfs:label>
-        <rdfs:seeAlso rdf:resource="http://wiki.geneontology.org/index.php/Acts_upstream_of_or_within,_positive_effect"/>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Acts_upstream_of_or_within,_positive_effect</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6048,6 +6018,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_upstream_of_or_within,_negative_effect</oboInOwl:shorthand>
         <rdfs:label>acts upstream of or within, negative effect</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Acts_upstream_of_or_within,_negative_effect</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6069,7 +6040,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_upstream_of,_positive_effect</oboInOwl:shorthand>
         <rdfs:label>acts upstream of, positive effect</rdfs:label>
-        <rdfs:seeAlso rdf:resource="http://wiki.geneontology.org/index.php/Acts_upstream_of,_positive_effect"/>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Acts_upstream_of,_positive_effect</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6091,7 +6062,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_gp2term"/>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acts_upstream_of,_negative_effect</oboInOwl:shorthand>
         <rdfs:label>acts upstream of, negative effect</rdfs:label>
-        <rdfs:seeAlso rdf:resource="http://wiki.geneontology.org/index.php/Acts_upstream_of,_negative_effect"/>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Acts_upstream_of,_negative_effect</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6106,6 +6077,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0004046</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">causally_upstream_of_or_within,_negative_effect</oboInOwl:shorthand>
         <rdfs:label>causally upstream of or within, negative effect</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://wiki.geneontology.org/Causally_upstream_of_or_within,_negative_effect</rdfs:seeAlso>
     </owl:ObjectProperty>
     
 
@@ -6120,6 +6092,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0004047</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">causally_upstream_of_or_within,_positive_effect</oboInOwl:shorthand>
         <rdfs:label>causally upstream of or within, positive effect</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://wiki.geneontology.org/Causally_upstream_of_or_within,_positive_effect"/>
     </owl:ObjectProperty>
     
 
@@ -6144,7 +6117,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0012011">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
         <obo:IAO_0000115>p is indirectly causally upstream of q iff p is causally upstream of q and there exists some process r such that p is causally upstream of r and r is causally upstream of q.</obo:IAO_0000115>
-        <oboInOwl:created_by>pg</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0003-1813-6857"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-09-26T06:07:17Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0012011</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_causally_upstream_of</oboInOwl:shorthand>
@@ -6159,7 +6132,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0012011"/>
         <obo:IAO_0000115>p indirectly regulates q iff p is indirectly causally upstream of q and p regulates q.</obo:IAO_0000115>
-        <oboInOwl:created_by>pg</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0003-1813-6857"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-09-26T06:08:01Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0012012</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">indirectly_regulates</oboInOwl:shorthand>
@@ -6181,7 +6154,7 @@ For example, A and B may be gene products and binding of B by A positively regul
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-2620-0345"/>
         <obo:IAO_0000232>A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.</obo:IAO_0000232>
         <obo:IAO_0000232>See github ticket https://github.com/oborel/obo-relations/issues/497</obo:IAO_0000232>
-        <oboInOwl:creation_date>2021-11-08T12:00:00Z</oboInOwl:creation_date>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-11-08T12:00:00Z</oboInOwl:creation_date>
         <oboInOwl:hasBroadSynonym>utilizes</oboInOwl:hasBroadSynonym>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0017001</oboInOwl:hasDbXref>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">device_utilizes_material</oboInOwl:shorthand>
@@ -6333,7 +6306,8 @@ For example, A and B may be gene products and binding of B by A positively regul
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <obo:IAO_0000115 xml:lang="en">A continuant that is a bearer of quality and realizable entity entities, in which other entities inhere and which itself cannot inhere in anything.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">A continuant that is a bearer of quality and realizable entity entities, in which other entities inhere and which itself cannot inhere in anything.</rdfs:comment>
         <rdfs:label xml:lang="en">independent continuant</rdfs:label>
     </owl:Class>
     
@@ -6349,7 +6323,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <obo:IAO_0000115 xml:lang="en">An occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">An occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t.</rdfs:comment>
         <rdfs:label xml:lang="en">process</rdfs:label>
     </owl:Class>
     
@@ -6408,7 +6383,8 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <obo:IAO_0000115 xml:lang="en">A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">b is a specifically dependent continuant = Def. b is a continuant &amp; there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</rdfs:comment>
         <rdfs:label xml:lang="en">specifically dependent continuant</rdfs:label>
     </owl:Class>
     
@@ -6434,7 +6410,8 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.</rdfs:comment>
         <rdfs:label xml:lang="en">generically dependent continuant</rdfs:label>
     </owl:Class>
     
@@ -6461,53 +6438,7 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <!-- http://purl.obolibrary.org/obo/CARO_0000000 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CARO_0000000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
-        <obo:IAO_0000115>A part of a cellular organism that is either an immaterial entity or a material entity with granularity above the level of a protein complex.  Or, a substance produced by a cellular organism with granularity above the level of a protein complex.</obo:IAO_0000115>
-        <oboInOwl:id>CARO:0000000</oboInOwl:id>
-        <rdfs:comment>Following BFO, material anatomical entities may have immaterial parts (the lumen of your stomach is part of your stomach).  The granularity limit follows the limits set by the Gene Ontology on the granularity limit for GO:cellular_component. Note that substances produced by an organism (sweat, feaces, urine) do not need to be part of an organism to qualify as an anatomical structure.</rdfs:comment>
-        <rdfs:label>anatomical entity</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CARO_0000000"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>A part of a cellular organism that is either an immaterial entity or a material entity with granularity above the level of a protein complex.  Or, a substance produced by a cellular organism with granularity above the level of a protein complex.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref>CAROC:Brownsville2014</oboInOwl:hasDbXref>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CARO_0000003 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CARO_0000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CARO_0000006"/>
-        <obo:IAO_0000115>Material anatomical entity that is a single connected structure with inherent 3D shape generated by coordinated expression of the organism&apos;s own genome.</obo:IAO_0000115>
-        <oboInOwl:id>CARO:0000003</oboInOwl:id>
-        <rdfs:comment>Note that the definition does not say &apos;generated exclusively by the co-ordinated expression of the organism&apos;s own genome&apos;, so this is still valid for cases where normal morphogenesis requires the actions of a facultative symbiont, or some looser dependency such as the a requirement for the presence of gut flora for normal gut development.</rdfs:comment>
-        <rdfs:label>connected anatomical structure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CARO_0000006 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CARO_0000006">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CARO_0000000"/>
-        <obo:IAO_0000115>An anatomical entity that has mass.</obo:IAO_0000115>
-        <oboInOwl:id>CARO:0000006</oboInOwl:id>
-        <rdfs:label>material anatomical entity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CARO_0001010 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CARO_0001010">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-        <obo:IAO_0000115>Material anatomical entity that is a member of an individual species or is a viral or viroid particle.</obo:IAO_0000115>
-        <obo:IAO_0000117>Melissa Haendel</obo:IAO_0000117>
-        <rdfs:label>organism or virus or viroid</rdfs:label>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CARO_0000000"/>
     
 
 
@@ -6520,6 +6451,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
         <obo:IAO_0000115>A material entity of anatomical origin (part of or deriving from an organism) that has as its parts a maximally connected cell compartment surrounded by a plasma membrane.</obo:IAO_0000115>
         <oboInOwl:hasDbXref>CALOHA:TS-2035</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>FBbt:00007002</oboInOwl:hasDbXref>
@@ -6545,7 +6477,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://purl.obolibrary.org/obo/GO_0003674 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0003674">
-        <obo:IAO_0000115>A molecular process that can be carried out by the action of a single macromolecular machine, usually via direct physical interactions with other molecular entities. Function in this sense denotes an action, or activity, that a gene product (or a complex) performs. These actions are described from two distinct but related perspectives: (1) biochemical activity, and (2) role as a component in a larger system/process.</obo:IAO_0000115>
+        <obo:IAO_0000115>A molecular process that can be carried out by the action of a single macromolecular machine, usually via direct physical interactions with other molecular entities. Function in this sense denotes an action, or activity, that a gene product (or a complex) performs.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>molecular function</oboInOwl:hasExactSynonym>
         <oboInOwl:id>GO:0003674</oboInOwl:id>
         <rdfs:comment>Note that, in addition to forming the root of the molecular function ontology, this term is recommended for use for the annotation of gene products whose molecular function is unknown. When this term is used for annotation, it indicates that no information was available about the molecular function of the gene product annotated as of the date the annotation was made; the evidence code &apos;no data&apos; (ND), is used to indicate this. Despite its name, this is not a type of &apos;function&apos; in the sense typically defined by upper ontologies such as Basic Formal Ontology (BFO). It is instead a BFO:process carried out by a single gene product or complex.</rdfs:comment>
@@ -6554,7 +6486,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003674"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>A molecular process that can be carried out by the action of a single macromolecular machine, usually via direct physical interactions with other molecular entities. Function in this sense denotes an action, or activity, that a gene product (or a complex) performs. These actions are described from two distinct but related perspectives: (1) biochemical activity, and (2) role as a component in a larger system/process.</owl:annotatedTarget>
+        <owl:annotatedTarget>A molecular process that can be carried out by the action of a single macromolecular machine, usually via direct physical interactions with other molecular entities. Function in this sense denotes an action, or activity, that a gene product (or a complex) performs.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:pdt</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -6575,7 +6507,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://purl.obolibrary.org/obo/GO_0008150 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008150">
-        <obo:IAO_0000115>A biological process represents a specific objective that the organism is genetically programmed to achieve. Biological processes are often described by their outcome or ending state, e.g., the biological process of cell division results in the creation of two daughter cells (a divided cell) from a single parent cell. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</obo:IAO_0000115>
+        <obo:IAO_0000115>A biological process is the execution of a genetically-encoded biological module or program. It consists of all the steps required to achieve the specific biological objective of the module. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</obo:IAO_0000115>
         <oboInOwl:created_by>jl</oboInOwl:created_by>
         <oboInOwl:creation_date>2012-09-19T15:05:24Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref>Wikipedia:Biological_process</oboInOwl:hasDbXref>
@@ -6590,7 +6522,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>A biological process represents a specific objective that the organism is genetically programmed to achieve. Biological processes are often described by their outcome or ending state, e.g., the biological process of cell division results in the creation of two daughter cells (a divided cell) from a single parent cell. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</owl:annotatedTarget>
+        <owl:annotatedTarget>A biological process is the execution of a genetically-encoded biological module or program. It consists of all the steps required to achieve the specific biological objective of the module. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>GOC:pdt</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -6689,9 +6621,61 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000078">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:oneOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000002"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000120"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000121"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000122"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000123"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000124"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000125"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000423"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000428"/>
+                </owl:oneOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <obo:IAO_0000111 xml:lang="en">curation status specification</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Better to represent curation as a process with parts and then relate labels to that process (in IAO meeting)</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000266</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">curation status specification</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/MOD_00000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOD_00000"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000111 xml:lang="en">organism</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">animal</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">fungus</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">plant</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">virus</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.</obo:IAO_0000115>
+        <obo:IAO_0000116>10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and &apos;other organisms&apos;)</obo:IAO_0000116>
+        <obo:IAO_0000116>13-02-2009:
+OBI doesn&apos;t take position as to  when an organism starts or ends being an organism - e.g. sperm, foetus.
+This issue is outside the scope of OBI.</obo:IAO_0000116>
+        <obo:IAO_0000117>GROUP: OBI Biomaterial Branch</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/Organism</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">organism</rdfs:label>
+    </owl:Class>
     
 
 
@@ -6741,6 +6725,242 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <obo:IAO_0000115>Material anatomical entity that is a single connected structure with inherent 3D shape generated by coordinated expression of the organism&apos;s own genome.</obo:IAO_0000115>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <oboInOwl:hasDbXref>AAO:0010825</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AEO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BILA:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CARO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EHDAA2:0003003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EMAPA:0</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FBbt:00007001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:305751</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:67135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>GAID:781</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>HAO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>MA:0003000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>MESH:D000825</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>SCTID:362889002</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TAO:0000037</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TGMA:0001823</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>VHOG:0001759</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>XAO:0003000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>ZFA:0000037</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://dbpedia.org/ontology/AnatomicalStructure</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>biological structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>connected biological structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:id>UBERON:0000061</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#common_anatomy"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#upper_level"/>
+        <rdfs:label>anatomical structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Material anatomical entity that is a single connected structure with inherent 3D shape generated by coordinated expression of the organism&apos;s own genome.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>CARO:0000003</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget>connected biological structure</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>CARO:0000003</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <obo:IAO_0000115>Anatomical entity that has mass.</obo:IAO_0000115>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <oboInOwl:hasDbXref>AAO:0010264</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AEO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BILA:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CARO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EHDAA2:0003006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FBbt:00007016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:67165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>HAO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TAO:0001836</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TGMA:0001826</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>VHOG:0001721</oboInOwl:hasDbXref>
+        <oboInOwl:id>UBERON:0000465</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#common_anatomy"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#upper_level"/>
+        <rdfs:label>material anatomical entity</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Anatomical entity that has mass.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>http://orcid.org/0000-0001-9114-8737</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <obo:IAO_0000115>Biological entity that is either an individual member of a biological species or constitutes the structural organization of an individual member of a biological species.</obo:IAO_0000115>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <oboInOwl:hasDbXref>AAO:0010841</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AEO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BILA:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BIRNLEX:6</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CARO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EHDAA2:0002229</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FBbt:10000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:62955</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>HAO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>MA:0000001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>NCIT:C12219</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TAO:0100000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TGMA:0001822</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UMLS:C1515976</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>WBbt:0000100</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>XAO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>ZFA:0100000</oboInOwl:hasDbXref>
+        <oboInOwl:id>UBERON:0001062</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#common_anatomy"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#upper_level"/>
+        <rdfs:label>anatomical entity</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Biological entity that is either an individual member of a biological species or constitutes the structural organization of an individual member of a biological species.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>FMA:62955</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://orcid.org/0000-0001-9114-8737</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>UMLS:C1515976</owl:annotatedTarget>
+        <oboInOwl:source>ncithesaurus:Anatomic_Structure_System_or_Substance</oboInOwl:source>
+    </owl:Axiom>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000002 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000002">
+        <obo:IAO_0000111 xml:lang="en">example to be eventually removed</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">example to be eventually removed</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000120 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000120">
+        <obo:IAO_0000111 xml:lang="en">metadata complete</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">metadata complete</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000121 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000121">
+        <obo:IAO_0000111 xml:lang="en">organizational term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Term created to ease viewing/sort terms for development purpose, and will not be included in a release</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">organizational term</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000122 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000122">
+        <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking &quot;ready_for_release&quot; should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed &quot;ready_for_release&quot; will also derived from a chain of ancestor classes that are also &quot;ready_for_release.&quot;</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">ready for release</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000123 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000123">
+        <obo:IAO_0000111 xml:lang="en">metadata incomplete</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">metadata incomplete</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000124 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000124">
+        <obo:IAO_0000111 xml:lang="en">uncurated</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Nothing done yet beyond assigning a unique class ID and proposing a preferred term.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">uncurated</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000125 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000125">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/>
+        <obo:IAO_0000111 xml:lang="en">pending final vetting</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">pending final vetting</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000423 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000423">
+        <obo:IAO_0000111 xml:lang="en">to be replaced with external ontology term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Terms with this status should eventually replaced with a term from another ontology.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">to be replaced with external ontology term</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000428 -->
+
+    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000428">
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/>
+        <obo:IAO_0000111 xml:lang="en">requires discussion</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">requires discussion</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -6750,13 +6970,13 @@ For example, A and B may be gene products and binding of B by A positively regul
      -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000060">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002401">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002403">
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
+        <obo:IAO_0000115>OBSOLETE. Was not defined before obsoletion.</obo:IAO_0000115>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002406">
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_molecular_function"/>
@@ -6779,8 +6999,8 @@ For example, A and B may be gene products and binding of B by A positively regul
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0004009">
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_ontology"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#AE_molecular_function"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#display_for_curators"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/go#valid_for_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_go_annotation_extension"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/valid_for_gocam"/>
@@ -6830,6 +7050,19 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Class>
         </rdfs:subClassOf>
     </owl:Restriction>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000120"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000121"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000122"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000123"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000124"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000125"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000423"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000428"/>
+        </owl:distinctMembers>
+    </rdf:Description>
     
 
 
@@ -6895,13 +7128,13 @@ For example, A and B may be gene products and binding of B by A positively regul
     <rdf:Description rdf:about="urn:swrl#D">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
+    <rdf:Description rdf:about="urn:swrl#mf">
+        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
+    </rdf:Description>
     <rdf:Description rdf:about="urn:swrl#eff">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
     <rdf:Description rdf:about="urn:swrl#in">
-        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:swrl#mf">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
     <rdf:Description rdf:about="urn:swrl#mf2">
@@ -6913,13 +7146,13 @@ For example, A and B may be gene products and binding of B by A positively regul
     <rdf:Description rdf:about="urn:swrl:var#q">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
+    <rdf:Description rdf:about="urn:swrl:var#x">
+        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
+    </rdf:Description>
     <rdf:Description rdf:about="urn:swrl:var#y">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
     <rdf:Description rdf:about="urn:swrl:var#z">
-        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="urn:swrl:var#x">
         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Variable"/>
     </rdf:Description>
     <rdf:Description rdf:about="urn:swrl:var#u">
@@ -7594,9 +7827,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
-                        <swrl:argument1 rdf:resource="urn:swrl#eff"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#in"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
+                        <swrl:argument1 rdf:resource="urn:swrl#mf"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#eff"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7605,9 +7838,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
-                                <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#eff"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
+                                <swrl:argument1 rdf:resource="urn:swrl#eff"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#in"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7639,9 +7872,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
                         <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#in"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#eff"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7650,9 +7883,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#eff"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#in"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7684,9 +7917,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002578"/>
                         <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#eff"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7695,9 +7928,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002578"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#eff"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7729,9 +7962,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002629"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
                         <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#eff"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7740,9 +7973,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002629"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#eff"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7774,9 +8007,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002630"/>
                         <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#eff"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7785,9 +8018,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002630"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#mf"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#mf2"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#eff"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7819,7 +8052,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002404"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
                         <swrl:argument1 rdf:resource="urn:swrl#x"/>
                         <swrl:argument2 rdf:resource="urn:swrl#y"/>
                     </rdf:Description>
@@ -7830,7 +8063,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002404"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#x"/>
                                 <swrl:argument2 rdf:resource="urn:swrl#y"/>
                             </rdf:Description>
@@ -7847,7 +8080,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#ClassAtom"/>
                         <swrl:classPredicate rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-                        <swrl:argument1 rdf:resource="urn:swrl#x"/>
+                        <swrl:argument1 rdf:resource="urn:swrl#y"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7857,7 +8090,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#ClassAtom"/>
                                 <swrl:classPredicate rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-                                <swrl:argument1 rdf:resource="urn:swrl#y"/>
+                                <swrl:argument1 rdf:resource="urn:swrl#x"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7875,7 +8108,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
                         <swrl:argument1 rdf:resource="urn:swrl#x"/>
                         <swrl:argument2 rdf:resource="urn:swrl#y"/>
                     </rdf:Description>
@@ -7886,7 +8119,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#x"/>
                                 <swrl:argument2 rdf:resource="urn:swrl#y"/>
                             </rdf:Description>
@@ -7903,7 +8136,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#ClassAtom"/>
                         <swrl:classPredicate rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-                        <swrl:argument1 rdf:resource="urn:swrl#x"/>
+                        <swrl:argument1 rdf:resource="urn:swrl#y"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -7913,7 +8146,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#ClassAtom"/>
                                 <swrl:classPredicate rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-                                <swrl:argument1 rdf:resource="urn:swrl#y"/>
+                                <swrl:argument1 rdf:resource="urn:swrl#x"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -7930,7 +8163,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0012011"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
                         <swrl:argument1 rdf:resource="urn:swrl:var#p"/>
                         <swrl:argument2 rdf:resource="urn:swrl:var#q"/>
                     </rdf:Description>
@@ -7941,7 +8174,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0012011"/>
                                 <swrl:argument1 rdf:resource="urn:swrl:var#p"/>
                                 <swrl:argument2 rdf:resource="urn:swrl:var#q"/>
                             </rdf:Description>
@@ -7974,51 +8207,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002213"/>
-                        <swrl:argument1 rdf:resource="urn:swrl#y"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#z"/>
-                    </rdf:Description>
-                </rdf:first>
-                <rdf:rest>
-                    <rdf:Description>
-                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
-                        <rdf:first>
-                            <rdf:Description>
-                                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
-                                <swrl:argument1 rdf:resource="urn:swrl#x"/>
-                                <swrl:argument2 rdf:resource="urn:swrl#y"/>
-                            </rdf:Description>
-                        </rdf:first>
-                        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-                    </rdf:Description>
-                </rdf:rest>
-            </rdf:Description>
-        </swrl:body>
-        <swrl:head>
-            <rdf:Description>
-                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
-                <rdf:first>
-                    <rdf:Description>
-                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
                         <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
-                        <swrl:argument1 rdf:resource="urn:swrl#x"/>
-                        <swrl:argument2 rdf:resource="urn:swrl#z"/>
-                    </rdf:Description>
-                </rdf:first>
-                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-            </rdf:Description>
-        </swrl:head>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Imp"/>
-        <swrl:body>
-            <rdf:Description>
-                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
-                <rdf:first>
-                    <rdf:Description>
-                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002213"/>
                         <swrl:argument1 rdf:resource="urn:swrl#x"/>
                         <swrl:argument2 rdf:resource="urn:swrl#y"/>
                     </rdf:Description>
@@ -8029,7 +8218,7 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002213"/>
                                 <swrl:argument1 rdf:resource="urn:swrl#y"/>
                                 <swrl:argument2 rdf:resource="urn:swrl#z"/>
                             </rdf:Description>
@@ -8062,9 +8251,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0019002"/>
-                        <swrl:argument1 rdf:resource="urn:swrl:var#y"/>
-                        <swrl:argument2 rdf:resource="urn:swrl:var#z"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
+                        <swrl:argument1 rdf:resource="urn:swrl#y"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#z"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -8073,9 +8262,53 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
-                                <swrl:argument1 rdf:resource="urn:swrl:var#x"/>
-                                <swrl:argument2 rdf:resource="urn:swrl:var#y"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002213"/>
+                                <swrl:argument1 rdf:resource="urn:swrl#x"/>
+                                <swrl:argument2 rdf:resource="urn:swrl#y"/>
+                            </rdf:Description>
+                        </rdf:first>
+                        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+                    </rdf:Description>
+                </rdf:rest>
+            </rdf:Description>
+        </swrl:body>
+        <swrl:head>
+            <rdf:Description>
+                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
+                <rdf:first>
+                    <rdf:Description>
+                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
+                        <swrl:argument1 rdf:resource="urn:swrl#x"/>
+                        <swrl:argument2 rdf:resource="urn:swrl#z"/>
+                    </rdf:Description>
+                </rdf:first>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+            </rdf:Description>
+        </swrl:head>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Imp"/>
+        <swrl:body>
+            <rdf:Description>
+                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
+                <rdf:first>
+                    <rdf:Description>
+                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002212"/>
+                        <swrl:argument1 rdf:resource="urn:swrl:var#x"/>
+                        <swrl:argument2 rdf:resource="urn:swrl:var#y"/>
+                    </rdf:Description>
+                </rdf:first>
+                <rdf:rest>
+                    <rdf:Description>
+                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList"/>
+                        <rdf:first>
+                            <rdf:Description>
+                                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0019002"/>
+                                <swrl:argument1 rdf:resource="urn:swrl:var#y"/>
+                                <swrl:argument2 rdf:resource="urn:swrl:var#z"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -8106,9 +8339,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                 <rdf:first>
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002264"/>
-                        <swrl:argument1 rdf:resource="urn:swrl:var#x"/>
-                        <swrl:argument2 rdf:resource="urn:swrl:var#y"/>
+                        <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
+                        <swrl:argument1 rdf:resource="urn:swrl:var#y"/>
+                        <swrl:argument2 rdf:resource="urn:swrl:var#z"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -8117,9 +8350,9 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                         <rdf:first>
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
-                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
-                                <swrl:argument1 rdf:resource="urn:swrl:var#y"/>
-                                <swrl:argument2 rdf:resource="urn:swrl:var#z"/>
+                                <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002264"/>
+                                <swrl:argument1 rdf:resource="urn:swrl:var#x"/>
+                                <swrl:argument2 rdf:resource="urn:swrl:var#y"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -8151,8 +8384,8 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                     <rdf:Description>
                         <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
                         <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
-                        <swrl:argument1 rdf:resource="urn:swrl:var#q"/>
-                        <swrl:argument2 rdf:resource="urn:swrl:var#u"/>
+                        <swrl:argument1 rdf:resource="urn:swrl:var#p"/>
+                        <swrl:argument2 rdf:resource="urn:swrl:var#q"/>
                     </rdf:Description>
                 </rdf:first>
                 <rdf:rest>
@@ -8162,8 +8395,8 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
                             <rdf:Description>
                                 <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom"/>
                                 <swrl:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002411"/>
-                                <swrl:argument1 rdf:resource="urn:swrl:var#p"/>
-                                <swrl:argument2 rdf:resource="urn:swrl:var#q"/>
+                                <swrl:argument1 rdf:resource="urn:swrl:var#q"/>
+                                <swrl:argument2 rdf:resource="urn:swrl:var#u"/>
                             </rdf:Description>
                         </rdf:first>
                         <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
@@ -8190,5 +8423,5 @@ e.g.  if GP X enables ATPase coupled transporter activity&apos; and &apos;ATPase
 
 
 
-<!-- Generated by the OWL API (version 4.2.6) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
This should remove the stale definition of biological_process present in gorel.owl, and infecting go-gaf.owl. For https://github.com/geneontology/go-ontology/issues/26516 

I'm not sure why gorel.owl includes so much extra content.