### PR TITLE
Save go-edit.obo using Protege 5.6.4

### DIFF
--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -3,4 +3,4 @@
 # Any updates to the odkfull version MUST be coordinated with geneontology/pipeline.
 # When updating the odkfull version, remember to also update the GitHub Actions workflows.
 
-docker run -m 12g  -v $PWD/../../:/work -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.4 "$@"
+docker run -m 12g  -v $PWD/../../:/work -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.5.1 "$@"


### PR DESCRIPTION
I think all changes are related to compaction of IAO:0000233 when used in an axiom annotation, and a few tweaks to usages of the creation_date tag. But it results in a large diff, so we all need to switch to this Protege at the same time.