### PR TITLE
Add check for obsolete EC refs.

### DIFF
--- a/src/util/ontology-qc.dl
+++ b/src/util/ontology-qc.dl
@@ -62,6 +62,9 @@ synonym_xref(term, property, ref) :-
     synonym_property(property),
     ontrdf(axiom, OIO_HAS_DB_XREF, ref).
 
+error(cat("ERROR: ", term, " has an xref to an obsolete EC: ", ec)) :- xref(term, ec), valid_term(term), obsolete_ec(ec).
+error(cat("ERROR: ", term, " has a definition xref to an obsolete EC: ", ec)) :- defxref(term, ec), valid_term(term), obsolete_ec(ec).
+error(cat("ERROR: ", term, " has a synonym xref to an obsolete EC: ", ec)) :- synonym_xref(term, _, ec), valid_term(term), obsolete_ec(ec).
 error(cat("ERROR: ", term, " references an undeclared subset: ", subset)) :- subset_assertion(term, subset), !declared_subset(subset).
 
 .output error(filename="datalog-violations.tsv")


### PR DESCRIPTION
For #21347.

This PR will fail until existing obsolete EC xrefs are fixed:

- ERROR: <http://purl.obolibrary.org/obo/GO_0047844> has an xref to an obsolete EC: "EC:3.5.4.14"
- ERROR: <http://purl.obolibrary.org/obo/GO_0047844> has a definition xref to an obsolete EC: "EC:3.5.4.14"
- ERROR: <http://purl.obolibrary.org/obo/GO_0047844> has a synonym xref to an obsolete EC: "EC:3.5.4.14"
- ERROR: <http://purl.obolibrary.org/obo/GO_0050110> has a synonym xref to an obsolete EC: "EC:3.2.1.110"