### PR TITLE
Don't filter annotations out of ECO import for go-amigo.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -530,6 +530,7 @@ mirror/pr.owl: mirror/pr-download.owl
 mirror/opl.owl: mirror/opl-download.owl
 	$(OWLTOOLS) $< $(FILTER_EXTERNAL) --remove-axioms-about -d -v OPL -o $@
 
+# Avoid filtering annotations out via owltools. dbxrefs for three-letter codes are needed in Amigo.
 mirror/eco.owl: mirror/eco-download.owl
 	cp $< $@
 

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -530,6 +530,9 @@ mirror/pr.owl: mirror/pr-download.owl
 mirror/opl.owl: mirror/opl-download.owl
 	$(OWLTOOLS) $< $(FILTER_EXTERNAL) --remove-axioms-about -d -v OPL -o $@
 
+mirror/eco.owl: mirror/eco-download.owl
+	cp $< $@
+
 mirror/%.owl: mirror/%-download.owl
 	$(OWLTOOLS) $< $(FILTER_EXTERNAL) -o $@
 .PRECIOUS: mirror/%.owl


### PR DESCRIPTION
This should restore inclusion of xref three-letter codes in go-amigo.owl. For https://github.com/geneontology/noctua/issues/860. Possibly related to https://github.com/geneontology/amigo/issues/716.