### PR TITLE
Update only_in_taxon.tsv

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -926,4 +926,3 @@ GO:0010736	serum response element binding	NCBITaxon:6072	Eumetazoa
 GO:0009887	animal organ morphogenesis	NCBITaxon:6072	Eumetazoa	
 GO:0010236	plastoquinone biosynthetic process	NCBITaxon:33090	Viridiplantae	
 GO:0051960	regulation of nervous system development	NCBITaxon:6072	Eumetazoa	
-GO:0097271	protein localization to bud neck	NCBITaxon:47537	Saccharomycotina	


### PR DESCRIPTION
removed
GO:0097271 protein localization to bud neck

saccharotina
https://github.com/geneontology/go-ontology/issues/27455