### PR TITLE
Run SPARQL checks on enhanced.owl rather than raw edit file.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -620,7 +620,7 @@ VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-l
 
 # run all violation checks
 VARGS = $(foreach V,$(VCHECKS), $(SPARQLDIR)/$V-violation.sparql)
-sparql_test: $(SRC) reasoned.owl
+sparql_test: enhanced.owl reasoned.owl
 	$(ROBOT) verify --input $< --queries $(VARGS) -O reports/
 	# These purposely aren't checking problems in imports
 	$(ROBOT) verify --input reasoned.owl --queries $(SPARQLDIR)/multiple-class-links-violation.sparql $(SPARQLDIR)/obsolete-reference-violation.sparql $(SPARQLDIR)/missing_superclass-violation.sparql -O reports/


### PR DESCRIPTION
This keeps the GitHub actions CI aligned with the checks in the full build. Previously the full build was failing because a check was running before `robot repair` had run.