### PR TITLE
Moved subsets from kwalify to linkml and tidied yaml file.

### DIFF
--- a/src/ontology/subsets/Makefile
+++ b/src/ontology/subsets/Makefile
@@ -1,0 +1,12 @@
+# TODO: integrate this Makefile into normal gh actions.
+# for now you must do a separate pip or poetry install
+# of LinkML
+
+RUN = poetry run
+SCHEMA = subsets.schema.yaml
+
+validate: go_subsets_metadata.yaml $(SCHEMA)
+	$(RUN) linkml-validate -s subsets.schema.yaml $<
+
+subsets.jsonschema.json: subsets.schema.yaml $(SCHEMA)
+	$(RUN) gen-json-schema $< > $@

--- a/src/ontology/subsets/Makefile
+++ b/src/ontology/subsets/Makefile
@@ -5,6 +5,10 @@
 RUN = poetry run
 SCHEMA = subsets.schema.yaml
 
+all: validate subsets.jsonschema.json
+test: validate
+
+
 validate: go_subsets_metadata.yaml $(SCHEMA)
 	$(RUN) linkml-validate -s subsets.schema.yaml $<
 

--- a/src/ontology/subsets/README.md
+++ b/src/ontology/subsets/README.md
@@ -1,3 +1,22 @@
+# Subsets
+
 This folder contains manually maintained metadata about subsets, including the subset type and the taxonomic range to which it applies. For more information see the Subsets Schema at https://github.com/geneontology/go-ontology/blob/master/src/ontology/subsets/subsets.schema.yaml.
 
 GO subsets are derived from the ontology, and are produced here (http://current.geneontology.org/ontology/subsets/index.html)http://current.geneontology.org/ontology/subsets/index.html.
+
+## Metadata
+
+Subset metadata is in the file [go_subsets_metadata.yaml](go_subsets_metadata.yaml). The schema
+is described in LinkML. A derived JSON-Schema file is provided.
+
+Note that validation is not yet integrated into gh actions. For now,
+do this:
+
+    linkml-validate -s subsets.schema.yaml go_subsets_metadata.yaml
+
+
+Or simply
+
+   make validate
+
+

--- a/src/ontology/subsets/go_subsets_metadata.yaml
+++ b/src/ontology/subsets/go_subsets_metadata.yaml
@@ -1,537 +1,416 @@
-- id: goantislim_grouping
-  title: GO antislim
-  type: blacklist
-  preferred label: goantislim
-  status: obsolete
-  description: "Grouping classes that can be excluded in enrichment analyses etc. Archived .obo file can be found at http://release.geneontology.org/2018-08-09/ontology/subsets/goantislim_grouping.obo"
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact:
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: 
-      label: 
-      orcid: 
-      github:
-- id: gocheck_do_not_annotate
-  title: GO antislim
-  type: blacklist
-  preferred label: Do not annotate
-  status: active
-  description: "Terms that are too high level to be informative for annotation."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact:
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+id: http://purl.obolibrary.org/obo/go/subsets/go_subsets_metadata
+description: Subsets
+subsets:
+  - id: goantislim_grouping
+    title: GO antislim
+    role: ExclusionList
+    label: goantislim
+    status: obsolete
+    description: Grouping classes that can be excluded in enrichment analyses etc.
+    archived_url: http://release.geneontology.org/2018-08-09/ontology/subsets/goantislim_grouping.obo
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    contact:
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github:
-- id: gocheck_do_not_manually_annotate
-  title: Terms not allowed for manual annotation
-  type: 
-  preferred label: Do not manually annotate
-  status: obsolete
-  description: "Terms that are too high level to be informative for manual annotation; merged with gocheck_do_not_annotate."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  github:
     tracker: https://github.com/geneontology/go-ontology/issues
-  contact:
-    - email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+  - id: gocheck_do_not_annotate
+    title: GO antislim
+    role: ExclusionList
+    label: Do not annotate
+    status: active
+    description: "Terms that are too high level to be informative for annotation."
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    contact:
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github:
-- id: gocheck_obsoletion_candidate
-  title: Obsoletion candidate subset
-  preferred label: Obsoletion candidate subset
-  type: blacklist
-  status: active
-  description: "Terms that are scheduled for obsoletion."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: gocheck_do_not_manually_annotate
+    title: Terms not allowed for manual annotation
+    label: Do not manually annotate
+    status: obsolete
+    replaced_by:
+      - gocheck_do_not_annotate
+    description: "Terms that are too high level to be informative for manual annotation; merged with gocheck_do_not_annotate."
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+    contact:
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github: 
-- id: goslim_agr
-  title: AGR slim
-  type: ribbon
-  preferred label: Animals and fungi (Opisthokonta)
-  status: active
-  description: "Subset for Alliance of Genome Resources (AGR). The purpose of this subsets is mainly to drive the 'ribbon' display."
-  taxon:
-    id: NCBITaxon:33154
-    label: Opisthokonta
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: Mary.Dolan@jax.org
-      label: Mary Dolan
-      orcid: http://orcid.org/0000-0001-7732-3295
-      github: 
-- id: goslim_aspergillus
-  title: Aspergillus slim
-  type: binning subset
-  status: obsolete
-  description: "Aspergillus GO slim."
-  taxon:
-    id: NCBITaxon:5052
-    label: Aspergillus 
+  - id: gocheck_obsoletion_candidate
+    title: Obsoletion candidate subset
+    label: Obsoletion candidate subset
+    role: ExclusionList
+    status: active
+    description: "Terms that are scheduled for obsoletion."
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
     contact: 
-    email: candida-curator@lists.stanford.edu
-    label: CDG helpdesk
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: jodils@stanford.edu
-      label: Jodi Lew-Smith
-      orcid: https://orcid.org/0000-0003-0784-046X
-      github: jlewsmith
-- id: goslim_candida
-  title: Candida slim
-  type: binning subset
-  status: active
-  description: "Candida GO slim."
-  seeAlso: 
-  taxon: 
-    id: NCBITaxon:1535326
-    label: Candida
-  contact: 
-    email: candida-curator@lists.stanford.edu
-    label: CGD helpdesk
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-   contributors:
-    - email: jodils@stanford.edu
-      label: Jodi Lew-Smith
-      orcid: https://orcid.org/0000-0003-0784-046X
-      github: jlewsmith
-- id: goslim_chembl
-  title: ChEMBL slim
-  type: binning subset
-  status: active
-  description: "Subset for ChEMBL."
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact: 
-    email: Barbara Zdrazil
-    label: bzdrazil@ebi.ac.uk
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: Barbara Zdrazil
-      label: bzdrazil@ebi.ac.uk
-      orcid: https://orcid.org/0000-0001-9395-1515
-      github: BZdrazil
-- id: goslim_drosophila
-  title: Drosophila subset
-  preferred label: Insects
-  type: binning subset
-  status: active
-  description: "GO subset for insects. This subset can be used for binning purposes, most annotations should map to a term in the subset."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:50557
-    label: Insecta
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: gocur@morgan.harvard.edu
-      label: GO FlyBase curators
-      orcid: orcid:0000-0003-3212-6364
-      github: hattrill
-- id: goslim_euk_cellular_processes_ribbon
-  title: GO ribbon for eukaroytic cellular processes
-  preferred label: GO ribbon for eukaroytic cellular processes
-  type: ribbon
-  status: active
-  description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for cellular processes in eukaryotes."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:2759
-    label: Eukaryota
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github: 
-- id: goslim_flyBase_ribbon
-  title: FlyBase Ribbon slim
-  preferred label: Insects
-  type: ribbon
-  status: active
-  description: "Insect GO ribbon subset produced by FlyBase. The purpose of this subset is mainly to drive the Flybase and the UniProt 'ribbon' display."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:50557
-    label: Insecta
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: gocur@morgan.harvard.edu
-      label: GO FlyBase curators
-      orcid: orcid:0000-0003-3212-6364
-      github: hattrill
-- id: goslim_generic
-  title: Generic GO subset
-  type: binning subset
-  preferred label: All organisms
-  status: active
-  description: "Generic GO subset. Applies to all species. This slim can be used for binning purposes, most annotations should map to a term in the slim."
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact:
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: goslim_agr
+    title: AGR slim
+    role: Ribbon
+    label: Animals and fungi (Opisthokonta)
+    status: active
+    description: "Subset for Alliance of Genome Resources (AGR). The purpose of this subsets is mainly to drive the 'ribbon' display."
+    taxa:
+      - id: NCBITaxon:33154
+        label: Opisthokonta
+    contact: 
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github: 
-- id: goslim_goa
-  title: GOA slim
-  type: 
-  status: obsolete
-  description: "The GOA slim had not been maintained since 2002, and had no terms in the 2018 version of the ontology. This subset was removed from the ontology. The 2002 version of the GOA slim is here: http://cvsweb.geneontology.org/cgi-bin/cvsweb.cgi/go/GO_slims/archived_GO_slims/goslim_goa.2002?rev=1.4;content-type=text%2Fplain."
-  seeAlso: 
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: 
-    label: 
-  github:
-   tracker: 
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github:     
-- id: goslim_metagenomics
-  title: Metagenomics slim
-  type: 
-  status: pending contact
-  description: ""
-  seeAlso: 
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: 
-    label: 
-  github:
-   tracker: 
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-- id: goslim_mouse
-  title: Mouse GO slim
-  type: binning subset
-  status: active
-  description: "Mouse GO subset."
-  taxon:
-    id: NCBITaxon:10090
-    label: Mus musculus
-  contact:
-    email: mgi-help@jax.org
-    label: MGI helpdesk
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: Mary.Dolan@jax.org
-      label: Mary Dolan
-      orcid: https://orcid.org/0000-0001-7732-3295
-      github: mdolanme
-- id: goslim_pir
-  title: PIR slim
-  type: binning subset
-  status: active
-  description: "PIR (Protein Information Ressource) slim"
-  taxon:
-    id: NCBITaxon:1
-    label: all organisms
-  contact: 
-    email: dan5@georgetown.edu
-    label: Darren Natale
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: dan5@georgetown.edu
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: Mary.Dolan@jax.org
+        label: Mary Dolan
+        orcid: orcid:0000-0001-7732-3295
+  - id: goslim_aspergillus
+    title: Aspergillus slim
+    role: Binning
+    status: obsolete
+    description: "Aspergillus GO slim."
+    taxa:
+      - id: NCBITaxon:5052
+        label: Aspergillus 
+    contact: 
+      email: candida-curator@lists.stanford.edu
+      label: CDG helpdesk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: jodils@stanford.edu
+        label: Jodi Lew-Smith
+        orcid: orcid:0000-0003-0784-046X
+        github: jlewsmith
+  - id: goslim_candida
+    title: Candida slim
+    role: Binning
+    status: active
+    description: "Candida GO slim."
+    taxa: 
+      - id: NCBITaxon:1535326
+        label: Candida
+    contact: 
+      email: candida-curator@lists.stanford.edu
+      label: CGD helpdesk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: jodils@stanford.edu
+        label: Jodi Lew-Smith
+        orcid: orcid:0000-0003-0784-046X
+        github: jlewsmith
+  - id: goslim_chembl
+    title: ChEMBL slim
+    role: Binning
+    status: active
+    description: "Subset for ChEMBL."  ## TODO: add more details
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    contact: 
+      email: bzdrazil@ebi.ac.uk
+      label: Barbara Zdrazil
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: bzdrazil@ebi.ac.uk
+        label: Barbara Zdrazil
+        orcid: orcid:0000-0001-9395-1515
+        github: BZdrazil
+  - id: goslim_drosophila
+    title: Drosophila subset
+    label: Insects
+    role: Binning
+    status: active
+    description: "GO subset for insects. This subset can be used for binning purposes, most annotations should map to a term in the subset."
+    taxa:
+      - id: NCBITaxon:50557
+        label: Insecta
+    contact: 
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+        - email: gocur@morgan.harvard.edu
+          label: GO FlyBase curators
+          orcid: orcid:0000-0003-3212-6364
+          github: hattrill
+  - id: goslim_euk_cellular_processes_ribbon
+    title: GO ribbon for eukaroytic cellular processes
+    label: GO ribbon for eukaroytic cellular processes
+    role: Ribbon
+    status: active
+    description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for cellular processes in eukaryotes."
+    taxa:
+      - id: NCBITaxon:2759
+        label: Eukaryota
+    contact: 
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: goslim_flyBase_ribbon
+    title: FlyBase Ribbon slim
+    label: Insects  ## TODO: I don't think this is a good name
+    role: Ribbon
+    status: active
+    description: "Insect GO ribbon subset produced by FlyBase. The purpose of this subset is mainly to drive the Flybase and the UniProt 'ribbon' display."
+    taxa:
+      - id: NCBITaxon:50557
+        label: Insecta
+    contact: 
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: gocur@morgan.harvard.edu
+        label: GO FlyBase curators
+        orcid: orcid:0000-0003-3212-6364
+        github: hattrill
+  - id: goslim_generic
+    title: Generic GO subset
+    role: Binning
+    label: All organisms
+    status: active
+    description: Generic GO subset. Applies to all species. This slim can be used for binning purposes, 
+      most annotations should map to a term in the slim.
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    contact:
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: goslim_goa
+    title: GOA slim
+    status: obsolete
+    description: "The GOA slim had not been maintained since 2002, and had no terms in the 2018 version of the ontology. This subset was removed from the ontology."
+    archived_url: "http://cvsweb.geneontology.org/cgi-bin/cvsweb.cgi/go/GO_slims/archived_GO_slims/goslim_goa.2002?rev=1.4;content-type=text%2Fplain."
+  - id: goslim_metagenomics
+    title: Metagenomics slim
+    status: unknown
+    description: A slim for high-level visualisation of the functional profile of metagenomic samples
+    see_also:
+      - https://www.ebi.ac.uk/about/news/updates-from-data-resources/metagenomics-go-slim-2016/
+  - id: goslim_mouse
+    title: Mouse GO slim
+    role: Binning
+    status: active
+    description: "Mouse GO subset."
+    taxa:
+      - id: NCBITaxon:10090
+        label: Mus musculus
+    contact:
+      email: mgi-help@jax.org
+      label: MGI helpdesk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: Mary.Dolan@jax.org
+        label: Mary Dolan
+        orcid: orcid:0000-0001-7732-3295
+        github: mdolanme
+  - id: goslim_pir
+    title: PIR slim
+    role: Binning
+    status: active
+    description: "PIR (Protein Information Resource) slim"  ## TODO: better describe this
+    taxa:
+      - id: NCBITaxon:1
+        label: all organisms
+    contact: 
+      email: dan5@georgetown.edu
       label: Darren Natale
-      orcid: https://orcid.org/0000-0001-5809-9523
-      github: nataled
-- id: goslim_plant_ribbon
-  title: Plant Ribbon subset
-  preferred label: Plants
-  type: ribbon
-  status: active
-  description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for plant and algae species."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:33090
-    label: Viridiplantae
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
-      label: GO Ontology Curators
-      orcid: 
-      github: 
-- id: goslim_plant
-  title: Plant slim
-  type: binning subset
-  status: active
-  description: "Plant GO subset."
-  taxon: 
-    id: NCBITaxon:33090
-    label: Viridiplantae
-  contact: 
-    email: curator@arabidopsis.org
-    label: TAIR helpdesk
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: tberardi@arabidopsis.org
-      label: Tanya Berardini
-      orcid: https://orcid.org/0000-0002-3837-8864
-      github: tberardini
-- id: goslim_pombe
-  title: Schizosaccharomyces pombe slim
-  type: binning subset
-  status: active
-  description: "Schizosaccharomyces pombe GO subset."
-  taxon:
-    id: NCBITaxon:4896
-    label: Schizosaccharomyces pombe
-  contact: 
-    email: vw253@cam.ac.uk
-    label: Valerie Wood
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: vw253@cam.ac.uk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: dan5@georgetown.edu
+        label: Darren Natale
+        orcid: orcid:0000-0001-5809-9523
+        github: nataled
+  - id: goslim_plant_ribbon
+    title: Plant Ribbon subset
+    label: Plants
+    role: Ribbon
+    status: active
+    description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for plant and algae species."
+    taxa:
+      - id: NCBITaxon:33090
+        label: Viridiplantae
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: goslim_plant
+    title: Plant slim
+    role: Binning
+    status: active
+    description: "Plant GO subset."
+    taxa: 
+      - id: NCBITaxon:33090
+        label: Viridiplantae
+    contact: 
+      email: curator@arabidopsis.org
+      label: TAIR helpdesk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: tberardi@arabidopsis.org
+        label: Tanya Berardini
+        orcid: orcid:0000-0002-3837-8864
+        github: tberardini
+  - id: goslim_pombe
+    title: Schizosaccharomyces pombe slim
+    role: Binning
+    status: active
+    description: "Schizosaccharomyces pombe GO subset."
+    taxa:
+      - id: NCBITaxon:4896
+        label: Schizosaccharomyces pombe
+    contact: 
+      email: vw253@cam.ac.uk
       label: Valerie Wood
-      orcid: https://orcid.org/0000-0001-6330-7526
-      github: ValWood
-- id: goslim_prokaroyte_ribbon
-  title: Prokaryote Ribbon slim
-  preferred label: Bacteria and Archaea (Prokaryotes)
-  type: ribbon
-  status: active
-  description: "Prokaryote GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for prokaryote organisms."
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:2
-    label: Bacteria
-    id: NCBITaxon:2157
-    label: Archaea
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: go-ontology@lists.stanford.edu
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: vw253@cam.ac.uk
+        label: Valerie Wood
+        orcid: orcid:0000-0001-6330-7526
+        github: ValWood
+  - id: goslim_prokaroyte_ribbon
+    title: Prokaryote Ribbon slim
+    label: Bacteria and Archaea (Prokaryotes)
+    role: Ribbon
+    status: active
+    description: "Prokaryote GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for prokaryote organisms."
+    taxa:
+      - id: NCBITaxon:2
+        label: Bacteria
+      - id: NCBITaxon:2157
+        label: Archaea
+    contact: 
+      email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
-      orcid: 
-      github: 
-- id: goslim_synapse
-  title: synapse GO slim
-  type: binning subset
-  status: active
-  description: "Synapse GO slim provided by SynGO. This is the subset of GO terms available for annotation in the SynGO tool."
-  taxon:
-    id: NCBITaxon:9606
-    label: Homo sapiens
-    id: NCBITaxon:10090
-    label: Mus musculus
-    id: NCBITaxon:10116
-    label: Rattus norvegicus
-    id: NCBITaxon:7227
-    label: Drosophila melanogaster
-    id: NCBITaxon:6239
-    label: Caenorhabditis elegans
-    id: NCBITaxon:7955
-    label: Danio rerio
-  contact:
-   - email: pim.van.nierop@gmail.com
-     label: Pim van Nierop
-   - email: frank.koopmans@vu.nl
-     label: Frank Koopmans
-  github: 
-   tracker: https://github.com/geneontology/go-ontology
-   contributors:
-    - email: pim.van.nierop@gmail.com
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: go-ontology@lists.stanford.edu
+        label: GO Ontology Curators
+  - id: goslim_synapse
+    title: synapse GO slim
+    role: Binning
+    status: active
+    description: "Synapse GO slim provided by SynGO. This is the subset of GO terms available for annotation in the SynGO tool."
+    taxa:
+      - id: NCBITaxon:9606
+        label: Homo sapiens
+      - id: NCBITaxon:10090
+        label: Mus musculus
+      - id: NCBITaxon:10116
+        label: Rattus norvegicus
+      - id: NCBITaxon:7227
+        label: Drosophila melanogaster
+      - id: NCBITaxon:6239
+        label: Caenorhabditis elegans
+      - id: NCBITaxon:7955
+        label: Danio rerio
+    contact:
+      email: pim.van.nierop@gmail.com
       label: Pim van Nierop
-      orcid: https://orcid.org/0000-0003-0593-3443
-      github: Pimmelorus
-    - email: frank.koopmans@vu.nl
-      label: Frank Koopmans
-      orcid: https://orcid.org/0000-0002-4973-5732
-      github: ftwkoopmans
-- id: goslim_virus
-  title: Virus slim
-  type: 
-  status: obsolete
-  description: "Archived .obo file can be found at http://release.geneontology.org/2018-08-09/ontology/subsets/goslim_virus.obo."
-  seeAlso: 
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: 
-    label: 
-  github: 
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-- id: goslim_yeast
-  title: Yeast slim
-  type: 
-  status: active
-  description: "Saccharomyces cerevisiae GO slim"
-  seeAlso: 
-  taxon:
-    id: NCBITaxon:559292
-    label: Saccharomyces cerevisiae
-  contact: 
-    email: sgd-helpdesk@lists.stanford.edu
-    label: SGD helpdesk
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: stacia@stanford.edu
-      label: Stacia Engel
-      orcid: http://orcid.org/0000h-0001-5472-917X
-      github: srengel 
-    - email: suzia@stanford.edu
-      label: Suzi Aleksander
-      orcid: http://orcid.org/0000-0001-6787-2901 
-      github: suzialeksander
-- id: obsolete_gosubset_prok
-  title: Prokaryote subset
-  type: 
-  status: obsolete
-  description: "GO terms relevant for prokaryotes. Replaced by taxon constraints. To obtain a GO file relevant for prokaryotes, one should should exclude any term (and children) with the relationships 'never in bacteria' or 'only in eukaryotes' (and subclasses of eukaryotes). The latest version of the gosubset_prok .obo file can be found at http://purl.obolibrary.org/obo/go/releases/2018-06-01/subsets/gosubset_prok.obo"
-  seeAlso: 
-  taxon:
-    id: 
-    label: Bacteria
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-- id: mf_needs_review
-  title: MF terms to be reviewed
-  type: 
-  status: obsolete
-  description: "MF terms to be reviewed. Terms reviewed in 2018, see https://github.com/geneontology/go-ontology/issues/16166. Archived .obo file can be found at http://release.geneontology.org/2018-07-02/ontology/subsets/mf_needs_review.obo".
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-  tracker: https://github.com/geneontology/go-ontology/issues
-  contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-- id: termgenie_unvetted
-  title: Term Genie terms to be reviewed
-  type: 
-  status: obsolete
-  description: "Term Genie terms to be reviewed."
-  seeAlso: 
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-- id: obsolete_virus_checked
-  title: Virus checked
-  type: 
-  status: obsolete
-  description: "Terms approved by the Virus working group (2010). Archived .obo file can be found at http://release.geneontology.org/2018-08-09/ontology/subsets/virus_checked.obo."
-  seeAlso: 
-  taxon:
-    id: 
-    label: 
-  contact: 
-    email: go-ontology@lists.stanford.edu
-    label: GO Ontology Curators
-  github:
-   tracker: https://github.com/geneontology/go-ontology/issues
-   contributors:
-    - email: 
-      label:
-      orcid:  
-      github: 
-      
+    tracker: https://github.com/geneontology/go-ontology
+    contributors:
+      - email: pim.van.nierop@gmail.com
+        label: Pim van Nierop
+        orcid: orcid:0000-0003-0593-3443
+        github: Pimmelorus
+      - email: frank.koopmans@vu.nl
+        label: Frank Koopmans
+        orcid: orcid:0000-0002-4973-5732
+        github: ftwkoopmans
+  - id: goslim_virus
+    title: Virus slim
+    status: obsolete
+    description: Virus-relevant terms
+    archived_url: "http://release.geneontology.org/2018-08-09/ontology/subsets/goslim_virus.obo."
+    taxa:
+      - id: NCBITaxon:10239
+        label: Viruses
+    tracker: https://github.com/geneontology/go-ontology/issues
+  - id: goslim_yeast
+    title: Yeast slim
+    status: active
+    role: Binning
+    description: "Saccharomyces cerevisiae GO slim"
+    taxa:
+      - id: NCBITaxon:559292
+        label: Saccharomyces cerevisiae
+    contact: 
+      email: sgd-helpdesk@lists.stanford.edu
+      label: SGD helpdesk
+    tracker: https://github.com/geneontology/go-ontology/issues
+    contributors:
+      - email: stacia@stanford.edu
+        label: Stacia Engel
+        orcid: orcid:0000-0001-5472-917X
+        github: srengel 
+      - email: suzia@stanford.edu
+        label: Suzi Aleksander
+        orcid: orcid:0000-0001-6787-2901 
+        github: suzialeksander
+  - id: obsolete_gosubset_prok
+    title: Prokaryote subset
+    status: obsolete
+    description: "GO terms relevant for prokaryotes. Replaced by taxon constraints. To obtain a GO file relevant for prokaryotes, one should should exclude any term (and children) with the relationships 'never in bacteria' or 'only in eukaryotes' (and subclasses of eukaryotes). The latest version of the gosubset_prok .obo file can be found at http://purl.obolibrary.org/obo/go/releases/2018-06-01/subsets/gosubset_prok.obo"
+    taxa:
+      - id: NCBITaxon:2
+        label: Bacteria
+    contact: 
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+  - id: mf_needs_review
+    title: MF terms to be reviewed
+    status: obsolete
+    description: "MF terms to be reviewed. Terms reviewed in 2018."
+    archived_url: http://release.geneontology.org/2018-07-02/ontology/subsets/mf_needs_review.obo
+    contact:
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+    see_also:
+      - https://github.com/geneontology/go-ontology/issues/16166
+  - id: termgenie_unvetted
+    title: Term Genie terms to be reviewed
+    status: obsolete
+    description: "Term Genie terms to be reviewed."
+    contact: 
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues
+  - id: obsolete_virus_checked
+    title: Virus checked
+    status: obsolete
+    description: "Terms approved by the Virus working group (2010)."
+    archived_url: http://release.geneontology.org/2018-08-09/ontology/subsets/virus_checked.obo
+    taxa:
+      - id: NCBITaxon:10239
+        label: Viruses
+    contact:
+      email: go-ontology@lists.stanford.edu
+      label: GO Ontology Curators
+    tracker: https://github.com/geneontology/go-ontology/issues

--- a/src/ontology/subsets/go_subsets_metadata.yaml
+++ b/src/ontology/subsets/go_subsets_metadata.yaml
@@ -4,7 +4,7 @@ subsets:
   - id: goantislim_grouping
     title: GO antislim
     role: ExclusionList
-    label: goantislim
+    short_label: goantislim
     status: obsolete
     description: Grouping classes that can be excluded in enrichment analyses etc.
     archived_url: http://release.geneontology.org/2018-08-09/ontology/subsets/goantislim_grouping.obo
@@ -18,7 +18,7 @@ subsets:
   - id: gocheck_do_not_annotate
     title: GO antislim
     role: ExclusionList
-    label: Do not annotate
+    short_label: Do not annotate
     status: active
     description: "Terms that are too high level to be informative for annotation."
     taxa:
@@ -33,7 +33,7 @@ subsets:
         label: GO Ontology Curators
   - id: gocheck_do_not_manually_annotate
     title: Terms not allowed for manual annotation
-    label: Do not manually annotate
+    short_label: Do not manually annotate
     status: obsolete
     replaced_by:
       - gocheck_do_not_annotate
@@ -50,14 +50,14 @@ subsets:
       label: GO Ontology Curators
   - id: gocheck_obsoletion_candidate
     title: Obsoletion candidate subset
-    label: Obsoletion candidate subset
+    short_label: Obsoletion candidate subset
     role: ExclusionList
     status: active
     description: "Terms that are scheduled for obsoletion."
     taxa:
       - id: NCBITaxon:1
         label: all organisms
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -67,13 +67,13 @@ subsets:
   - id: goslim_agr
     title: AGR slim
     role: Ribbon
-    label: Animals and fungi (Opisthokonta)
+    short_label: Animals and fungi (Opisthokonta)
     status: active
     description: "Subset for Alliance of Genome Resources (AGR). The purpose of this subsets is mainly to drive the 'ribbon' display."
     taxa:
       - id: NCBITaxon:33154
         label: Opisthokonta
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -83,13 +83,14 @@ subsets:
         orcid: orcid:0000-0001-7732-3295
   - id: goslim_aspergillus
     title: Aspergillus slim
+    short_label: Aspergillus
     role: Binning
     status: obsolete
     description: "Aspergillus GO slim."
     taxa:
       - id: NCBITaxon:5052
-        label: Aspergillus 
-    contact: 
+        label: Aspergillus
+    contact:
       email: candida-curator@lists.stanford.edu
       label: CDG helpdesk
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -100,13 +101,14 @@ subsets:
         github: jlewsmith
   - id: goslim_candida
     title: Candida slim
+    short_label: Candida
     role: Binning
     status: active
     description: "Candida GO slim."
-    taxa: 
+    taxa:
       - id: NCBITaxon:1535326
         label: Candida
-    contact: 
+    contact:
       email: candida-curator@lists.stanford.edu
       label: CGD helpdesk
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -117,13 +119,14 @@ subsets:
         github: jlewsmith
   - id: goslim_chembl
     title: ChEMBL slim
+    short_label: ChEMBL
     role: Binning
     status: active
     description: "Subset for ChEMBL."  ## TODO: add more details
     taxa:
       - id: NCBITaxon:1
         label: all organisms
-    contact: 
+    contact:
       email: bzdrazil@ebi.ac.uk
       label: Barbara Zdrazil
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -134,14 +137,14 @@ subsets:
         github: BZdrazil
   - id: goslim_drosophila
     title: Drosophila subset
-    label: Insects
+    short_label: Insects
     role: Binning
     status: active
     description: "GO subset for insects. This subset can be used for binning purposes, most annotations should map to a term in the subset."
     taxa:
       - id: NCBITaxon:50557
         label: Insecta
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -152,14 +155,14 @@ subsets:
           github: hattrill
   - id: goslim_euk_cellular_processes_ribbon
     title: GO ribbon for eukaroytic cellular processes
-    label: GO ribbon for eukaroytic cellular processes
+    short_label: Eukaroytic cellular processes
     role: Ribbon
     status: active
     description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for cellular processes in eukaryotes."
     taxa:
       - id: NCBITaxon:2759
         label: Eukaryota
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -168,14 +171,14 @@ subsets:
         label: GO Ontology Curators
   - id: goslim_flyBase_ribbon
     title: FlyBase Ribbon slim
-    label: Insects  ## TODO: I don't think this is a good name
+    short_label: Insects
     role: Ribbon
     status: active
     description: "Insect GO ribbon subset produced by FlyBase. The purpose of this subset is mainly to drive the Flybase and the UniProt 'ribbon' display."
     taxa:
       - id: NCBITaxon:50557
         label: Insecta
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -187,7 +190,7 @@ subsets:
   - id: goslim_generic
     title: Generic GO subset
     role: Binning
-    label: All organisms
+    short_label: All organisms
     status: active
     description: Generic GO subset. Applies to all species. This slim can be used for binning purposes, 
       most annotations should map to a term in the slim.
@@ -208,6 +211,7 @@ subsets:
     archived_url: "http://cvsweb.geneontology.org/cgi-bin/cvsweb.cgi/go/GO_slims/archived_GO_slims/goslim_goa.2002?rev=1.4;content-type=text%2Fplain."
   - id: goslim_metagenomics
     title: Metagenomics slim
+    short_label: Metagenomics
     status: unknown
     description: A slim for high-level visualisation of the functional profile of metagenomic samples
     see_also:
@@ -231,13 +235,14 @@ subsets:
         github: mdolanme
   - id: goslim_pir
     title: PIR slim
+    short_label: PIR
     role: Binning
     status: active
     description: "PIR (Protein Information Resource) slim"  ## TODO: better describe this
     taxa:
       - id: NCBITaxon:1
         label: all organisms
-    contact: 
+    contact:
       email: dan5@georgetown.edu
       label: Darren Natale
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -248,7 +253,7 @@ subsets:
         github: nataled
   - id: goslim_plant_ribbon
     title: Plant Ribbon subset
-    label: Plants
+    short_label: Plants
     role: Ribbon
     status: active
     description: "GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for plant and algae species."
@@ -261,13 +266,14 @@ subsets:
         label: GO Ontology Curators
   - id: goslim_plant
     title: Plant slim
+    short_label: Plants
     role: Binning
     status: active
     description: "Plant GO subset."
-    taxa: 
+    taxa:
       - id: NCBITaxon:33090
         label: Viridiplantae
-    contact: 
+    contact:
       email: curator@arabidopsis.org
       label: TAIR helpdesk
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -278,13 +284,14 @@ subsets:
         github: tberardini
   - id: goslim_pombe
     title: Schizosaccharomyces pombe slim
+    short_label: Schizosaccharomyces pombe
     role: Binning
     status: active
     description: "Schizosaccharomyces pombe GO subset."
     taxa:
       - id: NCBITaxon:4896
         label: Schizosaccharomyces pombe
-    contact: 
+    contact:
       email: vw253@cam.ac.uk
       label: Valerie Wood
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -295,7 +302,7 @@ subsets:
         github: ValWood
   - id: goslim_prokaroyte_ribbon
     title: Prokaryote Ribbon slim
-    label: Bacteria and Archaea (Prokaryotes)
+    short_label: Bacteria and Archaea (Prokaryotes)
     role: Ribbon
     status: active
     description: "Prokaryote GO ribbon subset that mainly serves to drive the UniProt 'ribbon' display for prokaryote organisms."
@@ -304,7 +311,7 @@ subsets:
         label: Bacteria
       - id: NCBITaxon:2157
         label: Archaea
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -313,6 +320,7 @@ subsets:
         label: GO Ontology Curators
   - id: goslim_synapse
     title: synapse GO slim
+    short_label: SynGO
     role: Binning
     status: active
     description: "Synapse GO slim provided by SynGO. This is the subset of GO terms available for annotation in the SynGO tool."
@@ -344,6 +352,7 @@ subsets:
         github: ftwkoopmans
   - id: goslim_virus
     title: Virus slim
+    short_label: Viruses
     status: obsolete
     description: Virus-relevant terms
     archived_url: "http://release.geneontology.org/2018-08-09/ontology/subsets/goslim_virus.obo."
@@ -359,7 +368,7 @@ subsets:
     taxa:
       - id: NCBITaxon:559292
         label: Saccharomyces cerevisiae
-    contact: 
+    contact:
       email: sgd-helpdesk@lists.stanford.edu
       label: SGD helpdesk
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -367,10 +376,10 @@ subsets:
       - email: stacia@stanford.edu
         label: Stacia Engel
         orcid: orcid:0000-0001-5472-917X
-        github: srengel 
+        github: srengel
       - email: suzia@stanford.edu
         label: Suzi Aleksander
-        orcid: orcid:0000-0001-6787-2901 
+        orcid: orcid:0000-0001-6787-2901
         github: suzialeksander
   - id: obsolete_gosubset_prok
     title: Prokaryote subset
@@ -379,7 +388,7 @@ subsets:
     taxa:
       - id: NCBITaxon:2
         label: Bacteria
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues
@@ -398,7 +407,7 @@ subsets:
     title: Term Genie terms to be reviewed
     status: obsolete
     description: "Term Genie terms to be reviewed."
-    contact: 
+    contact:
       email: go-ontology@lists.stanford.edu
       label: GO Ontology Curators
     tracker: https://github.com/geneontology/go-ontology/issues

--- a/src/ontology/subsets/subsets.jsonschema.json
+++ b/src/ontology/subsets/subsets.jsonschema.json
@@ -1,0 +1,316 @@
+{
+    "$defs": {
+        "Agent": {
+            "additionalProperties": false,
+            "description": "An individual, organization, or group",
+            "properties": {
+                "email": {
+                    "description": "The email address of the person or group",
+                    "pattern": "^[^\\s]+@[^\\s]+\\.[^\\s]+$",
+                    "type": "string"
+                },
+                "github": {
+                    "description": "The GitHub username for the person or group",
+                    "pattern": "^\\S+$",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The human-readable name for the person or group",
+                    "type": "string"
+                },
+                "orcid": {
+                    "description": "The ORCID identifier for the person or group",
+                    "pattern": "orcid:\\d{4}\\-\\d{4}\\-\\d{4}\\-[X\\d{4}]",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "email",
+                "label"
+            ],
+            "title": "Agent",
+            "type": "object"
+        },
+        "Contact": {
+            "additionalProperties": false,
+            "description": "The primary contact person for a subset",
+            "properties": {
+                "email": {
+                    "description": "The email address of the person or group",
+                    "pattern": "^[^\\s]+@[^\\s]+\\.[^\\s]+$",
+                    "type": "string"
+                },
+                "github": {
+                    "description": "The GitHub username for the person or group",
+                    "pattern": "^\\S+$",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The human-readable name for the person or group",
+                    "type": "string"
+                },
+                "orcid": {
+                    "description": "The ORCID identifier for the person or group",
+                    "pattern": "orcid:\\d{4}\\-\\d{4}\\-\\d{4}\\-[X\\d{4}]",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "email",
+                "label"
+            ],
+            "title": "Contact",
+            "type": "object"
+        },
+        "Contributor": {
+            "additionalProperties": false,
+            "description": "People or organizations who have contributed to the subset",
+            "properties": {
+                "email": {
+                    "description": "The email address of the person or group",
+                    "pattern": "^[^\\s]+@[^\\s]+\\.[^\\s]+$",
+                    "type": "string"
+                },
+                "github": {
+                    "description": "The GitHub username for the person or group",
+                    "pattern": "^\\S+$",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The human-readable name for the person or group",
+                    "type": "string"
+                },
+                "orcid": {
+                    "description": "The ORCID identifier for the person or group",
+                    "pattern": "orcid:\\d{4}\\-\\d{4}\\-\\d{4}\\-[X\\d{4}]",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "email",
+                "label"
+            ],
+            "title": "Contributor",
+            "type": "object"
+        },
+        "StatusEnum": {
+            "description": "",
+            "enum": [
+                "active",
+                "obsolete",
+                "unknown"
+            ],
+            "title": "StatusEnum",
+            "type": "string"
+        },
+        "Subset": {
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "status": {
+                                "const": "active"
+                            }
+                        },
+                        "required": [
+                            "status"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "description": {},
+                            "role": {},
+                            "tracker": {}
+                        },
+                        "required": [
+                            "role",
+                            "description",
+                            "tracker"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "archived_url": {}
+                        },
+                        "required": [
+                            "archived_url"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "status": {
+                                "const": "obsolete"
+                            }
+                        },
+                        "required": [
+                            "status"
+                        ]
+                    }
+                }
+            ],
+            "description": "",
+            "properties": {
+                "archived_url": {
+                    "description": "The URL of the archived subset",
+                    "type": "string"
+                },
+                "contact": {
+                    "$ref": "#/$defs/Contact",
+                    "description": "The primary contact person for the subset. Every active subset must have a contact person. There is a max of one contact, list others under contributors."
+                },
+                "contributors": {
+                    "description": "People or organizations who have contributed to the subset",
+                    "items": {
+                        "$ref": "#/$defs/Contributor"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "A description of the subset",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "subsets are identified by symbols such as goslim_agr",
+                    "pattern": "^[a-zA-Z_]+$",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "A human-readable name for the subset",
+                    "type": "string"
+                },
+                "replaced_by": {
+                    "description": "The subset that replaces this one",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "role": {
+                    "$ref": "#/$defs/SubsetTypeEnum",
+                    "description": "A slim or subset is built for a particular purpose or role."
+                },
+                "see_also": {
+                    "description": "URLs to related resources or information",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "$ref": "#/$defs/StatusEnum",
+                    "description": "The maintenance status of the subset"
+                },
+                "taxa": {
+                    "description": "The taxa to which the subset applies",
+                    "items": {
+                        "$ref": "#/$defs/Taxon"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "A human-readable long-form name for the subset",
+                    "type": "string"
+                },
+                "tracker": {
+                    "description": "The URL of the tracker for the subset",
+                    "pattern": "^https://github.com/geneontology[^\\s]+$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "title",
+                "status"
+            ],
+            "title": "Subset",
+            "type": "object"
+        },
+        "SubsetCollection": {
+            "additionalProperties": false,
+            "description": "A collection of metadata about subsets",
+            "properties": {
+                "description": {
+                    "description": "A description of the collection",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "subsets": {
+                    "description": "all subsets in a collection",
+                    "items": {
+                        "$ref": "#/$defs/Subset"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "title": "SubsetCollection",
+            "type": "object"
+        },
+        "SubsetTypeEnum": {
+            "description": "A slim or subset is built for a particular purpose or role. This enumeration includes the allowed values",
+            "enum": [
+                "ExclusionList",
+                "Binning",
+                "Ribbon",
+                "Tag"
+            ],
+            "title": "SubsetTypeEnum",
+            "type": "string"
+        },
+        "Taxon": {
+            "additionalProperties": false,
+            "description": "A taxonomic classification",
+            "properties": {
+                "id": {
+                    "description": "The identifier for the taxon. Should be from NCBI Taxonomy",
+                    "pattern": "^NCBITaxon:\\d+$",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The human-readable name for the taxon",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "label"
+            ],
+            "title": "Taxon",
+            "type": "object"
+        }
+    },
+    "$id": "http://w3id.org/oaklib/ontology_subset_schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "description": "A collection of metadata about subsets",
+    "metamodel_version": "1.7.0",
+    "properties": {
+        "description": {
+            "description": "A description of the collection",
+            "type": "string"
+        },
+        "id": {
+            "type": "string"
+        },
+        "subsets": {
+            "description": "all subsets in a collection",
+            "items": {
+                "$ref": "#/$defs/Subset"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "id"
+    ],
+    "title": "ontology_subset_schema",
+    "type": "object",
+    "version": null
+}

--- a/src/ontology/subsets/subsets.jsonschema.json
+++ b/src/ontology/subsets/subsets.jsonschema.json
@@ -177,10 +177,6 @@
                     "pattern": "^[a-zA-Z_]+$",
                     "type": "string"
                 },
-                "label": {
-                    "description": "A human-readable name for the subset",
-                    "type": "string"
-                },
                 "replaced_by": {
                     "description": "The subset that replaces this one",
                     "items": {
@@ -198,6 +194,10 @@
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "short_label": {
+                    "description": "A short human-readable name for the subset. For subsets that are based on species on taxonomy this should typically be the common name (pluralized) of the taxon. The short label is not guaranteed to be globally unique but it must be unique for any given role.",
+                    "type": "string"
                 },
                 "status": {
                     "$ref": "#/$defs/StatusEnum",

--- a/src/ontology/subsets/subsets.schema.yaml
+++ b/src/ontology/subsets/subsets.schema.yaml
@@ -71,9 +71,12 @@ classes:
         required: true
         slot_uri: dcterms:title
         description: A human-readable long-form name for the subset
-      label:
+      short_label:
         slot_uri: rdfs:label
-        description: A human-readable name for the subset
+        description: A short human-readable name for the subset. For subsets that
+          are based on species on taxonomy this should typically be the common name
+          (pluralized) of the taxon. The short label is not guaranteed to be globally
+          unique but it must be unique for any given role.
       role:
         aliases:
           - type
@@ -119,6 +122,11 @@ classes:
       archived_url:
         range: uri
         description: The URL of the archived subset
+    unique_keys:
+      short_name_unique:
+        unique_key_slots:
+          - short_name
+          - role
     rules:
       - description: Active subsets must have a role, description, and tracker
         preconditions:

--- a/src/ontology/subsets/subsets.schema.yaml
+++ b/src/ontology/subsets/subsets.schema.yaml
@@ -77,6 +77,9 @@ classes:
           are based on species on taxonomy this should typically be the common name
           (pluralized) of the taxon. The short label is not guaranteed to be globally
           unique but it must be unique for any given role.
+        comments:
+          - "The short label may be used in UIs and displays - for example, GO ribbon displays.
+             Because it is guaranteed unique within the 'Ribbon' role it will be unambiguous"
       role:
         aliases:
           - type

--- a/src/ontology/subsets/subsets.schema.yaml
+++ b/src/ontology/subsets/subsets.schema.yaml
@@ -1,71 +1,187 @@
-type: map
-mapping:
-  "id":
-    type: str
-    required: true
-  "title":
-    type: str
-    required: true
-  "preferred label":
-    type: str
-    required: true
-  "type":
-    type: str
-    required: true
-    enum: [blacklist, binning subset, ribbon, tag]
-  "status":
-    type: str
-    required: true
-    enum: [active, obsolete]
-  "description":
-    type: str
-    required: true
-  "taxon": 
-    - type: map
-      mapping:
-        "id":
-          type: str
-          required: true
-          pattern: /NCBITaxon\:\d+/
-        "label":
-          type: str
-          required: true
-  "github":
-    - type: map
-      mapping:
-        "tracker":
-          type: string
-          required: true+
-          pattern: /https:\/\/github\.com\/geneontology[^\s]+/
-  "contact":
-    - type: map
-      mapping:
-        "email":
-          type: str
-          required: true
-          pattern: /[^\s]+@[^\s]+\.[^\s]+/
-        "label":
-          type: str
-          required: true
-  "contributors":
-    - type: map
-      mapping:
-        "email":
-          type: str
-          required: true
-          pattern: /[^\s]+@[^\s]+\.[^\s]+/
-        "label":
-          type: str
-          required: true
-        "orcid":
-          type: str
-          required: false
-          pattern: /https:\/\/orcid.org\/\d{4}\-\d{4}\-\d{4}\-\d{4}/
-        "github":
-          type: str
-          required: false
+id: http://w3id.org/oaklib/ontology_subset_schema
+name: ontology_subset_schema
+imports:
+- linkml:types
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ontology_subset_schema: http://example.org/test-schema/
+  orcid: https://orcid.org/
+  oio: http://www.geneontology.org/formats/oboInOwl#
+  dcterms: http://purl.org/dc/terms/
+  bibo: http://purl.org/ontology/bibo/  
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  datacite: http://purl.org/spar/datacite/  
+  schema: http://schema.org/
+  biolink: https://w3id.org/biolink/
+default_prefix: ontology_subset_schema
+default_range: string
 
-   
-    
+enums:
+  SubsetTypeEnum:
+    description: A slim or subset is built for a particular purpose or role.
+      This enumeration includes the allowed values
+    permissible_values:
+      ExclusionList:
+        aliases:
+          - Blacklist
+          - Anti-slim
+        description: Contains a negative set of terms to be excluded for some purpose.
+          There is typically no limit to the size of an exclusion list.
+      Binning:
+        description: Used for rolling up and binning genes.
+      Ribbon:
+        description: Used for visualization in a ribbon-type display. Ribbons should not include
+          terms that are in direct or indirect hierarchical relationship with each other. Ribbons
+          also seek to minimize overlap in genes annotated to different terms where possible.
+      Tag: {}
+  StatusEnum:
+    permissible_values:
+      active:
+        description: Actively maintained. All terms in the subset are active (not obsolete) in the ontology.
+      obsolete:
+        description: No longer maintained. An archived_url should be provided where possible.
+      unknown:
+        description: Unknown, unstated
+classes:
+  SubsetCollection:
+    description: A collection of metadata about subsets
+    tree_root: true
+    attributes:
+      id:
+        required: true
+        identifier: true
+        range: uri
+      subsets:
+        description: all subsets in a collection
+        range: Subset
+        multivalued: true
+        inlined_as_list: true
+      description:
+        slot_uri: dcterms:description
+        description: A description of the collection
+  Subset:
+    class_uri: oio:Subset
+    attributes:
+      id:
+        required: true
+        identifier: true
+        description: subsets are identified by symbols such as goslim_agr
+        pattern: ^[a-zA-Z_]+$
+      title:
+        required: true
+        slot_uri: dcterms:title
+        description: A human-readable long-form name for the subset
+      label:
+        slot_uri: rdfs:label
+        description: A human-readable name for the subset
+      role:
+        aliases:
+          - type
+          - category
+        range: SubsetTypeEnum
+        description: A slim or subset is built for a particular purpose or role.
+      status:
+        slot_uri: bibo:status        
+        range: StatusEnum
+        required: true
+        description: The maintenance status of the subset
+      description:
+        slot_uri: dcterms:description
+        description: A description of the subset
+      taxa:
+        range: Taxon
+        inlined_as_list: true
+        multivalued: true
+        description: The taxa to which the subset applies
+      tracker:
+        pattern: ^https://github.com/geneontology[^\s]+$
+        description: The URL of the tracker for the subset
+      contact:
+        range: Contact
+        description: The primary contact person for the subset.
+          Every active subset must have a contact person.
+          There is a max of one contact, list others under contributors.
+      contributors:
+        slot_uri: dcterms:contributor
+        range: Contributor
+        multivalued: true
+        description: People or organizations who have contributed to the subset
+      see_also:
+        slot_uri: rdfs:seeAlso
+        range: uri
+        multivalued: true
+        description: URLs to related resources or information
+      replaced_by:
+        slot_uri: oio:replacedBy
+        range: Subset
+        description: The subset that replaces this one
+        multivalued: true
+      archived_url:
+        range: uri
+        description: The URL of the archived subset
+    rules:
+      - description: Active subsets must have a role, description, and tracker
+        preconditions:
+          slot_conditions:
+            status:
+              equals_string: active
+        postconditions:
+          slot_conditions:
+            role:
+              required: true
+            description:
+              required: true
+            tracker:
+              required: true
+      - description: Archived URLs only apply to obsolete subsets
+        preconditions:
+          slot_conditions:
+            archived_url:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            status:
+              equals_string: obsolete
+  Taxon:
+    description: A taxonomic classification
+    class_uri: biolink:OrganismTaxon
+    attributes:
+      id:
+        description: The identifier for the taxon. Should be from NCBI Taxonomy
+        required: true
+        identifier: true
+        pattern: ^NCBITaxon:\d+$
+        id_prefixes:
+          - NCBITaxon
+      label:
+        slot_uri: rdfs:label
+        required: true
+        description: The human-readable name for the taxon
+  Agent:
+    description: An individual, organization, or group
+    attributes:
+      email:
+        required: true
+        pattern: ^[^\s]+@[^\s]+\.[^\s]+$
+        slot_uri: schema:email
+        description: The email address of the person or group
+      label:
+        required: true
+        slot_uri: rdfs:label
+        description: The human-readable name for the person or group
+      orcid:
+        recommended: true
+        slot_uri: datacite:orcid
+        pattern: orcid:\d{4}\-\d{4}\-\d{4}\-[X\d{4}]
+        description: The ORCID identifier for the person or group
+      github:
+        recommended: true
+        pattern: ^\S+$
+        description: The GitHub username for the person or group
+  Contact:
+    is_a: Agent
+    description: The primary contact person for a subset
+  Contributor:
+    is_a: Agent
+    description: People or organizations who have contributed to the subset
 
- 


### PR DESCRIPTION
Fixes #27400

Updates subsets metadata and added a schema

Added metadata fields for

- archived_url
- see_also

Previous versions used a kwalify schema which is no longer supported.
Schema is now in LinkML which allows for more flexibility.

- added text descriptions for all fields
- added URIs for common metadata elements

LinkML also allows for rules so we can say "if a subset is active
then it must have a description, tracker, and a context" (ideally we would
place this constraint on all but there are legacy subsets we don't
have this for.


@alexsign you can use either the linkml or the jsonschema. Can also generate java classes, pydantic, etc if helpful

TODO (possibly other PRs):

- [ ] add checks to github actions (@balhoff @kltm we are using latest-ish version of odk? in which case linkml is included)
- [x] discuss with @pgaudet about label vs title
- [ ] make an OBO PURL that resolves to this

Note that validation is not yet integrated into gh actions. For now,
do this:

    linkml-validate -s subsets.schema.yaml go_subsets_metadata.yaml

Or simply

   make validate
