### PR TITLE
Refresh Reactome imports.

### DIFF
--- a/src/ontology/imports/reactome_xrefs_import.owl
+++ b/src/ontology/imports/reactome_xrefs_import.owl
@@ -8,7 +8,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/go/imports/reactome_xrefs_import.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/go/releases/2024-02-21/imports/reactome_xrefs_import.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/go/releases/2024-11-15/imports/reactome_xrefs_import.owl"/>
     </owl:Ontology>
     
 
@@ -175,6 +175,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-156912</owl:annotatedTarget>
         <rdfs:label>Peptide transfer from P-site tRNA to the A-site tRNA</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0000062">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8848247</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0000062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8848247</owl:annotatedTarget>
+        <rdfs:label>ACBD4,5 bind MCFA-CoA and LCFA-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0000064">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70634</oboInOwl:hasDbXref>
@@ -708,6 +717,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-1855194</owl:annotatedTarget>
         <rdfs:label>1-PP-IP5 is phosphorylated to 1,5-(PP)2-IP4 by IP6K1/3 in the cytosol</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0000900">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5690886</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0000900"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5690886</owl:annotatedTarget>
+        <rdfs:label>ACO1, IREB2 bind IREs in TFRC, ALAD, FTL, FTH1 mRNAs</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0001055">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6814549</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6814559</oboInOwl:hasDbXref>
@@ -733,6 +751,50 @@
         <owl:annotatedTarget>Reactome:R-HSA-1964482</owl:annotatedTarget>
         <rdfs:label>RNA polymerase III transcribes microbial dsDNA to dsRNA</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0001228">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856539</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856546</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856548</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856549</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856550</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856604</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856539</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds PKLR gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856546</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds FASN gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856548</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds ACACB gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856549</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds ACLY gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856550</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds ACACA gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856604</owl:annotatedTarget>
+        <rdfs:label>MLXIPL:MLX binds AGPAT1 gene promoter</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0001512">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8936519</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -750,12 +812,6 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001517"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2046222</owl:annotatedTarget>
-        <rdfs:label>CHST2,5,6 transfer SO4(2-) to GlcNAc residues on keratan-PG to form KSPG</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001517"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-3656269</owl:annotatedTarget>
         <rdfs:label>Defective CHST6 does not transfer SO4(2-) to GlcNAc residues on keratan-PG</rdfs:label>
     </owl:Axiom>
@@ -764,6 +820,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-6786012</owl:annotatedTarget>
         <rdfs:label>CHST4 transfers SO4(2-) from PAPS to Core 2 mucins</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001517"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2046222</owl:annotatedTarget>
+        <rdfs:label>CHST2,5,6 transfer SO4(2-) to GlcNAc residues on keratan-PG to form KSPG</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0001537">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2022063</oboInOwl:hasDbXref>
@@ -805,12 +867,6 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001665"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9846305</owl:annotatedTarget>
-        <rdfs:label>ST6GALNAC5,6 transfer Neu5Ac to GM1b</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001665"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-4084980</owl:annotatedTarget>
         <rdfs:label>ST6GALNAC1-6 transfer Neu5Ac to terminal GalNAc (alpha-2,6 link)</rdfs:label>
     </owl:Axiom>
@@ -819,6 +875,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9603991</owl:annotatedTarget>
         <rdfs:label>ST6GALNAC6 transfers Neu5Ac to Type 1 MSGG to form Type 1 DSGG</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0001665"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9846305</owl:annotatedTarget>
+        <rdfs:label>ST6GALNAC5,6 transfer Neu5Ac to GM1b</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0001671">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5251955</oboInOwl:hasDbXref>
@@ -943,7 +1005,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0002083"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162192</owl:annotatedTarget>
-        <rdfs:label>PHB and all-E-10PrP2 are combined into DHB by COQ2</rdfs:label>
+        <rdfs:label>COQ2 ligates all-E-10PrP2 to PHB</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0002151">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9836998</oboInOwl:hasDbXref>
@@ -987,6 +1049,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-176264</owl:annotatedTarget>
         <rdfs:label>Recruitment of the Rad9-Hus1-Rad1 complex to DNA</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003700">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-163666</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003700"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-163666</owl:annotatedTarget>
+        <rdfs:label>Formation of ChREBP:MLX heterodimer</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003720">
         <oboInOwl:hasDbXref>Reactome:R-HSA-163090</oboInOwl:hasDbXref>
@@ -1625,6 +1696,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-8869206</owl:annotatedTarget>
         <rdfs:label>PAFAH2 hydrolyses PAF to lyso-PAF and acetate</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003851">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-6785933</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003851"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-6785933</owl:annotatedTarget>
+        <rdfs:label>UGT8 transfers Gal from UDP-Gal to CERA</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003854">
         <oboInOwl:hasDbXref>Reactome:R-HSA-192097</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-193789</oboInOwl:hasDbXref>
@@ -1787,12 +1867,19 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003860">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70881</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9916727</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003860"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70881</owl:annotatedTarget>
         <rdfs:label>beta-hydroxyisobutyryl-CoA + H2O =&gt; beta-hydroxyisobutyrate + CoA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003860"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9916727</owl:annotatedTarget>
+        <rdfs:label>HIBCH mutants don&apos;t synthesize beta-hydroxyisobutyrate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003865">
         <oboInOwl:hasDbXref>Reactome:R-HSA-469659</oboInOwl:hasDbXref>
@@ -1833,7 +1920,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003868"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71163</owl:annotatedTarget>
-        <rdfs:label>p-hydroxyphenylpyruvate + O2 =&gt; homogentisate + CO2</rdfs:label>
+        <rdfs:label>HPD dioxygenates HPP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003870">
         <oboInOwl:hasDbXref>Reactome:R-HSA-189442</oboInOwl:hasDbXref>
@@ -2248,7 +2335,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003899"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9697084</owl:annotatedTarget>
-        <rdfs:label>Defective rpoB in Mtb RNAP transcribes RNA polyanion</rdfs:label>
+        <rdfs:label>Defective RpoB in Mtb RNAP transcribes RNA polyanion</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003899"/>
@@ -2804,6 +2891,29 @@
         <owl:annotatedTarget>Reactome:R-HSA-983422</owl:annotatedTarget>
         <rdfs:label>Disassembly of COPII coated vesicle</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003925">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400027</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400037</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-422320</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003925"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400027</owl:annotatedTarget>
+        <rdfs:label>Gq alpha:G beta:G gamma dissociates to Gq alpha:GTP and G beta:G gamma</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003925"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400037</owl:annotatedTarget>
+        <rdfs:label>Gi,Go Heterotrimeric G-protein complex dissociates</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003925"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-422320</owl:annotatedTarget>
+        <rdfs:label>Heterotrimeric G(s) complex dissociates</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003934">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1474146</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -3020,21 +3130,14 @@
         <owl:annotatedTarget>Reactome:R-HSA-197271</owl:annotatedTarget>
         <rdfs:label>NADSYN1 hexamer amidates NAAD to NAD+</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003953">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8870346</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8938076</oboInOwl:hasDbXref>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003957">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-450971</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003953"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003957"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8870346</owl:annotatedTarget>
-        <rdfs:label>BST1 hydrolyzes NAD+ to yield NAM and ADP-ribose</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003953"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8938076</owl:annotatedTarget>
-        <rdfs:label>CD38 hydrolyses NAD+ to NAM and ADP-ribose</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-450971</owl:annotatedTarget>
+        <rdfs:label>NNT dimer transfers proton from NADPH to NAD+</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003958">
         <oboInOwl:hasDbXref>Reactome:R-HSA-76494</oboInOwl:hasDbXref>
@@ -3048,9 +3151,6 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003959">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9018867</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9018901</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027625</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027631</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027632</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003959"/>
@@ -3062,25 +3162,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003959"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9018901</owl:annotatedTarget>
-        <rdfs:label>5-HEDH dehydrogenates 5(S)-Hp-18(R)-HpEPE to 18(R)-RvE2</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003959"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027625</owl:annotatedTarget>
-        <rdfs:label>5-HEDH dehydrogenates 7-HDPAn-3 to 7-oxo-DPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003959"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027631</owl:annotatedTarget>
-        <rdfs:label>5-HEDH dehydrogenates 7-HDHA to 7-oxo-DHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003959"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027632</owl:annotatedTarget>
-        <rdfs:label>5-HEDH dehydrogenates 5-HEPE to 5-oxo-EPA</rdfs:label>
+        <rdfs:label>5-HEDH dehydrogenates 5(S)-Hp-18(R)-HEPE to 18(R)-RvE2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003960">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6799722</oboInOwl:hasDbXref>
@@ -3375,6 +3457,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-73916</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-74181</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8848215</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915356</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003985"/>
@@ -3400,6 +3483,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-8848215</owl:annotatedTarget>
         <rdfs:label>ACAT2 condenses 2 Ac-CoA to form ACA-CoA</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003985"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915356</owl:annotatedTarget>
+        <rdfs:label>ACAT1 mutants don&apos;t synthesize propionyl-CoA or acetyl-CoA</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003986">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2066779</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-390304</oboInOwl:hasDbXref>
@@ -3414,7 +3503,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003986"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-390304</owl:annotatedTarget>
-        <rdfs:label>acetyl-CoA + H2O =&gt; acetate + CoASH</rdfs:label>
+        <rdfs:label>acetyl-CoA + H2O =&gt; acetate + CoASH + H+</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003987">
         <oboInOwl:hasDbXref>Reactome:R-HSA-449911</oboInOwl:hasDbXref>
@@ -3506,7 +3595,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003989"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-200555</owl:annotatedTarget>
-        <rdfs:label>acetyl-CoA + bicarbonate + ATP =&gt; malonyl-CoA + H2O + ADP + orthophosphate</rdfs:label>
+        <rdfs:label>Formation of Malonyl-CoA from Acetyl-CoA (liver)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003989"/>
@@ -3539,16 +3628,9 @@
         <rdfs:label>2xTRAP hydrolyzes FMN to RIB</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003994">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-450975</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5690911</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-70971</oboInOwl:hasDbXref>
     </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003994"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-450975</owl:annotatedTarget>
-        <rdfs:label>isocitrate &lt;=&gt; citrate</rdfs:label>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003994"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -3559,7 +3641,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003994"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70971</owl:annotatedTarget>
-        <rdfs:label>citrate &lt;=&gt; isocitrate</rdfs:label>
+        <rdfs:label>ACO2 isomerizes citrate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003995">
         <oboInOwl:hasDbXref>Reactome:R-HSA-109341</oboInOwl:hasDbXref>
@@ -3675,7 +3757,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0003997"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-390256</owl:annotatedTarget>
-        <rdfs:label>hexacosanoyl-CoA + O2 =&gt; trans-2,3-dehydrohexacosanoyl-CoA + H2O2</rdfs:label>
+        <rdfs:label>ACOX1 oxidizes C26:0 CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0003999">
         <oboInOwl:hasDbXref>Reactome:R-HSA-74213</oboInOwl:hasDbXref>
@@ -3881,6 +3963,7 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004022">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2162078</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-71707</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004022"/>
@@ -3888,11 +3971,8 @@
         <owl:annotatedTarget>Reactome:R-HSA-2162078</owl:annotatedTarget>
         <rdfs:label>abacavir + 2 NAD+ =&gt; abacavir 5&apos;-carboxylate + 2 NADH + 2 H+</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004024">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-71707</oboInOwl:hasDbXref>
-    </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004024"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004022"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71707</owl:annotatedTarget>
         <rdfs:label>ethanol + NAD+ =&gt; acetaldehyde + NADH + H+</rdfs:label>
@@ -4243,169 +4323,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-5693977</owl:annotatedTarget>
         <rdfs:label>AMT transfers NH2CH2 from GCSH:SAMDLL to THF</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004051">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-265296</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-266051</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9018858</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9018859</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9018863</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9018894</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020251</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020255</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020256</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020259</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020264</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020277</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020278</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020282</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9024997</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9025995</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9025996</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9025999</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9026005</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9026405</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027624</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027628</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027633</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-265296</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to 5S-HpETE by ALOX5</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-266051</owl:annotatedTarget>
-        <rdfs:label>5S-HpETE is dehydrated to LTA4 by ALOX5</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9018858</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 18(S)-HEPE to 5(S)-Hp-18(S)-HEPE</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9018859</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 5(S)-Hp-18(S)-HEPE to 5S,6S-epoxy-18(S)-HEPE</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9018863</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 18(R)-HEPE to 5(S)-Hp-18(R)-HEPE</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9018894</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 5(S)-Hp-18(R)-HEPE to 5S,6S-epoxy-18(R)-HEPE</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020251</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 17(R)-HDHA to 7(S)-Hp-17(R)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020255</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 7(S)-Hp-17(S)-HDHA to 7S(8)-epoxy-17S-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020256</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 7(S)-Hp-17R-HDHA to 7S(8)-epoxy-17R-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020259</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 17(R)-HDHA to 4(S)-Hp-17(R)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020264</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 17(S)-HDHA to 4(S)-Hp-17(S)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020277</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 4(S)-Hp-17(S)-HDHA to 4S(5)-epoxy-17(S)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020278</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 4(S)-Hp-17(R)-HDHA to 4S(5)-epoxy-17(R)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020282</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 17(S)-HDHA to 7(S)-Hp-17(S)-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9024997</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 14(S)-Hp-DHA to 7(S),14(S)-diHp-DHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9025995</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 7,17-diHp-DPAn-3 to 7,8-epoxy,17-HDPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9025996</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 17(S)-Hp-DPAn-3 to 7,17-diHp-DPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9025999</owl:annotatedTarget>
-        <rdfs:label>ALOX5 dehydrogenates 17(S)-Hp-DPAn-3 to 16(S),17(S)-epoxy-DPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9026005</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 14(S)-Hp-DPAn-3 to MaR3n-3 DPA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9026405</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises 13(R)-HDPAn-3 to RvT1-4</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027624</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises DHA to 7-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027628</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises EPA to 5-HEPE</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004051"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027633</owl:annotatedTarget>
-        <rdfs:label>ALOX5 oxidises DPAn-3 to 7-HDPAn-3</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004052">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161948</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161950</oboInOwl:hasDbXref>
@@ -4419,19 +4336,19 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004052"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161948</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid  is converted to 12-oxoETE by ALOX12</rdfs:label>
+        <rdfs:label>Arachidonate  is converted to 12-oxoETE by ALOX12</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004052"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161950</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to 12R-HpETE by ALOX12B</rdfs:label>
+        <rdfs:label>Arachidonate is oxidised to 12R-HpETE by ALOX12B</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004052"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161964</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to 12S-HpETE by ALOX12/15</rdfs:label>
+        <rdfs:label>Arachidonate is oxidised to 12S-HpETE by ALOX12/15</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004052"/>
@@ -4633,7 +4550,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004069"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70592</owl:annotatedTarget>
-        <rdfs:label>PXLP-K259-GOT1 transaminates alpha-ketoglutarate and aspartate</rdfs:label>
+        <rdfs:label>PXLP-K259-GOT1 transaminates 2-OG and L-Asp</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004069"/>
@@ -4645,7 +4562,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004069"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70613</owl:annotatedTarget>
-        <rdfs:label>GOT2 transaminates oxaloacetate and glutamate</rdfs:label>
+        <rdfs:label>GOT2 transaminates OA and L-Glu</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004070">
         <oboInOwl:hasDbXref>Reactome:R-HSA-73573</oboInOwl:hasDbXref>
@@ -4845,18 +4762,25 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004095">
         <oboInOwl:hasDbXref>Reactome:R-HSA-200406</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-200410</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9911362</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004095"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-200406</owl:annotatedTarget>
-        <rdfs:label>CPT1A,B transfers PALM to CAR</rdfs:label>
+        <rdfs:label>CPT1A transfers PALM to CAR</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004095"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-200410</owl:annotatedTarget>
-        <rdfs:label>palmitoylcarnitine + CoASH =&gt; palmitoyl-CoA + carnitine</rdfs:label>
+        <rdfs:label>CPT2 converts palmitoyl carnitine to palmitoyl-CoA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004095"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9911362</owl:annotatedTarget>
+        <rdfs:label>CPT1B transfers PALM to CAR</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004096">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1222704</oboInOwl:hasDbXref>
@@ -4924,7 +4848,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004108"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70975</owl:annotatedTarget>
-        <rdfs:label>Acetyl-CoA + H2O + Oxaloacetate =&gt; Citrate + CoA</rdfs:label>
+        <rdfs:label>CS acetylates OA to citrate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004109">
         <oboInOwl:hasDbXref>Reactome:R-HSA-189421</oboInOwl:hasDbXref>
@@ -4967,6 +4891,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9644869</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9705507</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9708261</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865748</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004115"/>
@@ -5003,6 +4928,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9708261</owl:annotatedTarget>
         <rdfs:label>PDE4A hydrolyses cAMP to AMP</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004115"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865748</owl:annotatedTarget>
+        <rdfs:label>PDE4D5 in p-S26-ANXA2:PP2A:PDE4D5:ITGA5:ITGB1:fibronectin hydrolyzes cAMP to yield AMP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004117">
         <oboInOwl:hasDbXref>Reactome:R-HSA-111955</oboInOwl:hasDbXref>
@@ -5214,18 +5145,69 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004148">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1222412</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5694018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9853499</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9858589</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9859172</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861616</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9907572</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1222412</owl:annotatedTarget>
-        <rdfs:label>lpdC dimer reactivates dlaT</rdfs:label>
+        <rdfs:label>LpdC dimer reactivates DlaT</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5694018</owl:annotatedTarget>
         <rdfs:label>DLD dimer:2xFAD oxidises GCSH:DHLL to GCSH:lipoate</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9853499</owl:annotatedTarget>
+        <rdfs:label>DLD dimer dehydrogenates dihydrolipoyl</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9858589</owl:annotatedTarget>
+        <rdfs:label>DLD dimer dehydrogenates dihydrolipoyl</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9859172</owl:annotatedTarget>
+        <rdfs:label>DLD dimer dehydrogenates dihydrolipoyl</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861616</owl:annotatedTarget>
+        <rdfs:label>DLD dimer dehydrogenates dihydrolipoyl</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004148"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9907572</owl:annotatedTarget>
+        <rdfs:label>Loss-of-function DLD mutants don&apos;t dehydrogenate dihydrolipoyl DBT</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004149">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9853512</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9858590</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004149"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9853512</owl:annotatedTarget>
+        <rdfs:label>DLST transfers succinyl to CoA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004149"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9858590</owl:annotatedTarget>
+        <rdfs:label>DLST transfers glutaryl to CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004151">
         <oboInOwl:hasDbXref>Reactome:R-HSA-73571</oboInOwl:hasDbXref>
@@ -5294,15 +5276,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-191414</owl:annotatedTarget>
         <rdfs:label>MVD decarboxylates MVA5PP to IPPP</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004164">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5358484</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004164"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5358484</owl:annotatedTarget>
-        <rdfs:label>DPH5 transfers four methyl groups from AdoMet to aminocarboxypropyl EEF2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004165">
         <oboInOwl:hasDbXref>Reactome:R-HSA-109338</oboInOwl:hasDbXref>
@@ -5375,7 +5348,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004174"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-169270</owl:annotatedTarget>
-        <rdfs:label>ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to QH2</rdfs:label>
+        <rdfs:label>ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004175">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1168640</oboInOwl:hasDbXref>
@@ -5445,7 +5418,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8952408</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8957265</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9008110</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9008475</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9009362</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9010096</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9011313</oboInOwl:hasDbXref>
@@ -5456,6 +5428,12 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9762096</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-983150</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-983158</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9839376</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9906017</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9908101</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9908105</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9908108</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9908780</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
@@ -5473,13 +5451,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1236935</owl:annotatedTarget>
-        <rdfs:label>Proteasomal cleavage of substrate</rdfs:label>
+        <rdfs:label>Proteasomal cleavage of substrate (26S proteasome catalyst)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1236970</owl:annotatedTarget>
-        <rdfs:label>Proteasomal clevage of exogenous antigen</rdfs:label>
+        <rdfs:label>Proteasomal clevage of exogenous antigen (26S proteasome catalyst)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
@@ -5862,12 +5840,6 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9008475</owl:annotatedTarget>
-        <rdfs:label>Proteasome degrades polyubiquitinated RUNX2</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9009362</owl:annotatedTarget>
         <rdfs:label>Proteasome degrades PolyUb-RUNX2</rdfs:label>
     </owl:Axiom>
@@ -5924,6 +5896,42 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-983158</owl:annotatedTarget>
         <rdfs:label>Trimming of peptides in ER</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9839376</owl:annotatedTarget>
+        <rdfs:label>TGFBR3(784-851) degradation</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9906017</owl:annotatedTarget>
+        <rdfs:label>Unknown peptidase cleaves UQCRFS1 subunit</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9908101</owl:annotatedTarget>
+        <rdfs:label>Maturation of the canonical 20S core particle</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9908105</owl:annotatedTarget>
+        <rdfs:label>Maturation of the 20S immunoproteasome core particle</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9908108</owl:annotatedTarget>
+        <rdfs:label>Maturation of the 20S thymoproteasome core particle</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9908780</owl:annotatedTarget>
+        <rdfs:label>Maturation of the preholospermatoproteasome</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004176">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9698929</oboInOwl:hasDbXref>
@@ -5993,7 +6001,6 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004177">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1236954</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2534096</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8851929</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-983162</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
@@ -6007,12 +6014,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2534096</owl:annotatedTarget>
         <rdfs:label>METAP1/2 demethylates GNAT1</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004177"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8851929</owl:annotatedTarget>
-        <rdfs:label>AOPEP:Zn2+ hydrolyses AGT(35-41) to AGT(36-41)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004177"/>
@@ -6050,13 +6051,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004181"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022378</owl:annotatedTarget>
-        <rdfs:label>ACE2 hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-9)</rdfs:label>
+        <rdfs:label>ACE2(18-805):Zn2+ hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-9)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004181"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022379</owl:annotatedTarget>
-        <rdfs:label>ACE2 hydrolyzes Angiotensin-(1-8) to Angiotensin-(1-7)</rdfs:label>
+        <rdfs:label>ACE2(18-805):Zn2+ hydrolyzes Angiotensin-(1-8) to Angiotensin-(1-7)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004181"/>
@@ -6845,6 +6846,8 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004198">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8848658</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8863012</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9855106</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861485</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004198"/>
@@ -6857,6 +6860,18 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8863012</owl:annotatedTarget>
         <rdfs:label>Calpain cleaves p35 to p25</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004198"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9855106</owl:annotatedTarget>
+        <rdfs:label>Calpain2 (m-Calpain) cleaves TLN1 (Talin-1)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004198"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861485</owl:annotatedTarget>
+        <rdfs:label>Calpain2 (m-Calpain, CAPN2:CAPNS:Ca2+) cleaves VCL (Vinculin)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004222">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1168777</oboInOwl:hasDbXref>
@@ -6960,6 +6975,12 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9840564</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9844241</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004222"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8949668</owl:annotatedTarget>
+        <rdfs:label>YME1L1 proteolyzes unassembled proSMDT1</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004222"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -7276,7 +7297,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004222"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2533950</owl:annotatedTarget>
-        <rdfs:label>Fibronectin degradation by MMP14, TMPRSS6</rdfs:label>
+        <rdfs:label>Fibronectin degradation by MMP14</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004222"/>
@@ -7554,12 +7575,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-8949659</owl:annotatedTarget>
         <rdfs:label>AFG3L2 (m-AAA protease) degrades SMDT1 that is not assembled in MCU</rdfs:label>
     </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004222"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8949668</owl:annotatedTarget>
-        <rdfs:label>YME1L1 proteolyzes unassembled proSMDT1</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004252">
         <oboInOwl:hasDbXref>Reactome:R-HSA-114697</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-1181152</oboInOwl:hasDbXref>
@@ -7741,6 +7756,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9829200</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9830805</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9830882</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9839367</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004252"/>
@@ -7836,7 +7852,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004252"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1454843</owl:annotatedTarget>
-        <rdfs:label>E-cadherin degradation by MMP3, MMP7 and plasmin.</rdfs:label>
+        <rdfs:label>E-cadherin degradation by MMP3, MMP7 and plasmin</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004252"/>
@@ -8822,6 +8838,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-9830882</owl:annotatedTarget>
         <rdfs:label>Nascent G signal peptide is cleaved at ER membrane</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004252"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9839367</owl:annotatedTarget>
+        <rdfs:label>TGFBR3_mem cleavage by MMPs</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004298">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9818574</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9818577</oboInOwl:hasDbXref>
@@ -8848,6 +8870,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-77325</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-77333</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-77344</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9916717</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004300"/>
@@ -8903,6 +8926,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-77344</owl:annotatedTarget>
         <rdfs:label>trans-Dec-2-enoyl-CoA+H2O&lt;=&gt;(S)-Hydroxydecanoyl-CoA</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004300"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9916717</owl:annotatedTarget>
+        <rdfs:label>ECHS1 mutants don&apos;t synthesize beta-hydroxyisobutyryl-CoA</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004301">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161961</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9018862</oboInOwl:hasDbXref>
@@ -8918,12 +8947,15 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9025998</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026000</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026008</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915968</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915986</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915994</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004301"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161961</owl:annotatedTarget>
-        <rdfs:label>EET(1) is hydrolysed to DHET(1) by EPHX2</rdfs:label>
+        <rdfs:label>5,6-EET is hydrolysed to 5,6-DHET by EPHX2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004301"/>
@@ -9002,6 +9034,24 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9026008</owl:annotatedTarget>
         <rdfs:label>Epoxide hydrolase hydrolyses 7,8-epoxy-HDPAn-3 to RvD1n-3DPA or RvD2n-3DPA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004301"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915968</owl:annotatedTarget>
+        <rdfs:label>8,9-EET is hydrolysed to 8.9-DHET by EPHX2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004301"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915986</owl:annotatedTarget>
+        <rdfs:label>11,12-EET is hydrolysed to 11,12-DHET by EPHX2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004301"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915994</owl:annotatedTarget>
+        <rdfs:label>14,15-EET is hydrolysed to 14,15-DHET by EPHX2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004303">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5693390</oboInOwl:hasDbXref>
@@ -9158,13 +9208,20 @@
         <rdfs:label>Two FPP molecules dimerize to form presqualene diphosphate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004312">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-163756</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-75872</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004312"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-163756</owl:annotatedTarget>
+        <rdfs:label>Formation of fatty acid synthase (FAS) dimer</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004312"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-75872</owl:annotatedTarget>
-        <rdfs:label>acetyl-CoA + 7 malonyl-CoA + 14 NADHP + 14 H+ =&gt; palmitate + 7 CO2 + 14 NADP+ + 8 CoASH + 6 H2O</rdfs:label>
+        <rdfs:label>Conversion of malonyl-CoA and acetyl-CoA to palmitate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004314">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8933547</oboInOwl:hasDbXref>
@@ -9323,20 +9380,13 @@
         <rdfs:label>D-fructose 1,6-bisphosphate &lt;=&gt; dihydroxyacetone phosphate + D-glyceraldehyde 3-phosphate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004333">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-451033</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-70982</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004333"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-451033</owl:annotatedTarget>
-        <rdfs:label>(S)-Malate &lt;=&gt; Fumarate + H2O</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004333"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70982</owl:annotatedTarget>
-        <rdfs:label>Fumarate + H2O &lt;=&gt; (S)-Malate</rdfs:label>
+        <rdfs:label>FH tetramer hydrates fumarate to L-malate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004334">
         <oboInOwl:hasDbXref>Reactome:R-HSA-71181</oboInOwl:hasDbXref>
@@ -9345,7 +9395,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004334"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71181</owl:annotatedTarget>
-        <rdfs:label>fumarylacetoacetate =&gt; fumarate + acetoacetate</rdfs:label>
+        <rdfs:label>FAH cleaves 4FAA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004335">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5610026</oboInOwl:hasDbXref>
@@ -9649,6 +9699,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-176059</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3301943</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5423653</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9011595</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026777</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026780</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026901</oboInOwl:hasDbXref>
@@ -9679,6 +9730,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5423653</owl:annotatedTarget>
         <rdfs:label>MGST trimers transfer GS from GSH to AFXBO and AFNBO</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004364"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9011595</owl:annotatedTarget>
+        <rdfs:label>GSTZ1 dimer dehalogenates DCA</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004364"/>
@@ -9754,15 +9811,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-75886</owl:annotatedTarget>
         <rdfs:label>glycerol 3-phosphate + acyl-CoA =&gt; 1-acylglycerol 3-phosphate + CoASH [mitochondrial membrane-associated]</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004367">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-75889</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004367"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-75889</owl:annotatedTarget>
-        <rdfs:label>DHAP is converted to G3P by GPD1/GPD1L</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004368">
         <oboInOwl:hasDbXref>Reactome:R-HSA-188467</oboInOwl:hasDbXref>
@@ -9855,6 +9903,7 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004379">
         <oboInOwl:hasDbXref>Reactome:R-HSA-184392</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203611</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2534087</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
@@ -9862,6 +9911,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-184392</owl:annotatedTarget>
         <rdfs:label>N-myristoylation of GAG polyprotein by NMT2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004379"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203611</owl:annotatedTarget>
+        <rdfs:label>N-myristoylation of eNOS</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004379"/>
@@ -10185,6 +10240,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-6805650</owl:annotatedTarget>
         <rdfs:label>MTA2-NuRD complex deacetylates TP53</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004408">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9866217</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004408"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9866217</owl:annotatedTarget>
+        <rdfs:label>HCCS inserts heme into cytochrome c</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004411">
         <oboInOwl:hasDbXref>Reactome:R-HSA-71164</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -10192,7 +10256,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004411"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71164</owl:annotatedTarget>
-        <rdfs:label>homogentisate + O2 =&gt; maleylacetoacetate</rdfs:label>
+        <rdfs:label>HGD dioxygenates homogentisate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004415">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1793209</oboInOwl:hasDbXref>
@@ -10563,7 +10627,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004449"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70967</owl:annotatedTarget>
-        <rdfs:label>isocitrate + NAD+ =&gt; alpha-ketoglutarate + CO2 + NADH + H+ [IDH3]</rdfs:label>
+        <rdfs:label>IDH3 complex decarboxylates isocitrate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004450">
         <oboInOwl:hasDbXref>Reactome:R-HSA-389540</oboInOwl:hasDbXref>
@@ -10586,7 +10650,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004450"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-450984</owl:annotatedTarget>
-        <rdfs:label>isocitrate + NADP+ =&gt; alpha-ketoglutarate + CO2 + NADPH + H+ [IDH2]</rdfs:label>
+        <rdfs:label>IDH2 dimer decarboxylates isocitrate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004452">
         <oboInOwl:hasDbXref>Reactome:R-HSA-191382</oboInOwl:hasDbXref>
@@ -10846,7 +10910,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004471"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9012268</owl:annotatedTarget>
-        <rdfs:label>ME2:Mg2+ tetramer oxidatively decarboxylates MAL to PYR</rdfs:label>
+        <rdfs:label>ME2 tetramer decarboxylates MAL to PYR</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004473">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9012036</oboInOwl:hasDbXref>
@@ -10856,13 +10920,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004473"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9012036</owl:annotatedTarget>
-        <rdfs:label>ME1:Mg2+ tetramer oxidatively decarboxylates MAL to PYR</rdfs:label>
+        <rdfs:label>ME1 tetramer decarboxylates MAL to PYR</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004473"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9012349</owl:annotatedTarget>
-        <rdfs:label>ME3:Mg2+ tetramer oxidatively decarboxylates MAL to PYR</rdfs:label>
+        <rdfs:label>ME3 tetramer decarboxylates MAL to PYR</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004475">
         <oboInOwl:hasDbXref>Reactome:R-HSA-446221</oboInOwl:hasDbXref>
@@ -10871,7 +10935,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004475"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-446221</owl:annotatedTarget>
-        <rdfs:label>Mannose-1-phosphate converted to GDP-Mannose</rdfs:label>
+        <rdfs:label>GMPPB converts Mannose-1-phosphate to GDP-Mannose</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004476">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3781832</oboInOwl:hasDbXref>
@@ -11079,18 +11143,25 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004485">
         <oboInOwl:hasDbXref>Reactome:R-HSA-508308</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-70773</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9909466</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004485"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-508308</owl:annotatedTarget>
-        <rdfs:label>beta-methylglutaconyl-CoA + ADP + orthophosphate + H2O &lt;=&gt; beta-methylcrotonyl-CoA + ATP + CO2 [MCCA]</rdfs:label>
+        <rdfs:label>beta-methylglutaconyl-CoA + ADP + orthophosphate &lt;=&gt; beta-methylcrotonyl-CoA + ATP + CO2 (MCCA)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004485"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70773</owl:annotatedTarget>
         <rdfs:label>beta-methylcrotonyl-CoA + ATP + CO2 &lt;=&gt; beta-methylglutaconyl-CoA + ADP + orthophosphate + H2O [MCCA]</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004485"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9909466</owl:annotatedTarget>
+        <rdfs:label>MCCC mutants don&apos;t synthesize beta-methylglutaconyl-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004486">
         <oboInOwl:hasDbXref>Reactome:R-HSA-200644</oboInOwl:hasDbXref>
@@ -11128,12 +11199,19 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004490">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70785</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9914271</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004490"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70785</owl:annotatedTarget>
         <rdfs:label>beta-methylglutaconyl-CoA + H2O &lt;=&gt; beta-hydroxy-beta-methylglutaryl-CoA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004490"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9914271</owl:annotatedTarget>
+        <rdfs:label>AUH mutants don&apos;t synthesize 3-hydroxy-methylglutaryl-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004491">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70893</oboInOwl:hasDbXref>
@@ -11188,7 +11266,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-211924</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211929</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211948</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-211951</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211959</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211960</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211962</oboInOwl:hasDbXref>
@@ -11217,7 +11294,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-5662662</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5662692</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5663050</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-6786239</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-76354</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-76373</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-76386</oboInOwl:hasDbXref>
@@ -11244,6 +11320,10 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9756162</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9756169</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9756180</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915971</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915992</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915993</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9915997</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
@@ -11298,12 +11378,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-211948</owl:annotatedTarget>
         <rdfs:label>CYP3A4 can N-demethylate loperamide</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-211951</owl:annotatedTarget>
-        <rdfs:label>CYP1B1 4-hydroxylates EST17b</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
@@ -11369,37 +11443,37 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161795</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is hydroxylated to 16/17/18-HETE by CYP(1)</rdfs:label>
+        <rdfs:label>Arachidonate is hydroxylated to 16-HETE by CYP(1)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161814</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is hydroxylated to 19-HETE by CYP(2)</rdfs:label>
+        <rdfs:label>Arachidonate is hydroxylated to 19-HETE by CYP(2)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161890</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is epoxidated to 5,6-EET by CYP(4)</rdfs:label>
+        <rdfs:label>Arachidonate is epoxidated to 5,6-EET by CYP(4)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161899</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is epoxidated to 8,9/11,12/14,15-EET by CYP(5)</rdfs:label>
+        <rdfs:label>Arachidonate is epoxidated to 8,9-EET by CYP(5)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161940</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is hydroxylated to 20-HETE by CYP(3)</rdfs:label>
+        <rdfs:label>Arachidonate is hydroxylated to 20-HETE by CYP(3)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162191</owl:annotatedTarget>
-        <rdfs:label>DMPhOH is hydroxylated to MDMQ10H2 by DMPhOH monooxygenase</rdfs:label>
+        <rdfs:label>Unknown enzyme hydroxylates DMPhOH</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
@@ -11472,12 +11546,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5663050</owl:annotatedTarget>
         <rdfs:label>DHI and DHICA polymerize forming eumelanin</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-6786239</owl:annotatedTarget>
-        <rdfs:label>CYP4V2 omega-hydroxylates DHA to HDoHE</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
@@ -11634,6 +11702,30 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9756180</owl:annotatedTarget>
         <rdfs:label>CYP3A4 monooxygenates ATVL to 4-OH-ATVL</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915971</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is epoxidated to 11,12-EET by CYP(5)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915992</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is hydroxylated to 17-HETE by CYP(1)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915993</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is hydroxylated to 18-HETE by CYP(1)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004497"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9915997</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is epoxidated to 14,15-EET by CYP(5)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004498">
         <oboInOwl:hasDbXref>Reactome:R-HSA-209868</oboInOwl:hasDbXref>
@@ -11799,22 +11891,8 @@
         <rdfs:label>Defective CYP17A1 does not cleave 17aHPROG</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004509">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-193964</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-193981</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5601976</oboInOwl:hasDbXref>
     </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004509"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-193964</owl:annotatedTarget>
-        <rdfs:label>CYP21A2 21-hydroxylates PROG</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004509"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-193981</owl:annotatedTarget>
-        <rdfs:label>CYP21A2 oxidises 17HPROG</rdfs:label>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004509"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -13130,6 +13208,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-73564</owl:annotatedTarget>
         <rdfs:label>UMPS dimer decarboxylates OMP to UMP</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004591">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-71401</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004591"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-71401</owl:annotatedTarget>
+        <rdfs:label>OGDH dimer decarboxylates 2-OG</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004594">
         <oboInOwl:hasDbXref>Reactome:R-HSA-196857</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-199203</oboInOwl:hasDbXref>
@@ -13857,7 +13944,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004631"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-191422</owl:annotatedTarget>
-        <rdfs:label>Mevalonate-5-phosphate is further phosphorylated.</rdfs:label>
+        <rdfs:label>Mevalonate-5-phosphate is further phosphorylated</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004632">
         <oboInOwl:hasDbXref>Reactome:R-HSA-196753</oboInOwl:hasDbXref>
@@ -14117,13 +14204,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004666"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-140355</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to PGG2 by PTGS1</rdfs:label>
+        <rdfs:label>Arachidonate is oxidised to PGG2 by PTGS1</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004666"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2309787</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to PGG2 by PTGS2</rdfs:label>
+        <rdfs:label>Arachidonate is oxidised to PGG2 by PTGS2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004667">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161620</oboInOwl:hasDbXref>
@@ -14412,6 +14499,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-201677</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-201691</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-201717</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-202111</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-202222</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-202437</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-202459</oboInOwl:hasDbXref>
@@ -14549,7 +14637,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-450499</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-450827</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-451152</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-451347</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4551570</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4608825</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4793911</oboInOwl:hasDbXref>
@@ -14794,9 +14881,27 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9817397</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9818789</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9819106</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824582</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824897</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824977</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824994</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824995</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9824999</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9825704</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9831514</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9831712</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9832782</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9834076</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9834945</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9835011</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9839363</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9851972</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9853369</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9855910</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860292</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860785</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860800</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861642</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
@@ -15415,6 +15520,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-201717</owl:annotatedTarget>
         <rdfs:label>CSNK2-mediated phosphorylation of DVL</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-202111</owl:annotatedTarget>
+        <rdfs:label>AKT1 phosphorylates eNOS</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
@@ -16230,19 +16341,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-450827</owl:annotatedTarget>
-        <rdfs:label>hp-IRAK1, hp-IRAK4 4 phosphorylate Pellino-1 and 2.</rdfs:label>
+        <rdfs:label>hp-IRAK1, hp-IRAK4 4 phosphorylate Pellino-1 and 2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-451152</owl:annotatedTarget>
         <rdfs:label>MAP kinase p38 phosphorylates KSRP</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-451347</owl:annotatedTarget>
-        <rdfs:label>Activation of JNK by DSCAM</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
@@ -17711,6 +17816,48 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824582</owl:annotatedTarget>
+        <rdfs:label>MAPK1 phosphorylates SOX10</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824897</owl:annotatedTarget>
+        <rdfs:label>p-S-TBK1 phosphorylates OPTN</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824977</owl:annotatedTarget>
+        <rdfs:label>MAPK1-dependent phosphorylation of MITF-M</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824994</owl:annotatedTarget>
+        <rdfs:label>RPS6KA1-dependent phosphorylation of MITF-M</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824995</owl:annotatedTarget>
+        <rdfs:label>GSK3B phosphorylates p-S409 MITF-M at S397, S401 and S405</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9824999</owl:annotatedTarget>
+        <rdfs:label>GSK3B phosphorylates p-S73 MITF-M at residue S69</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9825704</owl:annotatedTarget>
+        <rdfs:label>AKT3 phosphorylates TBX3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9831514</owl:annotatedTarget>
         <rdfs:label>CK2 phosphorylates nascent P</rdfs:label>
     </owl:Axiom>
@@ -17725,6 +17872,72 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9832782</owl:annotatedTarget>
         <rdfs:label>p-S232-S237-P is further phosphorylated</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9834076</owl:annotatedTarget>
+        <rdfs:label>PINK1 is autophosphorylated</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9834945</owl:annotatedTarget>
+        <rdfs:label>PINK1 phosphorylates Ub on MOM proteins</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9835011</owl:annotatedTarget>
+        <rdfs:label>PINK1 phosphorylates PRKN at S65</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9839363</owl:annotatedTarget>
+        <rdfs:label>TGFBR3 phosphorylation by TGFBR2 complex</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9851972</owl:annotatedTarget>
+        <rdfs:label>PLK1 phosphorylates FIRRM at S43</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9853369</owl:annotatedTarget>
+        <rdfs:label>PLK1 phosphorylates FIRMM at S744</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9855910</owl:annotatedTarget>
+        <rdfs:label>USF1 is phosphorylated by p-MAPK14</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860292</owl:annotatedTarget>
+        <rdfs:label>Activated IKBKB phosphorylates IRF5</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860785</owl:annotatedTarget>
+        <rdfs:label>PDPK1 (PDK1) phosphorylates PKN2 on threonine-816</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860800</owl:annotatedTarget>
+        <rdfs:label>mTORC2 phosphorylates AKT1 on serine-473</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004674"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861642</owl:annotatedTarget>
+        <rdfs:label>NEK1 phosphorylates ME1</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004675">
         <oboInOwl:hasDbXref>Reactome:R-HSA-170868</oboInOwl:hasDbXref>
@@ -17949,6 +18162,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-5687088</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-913451</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9838321</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861318</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004691"/>
@@ -18033,6 +18247,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9838321</owl:annotatedTarget>
         <rdfs:label>PRKACA phosphorylates TFAM in the mitochondrial matrix</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004691"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861318</owl:annotatedTarget>
+        <rdfs:label>PKA phosphorylates NOS3 (eNOS) on serine-633</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004692">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1475422</oboInOwl:hasDbXref>
@@ -18645,13 +18865,13 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-111898</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-198733</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-445079</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-451366</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5654560</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5654562</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5654565</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5654566</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-73722</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9626832</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9825759</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
@@ -18674,14 +18894,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-451366</owl:annotatedTarget>
-        <rdfs:label>Activation of p38MAPK by DSCAM</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5654560</owl:annotatedTarget>
-        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR1-associated FRS2.</rdfs:label>
+        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR1-associated FRS2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
@@ -18693,13 +18907,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5654565</owl:annotatedTarget>
-        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR3-associated FRS2.</rdfs:label>
+        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR3-associated FRS2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5654566</owl:annotatedTarget>
-        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR4-associated FRS2.</rdfs:label>
+        <rdfs:label>Activated ERK1/2 threonine-phosphorylates FGFR4-associated FRS2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
@@ -18712,6 +18926,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9626832</owl:annotatedTarget>
         <rdfs:label>MAPK1 or MAPK3 phosphorylates NCF1 at Ser345</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004707"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9825759</owl:annotatedTarget>
+        <rdfs:label>MAPK-dependent phosphorylation of KARS</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004708">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1247960</oboInOwl:hasDbXref>
@@ -19243,6 +19463,15 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-983703</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-983707</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-983709</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9841924</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842648</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842651</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842666</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842667</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860500</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860759</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861469</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865196</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
@@ -21500,6 +21729,60 @@
         <owl:annotatedTarget>Reactome:R-HSA-983709</owl:annotatedTarget>
         <rdfs:label>LYN, FYN, BLK phosphorylate ITAMs of Ig-alpha (CD79A) and Ig-beta (CD79B)</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9841924</owl:annotatedTarget>
+        <rdfs:label>ABL1 phosphorylates PPARG2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842648</owl:annotatedTarget>
+        <rdfs:label>Autophosphorylation of LTK dimer:ALKAL1,2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842651</owl:annotatedTarget>
+        <rdfs:label>Active LTK receptor phosphorylates SHC1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842666</owl:annotatedTarget>
+        <rdfs:label>Active LTK phosphorylates IRS1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842667</owl:annotatedTarget>
+        <rdfs:label>CLIP1-LTK fusion autophosphorylates</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860500</owl:annotatedTarget>
+        <rdfs:label>Phosphorylation of KDR (VEGFR2) and FLT4 (VEGFR3) and PECAM1 in PECAM1:CDH5:KDR:FLT4:CTNNB1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860759</owl:annotatedTarget>
+        <rdfs:label>p-T816-PKN2 phosphorylates AKT1 on serine-308</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861469</owl:annotatedTarget>
+        <rdfs:label>p-Y397-PTK2 (FAK) phosphorylates CHUK (IKKA)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004713"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865196</owl:annotatedTarget>
+        <rdfs:label>p-Y393-ABL1 phosphorylates tyrosine-407 of YAP1</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004714">
         <oboInOwl:hasDbXref>Reactome:R-HSA-166544</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-167019</oboInOwl:hasDbXref>
@@ -22040,7 +22323,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004721"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9636684</owl:annotatedTarget>
-        <rdfs:label>ndkA dephosphorylates RAB5A:GTP,RAB7A:GTP</rdfs:label>
+        <rdfs:label>NdkA dephosphorylates RAB5A:GTP,RAB7A:GTP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004722">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1295632</oboInOwl:hasDbXref>
@@ -22083,6 +22366,11 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9660538</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9686524</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9831948</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9853385</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861725</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865226</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865238</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9912527</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
@@ -22324,6 +22612,36 @@
         <owl:annotatedTarget>Reactome:R-HSA-9831948</owl:annotatedTarget>
         <rdfs:label>P:PP1 dephosphorylates M2-1</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9853385</owl:annotatedTarget>
+        <rdfs:label>PPP1CC dephosphorylates PLK1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861725</owl:annotatedTarget>
+        <rdfs:label>PGAM5 dodecamer dephosphorylates p-S336-ME1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865226</owl:annotatedTarget>
+        <rdfs:label>PP2A dephosphorylates serine-127 of YAP1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865238</owl:annotatedTarget>
+        <rdfs:label>PP2A dephosphorylates serine-715 of PDE4D5 in p-S715-PDE4D5:integrin alpha5:integrin beta1:fibronectin</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9912527</owl:annotatedTarget>
+        <rdfs:label>H139Hfs13* PPM1K does not dephosphorylate BCKDH</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004723">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2025882</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -22369,6 +22687,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9698408</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9700200</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9701507</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865167</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-997309</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-997311</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-997314</oboInOwl:hasDbXref>
@@ -22587,6 +22906,12 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004725"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865167</owl:annotatedTarget>
+        <rdfs:label>PTPN1 (PTP1B) dephosphorylates tyrosine-24 of ANXA2 (Annexin-2)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004725"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-997309</owl:annotatedTarget>
         <rdfs:label>Dephosphorylation of STAT1 by SHP2</rdfs:label>
     </owl:Axiom>
@@ -22751,16 +23076,16 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004736"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70501</owl:annotatedTarget>
-        <rdfs:label>PC catalyzes the carboxylation of PYR to form OA</rdfs:label>
+        <rdfs:label>PC carboxylates PYR to OA</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004738">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-71397</oboInOwl:hasDbXref>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004739">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861734</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004738"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004739"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-71397</owl:annotatedTarget>
-        <rdfs:label>lipo-PDH decarboxylates PYR to Ac-CoA</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9861734</owl:annotatedTarget>
+        <rdfs:label>PDH E1 decarboxylates PYR, transferring acetyl to DLAT</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004740">
         <oboInOwl:hasDbXref>Reactome:R-HSA-203946</oboInOwl:hasDbXref>
@@ -22769,7 +23094,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004740"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-203946</owl:annotatedTarget>
-        <rdfs:label>PDK isoforms phosphorylate lipo-PDH</rdfs:label>
+        <rdfs:label>PDK isozymes phosphorylate PDHC subunit E1</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004741">
         <oboInOwl:hasDbXref>Reactome:R-HSA-204169</oboInOwl:hasDbXref>
@@ -22778,7 +23103,16 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004741"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-204169</owl:annotatedTarget>
-        <rdfs:label>PDP dephosphorylates p-lipo-PDH</rdfs:label>
+        <rdfs:label>PDP1,2 dephosphorylate p-lipo-PDH</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004742">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861667</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004742"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861667</owl:annotatedTarget>
+        <rdfs:label>DLAT trimer transfers acetyl to CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004743">
         <oboInOwl:hasDbXref>Reactome:R-HSA-71670</oboInOwl:hasDbXref>
@@ -22787,7 +23121,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004743"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71670</owl:annotatedTarget>
-        <rdfs:label>phosphoenolpyruvate + ADP =&gt; pyruvate + ATP</rdfs:label>
+        <rdfs:label>PKM dephosphorylates PEP to PYR</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004745">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2454081</oboInOwl:hasDbXref>
@@ -22936,7 +23270,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004757"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1497869</owl:annotatedTarget>
-        <rdfs:label>Salvage - Sepiapterin is reduced to BH2</rdfs:label>
+        <rdfs:label>Salvage - Sepiapterin is reduced to q-BH2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004758">
         <oboInOwl:hasDbXref>Reactome:R-HSA-428127</oboInOwl:hasDbXref>
@@ -23085,7 +23419,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004775"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70997</owl:annotatedTarget>
-        <rdfs:label>ADP + Orthophosphate + Succinyl-CoA &lt;=&gt; ATP + Succinate + CoA</rdfs:label>
+        <rdfs:label>SUCLG1/A2 cleaves succinyl-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004776">
         <oboInOwl:hasDbXref>Reactome:R-HSA-71775</oboInOwl:hasDbXref>
@@ -23094,7 +23428,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004776"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71775</owl:annotatedTarget>
-        <rdfs:label>GDP + Orthophosphate + Succinyl-CoA &lt;=&gt; GTP + Succinate + CoA</rdfs:label>
+        <rdfs:label>SUCLG1/G2 cleaves succinyl-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004777">
         <oboInOwl:hasDbXref>Reactome:R-HSA-888548</oboInOwl:hasDbXref>
@@ -23736,13 +24070,13 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004838"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-517444</owl:annotatedTarget>
-        <rdfs:label>p-hydroxyphenylpyruvate + glutamate &lt;=&gt; tyrosine + alpha-ketoglutarate</rdfs:label>
+        <rdfs:label>TAT aminates HPP</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004838"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71155</owl:annotatedTarget>
-        <rdfs:label>tyrosine + alpha-ketoglutarate &lt;=&gt; p-hydroxyphenylpyruvate + glutamate</rdfs:label>
+        <rdfs:label>TAT deaminates tyrosine</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004839">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8852132</oboInOwl:hasDbXref>
@@ -23861,7 +24195,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-446877</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-450358</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-451418</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5205682</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5357757</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5362412</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5483238</oboInOwl:hasDbXref>
@@ -23919,6 +24252,9 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-983156</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9833155</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9833973</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9834070</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861563</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861640</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
@@ -24355,12 +24691,6 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5205682</owl:annotatedTarget>
-        <rdfs:label>Parkin promotes the ubiquitination of mitochondrial substrates</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5357757</owl:annotatedTarget>
         <rdfs:label>BIRC(cIAP1/2) ubiquitinates RIPK1</rdfs:label>
     </owl:Axiom>
@@ -24699,6 +25029,24 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9833973</owl:annotatedTarget>
         <rdfs:label>ISGylation of PKR</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9834070</owl:annotatedTarget>
+        <rdfs:label>PRKN ubiquitinates MOM substrates</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861563</owl:annotatedTarget>
+        <rdfs:label>CTLH E3 ligase ubiquitinates LDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004842"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861640</owl:annotatedTarget>
+        <rdfs:label>CTLH E3 ligase ubiquitinates PKM-1</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004843">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1358795</oboInOwl:hasDbXref>
@@ -25200,22 +25548,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-189488</owl:annotatedTarget>
         <rdfs:label>UROS transforms HMB to URO3</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004853">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-189425</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-190182</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004853"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-189425</owl:annotatedTarget>
-        <rdfs:label>UROD decarboxylates URO3 to COPRO3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004853"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-190182</owl:annotatedTarget>
-        <rdfs:label>UROD decarboxylates URO1 to COPRO1</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004854">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9727349</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -25325,6 +25657,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-114552</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-114558</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-167408</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381706</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004930"/>
@@ -25344,6 +25677,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-167408</owl:annotatedTarget>
         <rdfs:label>The high affinity receptor complex binds to G-protein</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004930"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381706</owl:annotatedTarget>
+        <rdfs:label>GLP1R:GLP1 activates G(s)</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004931">
         <oboInOwl:hasDbXref>Reactome:R-HSA-877187</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -25352,6 +25691,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-877187</owl:annotatedTarget>
         <rdfs:label>P2X7 mediates loss of intracellular K+</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004938">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400071</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0004938"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400071</owl:annotatedTarget>
+        <rdfs:label>Alpha-2A,alpha-2C Adrenergic Receptors bind adrenaline or noradrenaline</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0004965">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1013012</oboInOwl:hasDbXref>
@@ -25466,6 +25814,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-3965444</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-399938</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-399995</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400092</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4093336</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-416530</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-416588</oboInOwl:hasDbXref>
@@ -25638,7 +25987,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1250498</owl:annotatedTarget>
-        <rdfs:label>RAS guanyl-nucleotide exchange mediated by SOS1 in complex with GRB2 and phosphorylated EGFR:ERBB2 heterodimers.</rdfs:label>
+        <rdfs:label>RAS guanyl-nucleotide exchange mediated by SOS1 in complex with GRB2 and phosphorylated EGFR:ERBB2 heterodimers</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
@@ -25907,6 +26256,12 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400092</owl:annotatedTarget>
+        <rdfs:label>Alpha-2A,alpha-2C Adrenergic Receptors activate Gi.Go heterotrimeric G proteins</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-4093336</owl:annotatedTarget>
         <rdfs:label>p-TIAM1 exchanges GTP for GDP on RAC1, activating it</rdfs:label>
     </owl:Axiom>
@@ -25914,7 +26269,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-416530</owl:annotatedTarget>
-        <rdfs:label>FFAR1:FFAR1 ligands activates Gq</rdfs:label>
+        <rdfs:label>FFAR1:FFAR1 ligands activate Gq</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005085"/>
@@ -26774,15 +27129,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-9693282</owl:annotatedTarget>
         <rdfs:label>RHOF GAPs stimulate RHOF GTPase activity</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005219">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2855020</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005219"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2855020</owl:annotatedTarget>
-        <rdfs:label>RYR tetramers transport Ca2+ from sarcoplasmic reticulum lumen to cytosol</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005221">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2514867</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -26809,36 +27155,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9717383</owl:annotatedTarget>
         <rdfs:label>TRPM4 transports Na+ from the extracellular region to the cytosol</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005229">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2684901</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2744242</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2744361</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9659568</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005229"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2684901</owl:annotatedTarget>
-        <rdfs:label>ANOs transport cytosolic Cl- to extracellular region</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005229"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2744242</owl:annotatedTarget>
-        <rdfs:label>TTYH2/3 transport cytosolic Cl- to extracellular region</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005229"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2744361</owl:annotatedTarget>
-        <rdfs:label>BESTs transport cytosolic Cl- to extracellular region</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005229"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9659568</owl:annotatedTarget>
-        <rdfs:label>ANO1 transports cytosolic Cl- to extracellular region</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005231">
         <oboInOwl:hasDbXref>Reactome:R-HSA-399711</oboInOwl:hasDbXref>
@@ -27071,6 +27387,7 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005253">
         <oboInOwl:hasDbXref>Reactome:R-HSA-432034</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-432036</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9855161</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005253"/>
@@ -27084,13 +27401,35 @@
         <owl:annotatedTarget>Reactome:R-HSA-432036</owl:annotatedTarget>
         <rdfs:label>Aquaporin-6 passively transports anions out of vesicles</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005253"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9855161</owl:annotatedTarget>
+        <rdfs:label>Pannexin-1 (PANX1) channel transports ATP from the cytosol to the extracellular region</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005254">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2684901</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2744242</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2744349</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2744361</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-427570</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9659568</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9712204</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-975340</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-975449</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2684901</owl:annotatedTarget>
+        <rdfs:label>ANOs transport cytosolic Cl- to extracellular region</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2744242</owl:annotatedTarget>
+        <rdfs:label>TTYH2/3 transport cytosolic Cl- to extracellular region</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -27100,8 +27439,20 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2744361</owl:annotatedTarget>
+        <rdfs:label>BESTs transport cytosolic Cl- to extracellular region</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-427570</owl:annotatedTarget>
         <rdfs:label>Group 3 - Selective Cl- transport</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9659568</owl:annotatedTarget>
+        <rdfs:label>ANO1 transports cytosolic Cl- to extracellular region</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005254"/>
@@ -27201,6 +27552,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8949145</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8949178</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9663785</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9858800</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005262"/>
@@ -27243,6 +27595,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9663785</owl:annotatedTarget>
         <rdfs:label>CHRNA9:CHRNA10:AcCho transports Ca2+ from the extracellular region to the cytosol</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005262"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9858800</owl:annotatedTarget>
+        <rdfs:label>TRPV4 tetramer:CALM1:Ca2+ transports calcium ions (Ca2+) from the extracellular region to the cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005267">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1296024</oboInOwl:hasDbXref>
@@ -27390,7 +27748,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005280"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8875623</owl:annotatedTarget>
-        <rdfs:label>SLC25A18,A22 cotransport Glu, H+ from cytosol to mitochondrial matrix</rdfs:label>
+        <rdfs:label>SLC25A18,22 import L-Glu, H+</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005298">
         <oboInOwl:hasDbXref>Reactome:R-HSA-444100</oboInOwl:hasDbXref>
@@ -27562,7 +27920,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-2046087</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2046093</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-382575</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-390393</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-434381</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5684043</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -27583,12 +27940,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-382575</owl:annotatedTarget>
         <rdfs:label>ABCD1-3 dimers transfer LCFAs from cytosol to peroxisomal matrix</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005324"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-390393</owl:annotatedTarget>
-        <rdfs:label>Peroxisomal uptake of very long-chain fatty acyl CoA</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005324"/>
@@ -28317,6 +28668,7 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005461">
         <oboInOwl:hasDbXref>Reactome:R-HSA-174368</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5603297</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9912889</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005461"/>
@@ -28329,6 +28681,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5603297</owl:annotatedTarget>
         <rdfs:label>Defective SLC35D1 does not transport UDP-GlcA, UDPGlcNAc</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005461"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9912889</owl:annotatedTarget>
+        <rdfs:label>SLC35D2 exchanges UDP-GlcA for UMP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005462">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5653622</oboInOwl:hasDbXref>
@@ -28362,6 +28720,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-742373</owl:annotatedTarget>
         <rdfs:label>SLC35B4 mediates the transport of UDP-xylose into the Golgi lumen</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005476">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-200424</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005476"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-200424</owl:annotatedTarget>
+        <rdfs:label>Exchange of palmitoylcarnitine and carnitine across the inner mitochondrial membrane</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005501">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2454113</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2464809</oboInOwl:hasDbXref>
@@ -28391,6 +28758,24 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2465938</owl:annotatedTarget>
         <rdfs:label>RBP3 regulates atROL taken up by Muller cells</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005515">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9866132</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005515"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9866132</owl:annotatedTarget>
+        <rdfs:label>Intermediate II binds CYC1, UQCRC1, UQCRC2, UQCRH</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005516">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-202110</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0005516"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-202110</owl:annotatedTarget>
+        <rdfs:label>eNOS:Caveolin-1 complex binds to CaM</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0005524">
         <oboInOwl:hasDbXref>Reactome:R-HSA-265682</oboInOwl:hasDbXref>
@@ -28814,7 +29199,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008137"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-163217</owl:annotatedTarget>
-        <rdfs:label>Complex I oxidises NADH to NAD+, reduces CoQ to QH2</rdfs:label>
+        <rdfs:label>Complex I oxidises NADH to NAD+, reduces CoQ to CoQH2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008138">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5675373</oboInOwl:hasDbXref>
@@ -29042,7 +29427,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008177"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70994</owl:annotatedTarget>
-        <rdfs:label>Succinate &lt;=&gt; Fumarate (with FAD redox reaction on enzyme)</rdfs:label>
+        <rdfs:label>SDH complex dehydrogenates succinate</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008179">
         <oboInOwl:hasDbXref>Reactome:R-HSA-170672</oboInOwl:hasDbXref>
@@ -29387,25 +29772,25 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008237"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022368</owl:annotatedTarget>
-        <rdfs:label>MME:Zn2+ hydrolyses AGT(34-42)</rdfs:label>
+        <rdfs:label>MME:Zn2+ (Neprilysin) hydrolyses AGT(34-42)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008237"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022393</owl:annotatedTarget>
-        <rdfs:label>ANPEP hydrolyzes Angiotensin-(2-8) to Angiotensin-(3-8)</rdfs:label>
+        <rdfs:label>ANPEP:Zn2+ hydrolyzes Angiotensin-(2-8) to Angiotensin-(3-8)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008237"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022396</owl:annotatedTarget>
-        <rdfs:label>MME:Zn2+ hydrolyses AGT(34-43)</rdfs:label>
+        <rdfs:label>MME:Zn2+ (Neprilysin) hydrolyses AGT(34-43)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008237"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022399</owl:annotatedTarget>
-        <rdfs:label>ENPEP hydrolyzes Angiotensin-(1-8) to Angiotensin-(2-8)</rdfs:label>
+        <rdfs:label>ENPEP:Zn2+ hydrolyzes Angiotensin-(1-8) to Angiotensin-(2-8)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008237"/>
@@ -30093,18 +30478,11 @@
         <rdfs:label>Addition of galactose to Core 6 glycoprotein</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008379">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2161612</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3322995</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3341343</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3697882</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3697894</oboInOwl:hasDbXref>
     </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008379"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2161612</owl:annotatedTarget>
-        <rdfs:label>PGH2 is reduced to PGF2a by FAM213B</rdfs:label>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008379"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -30393,15 +30771,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-5602885</owl:annotatedTarget>
         <rdfs:label>Defective CYP7B1 does not 7-hydroxylate 25OH-CHOL</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008398">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-194678</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008398"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-194678</owl:annotatedTarget>
-        <rdfs:label>CYP51A1 demethylates LNSOL</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008401">
         <oboInOwl:hasDbXref>Reactome:R-HSA-211874</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211923</oboInOwl:hasDbXref>
@@ -30471,15 +30840,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-5358619</owl:annotatedTarget>
         <rdfs:label>EXO1 interacting with MSH2:MSH3 excises DNA strand containing an insertion/deletion loop (IDL)</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008410">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-70713</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008410"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-70713</owl:annotatedTarget>
-        <rdfs:label>BCKDH transfers CoA group from CoA-SH to BCAAs</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008417">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9033949</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9846332</oboInOwl:hasDbXref>
@@ -30511,6 +30871,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9696980</owl:annotatedTarget>
         <rdfs:label>Spike trimer glycoside chains get additional branches</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008425">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2162188</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008425"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2162188</owl:annotatedTarget>
+        <rdfs:label>COQ5 methylates MDMQ10H2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008440">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1855153</oboInOwl:hasDbXref>
@@ -30747,12 +31116,19 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008470">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70745</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9914837</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008470"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70745</owl:annotatedTarget>
         <rdfs:label>isovaleryl-CoA + FAD =&gt; beta-methylcrotonyl-CoA + FADH2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008470"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9914837</owl:annotatedTarget>
+        <rdfs:label>IVD mutants don&apos;t synthesize beta-methylcrotonyl-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008474">
         <oboInOwl:hasDbXref>Reactome:R-HSA-203613</oboInOwl:hasDbXref>
@@ -30764,7 +31140,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008474"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-203613</owl:annotatedTarget>
-        <rdfs:label>depalmitoylation of eNOS</rdfs:label>
+        <rdfs:label>Depalmitoylation of eNOS</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008474"/>
@@ -31281,9 +31657,16 @@
         <rdfs:label>SLC5A6 transports vitamins from extracellular region to cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008526">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1483229</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8869241</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8874470</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008526"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1483229</owl:annotatedTarget>
+        <rdfs:label>PI:PITPNB is transported from the ER membrane to the Golgi membrane</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008526"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -31466,15 +31849,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-6799977</owl:annotatedTarget>
         <rdfs:label>PGLYRP2 hydrolyzes bacterial peptidoglycan</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008746">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-450971</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008746"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-450971</owl:annotatedTarget>
-        <rdfs:label>NADPH + NAD+ + H+ [cytosol] =&gt; NADP+ + NADH + H+ [mitochondrial matrix]</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008747">
         <oboInOwl:hasDbXref>Reactome:R-HSA-4085217</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -31536,15 +31910,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-350604</owl:annotatedTarget>
         <rdfs:label>Agmatine + H2O &lt;=&gt; putrescine + urea</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008785">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-1222526</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008785"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-1222526</owl:annotatedTarget>
-        <rdfs:label>AhpC reduces peroxidated lipids</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008792">
         <oboInOwl:hasDbXref>Reactome:R-HSA-350598</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -31589,8 +31954,15 @@
         <rdfs:label>CHDH oxidises Cho to BETALD</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008817">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3159253</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3322125</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008817"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-3159253</owl:annotatedTarget>
+        <rdfs:label>MMAB adenosylates cob(I)alamin</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008817"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -31685,7 +32057,6 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008941">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1222723</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5340226</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008941"/>
@@ -31693,20 +32064,21 @@
         <owl:annotatedTarget>Reactome:R-HSA-1222723</owl:annotatedTarget>
         <rdfs:label>Nitric oxide is oxidized to nitrate</rdfs:label>
     </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008941"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5340226</owl:annotatedTarget>
-        <rdfs:label>CYGB dioxygenates NO</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008948">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9012016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861660</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008948"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9012016</owl:annotatedTarget>
-        <rdfs:label>FAHD1:Zn2+ dimer hydrolyses OA to PYR</rdfs:label>
+        <rdfs:label>FAHD1 dimer hydrolyses OA to PYR</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0008948"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861660</owl:annotatedTarget>
+        <rdfs:label>ME1 tetramer decarboxylates OA to PYR</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008962">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1483197</oboInOwl:hasDbXref>
@@ -31808,15 +32180,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5227490</owl:annotatedTarget>
         <rdfs:label>NoRC:HDAC:DNMT methylates cytosine of the rRNA genes</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0009020">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9024161</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0009020"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9024161</owl:annotatedTarget>
-        <rdfs:label>FTSJ1 2&apos;-O-methylates guanosine-34 in tRNA(Phe)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0009055">
         <oboInOwl:hasDbXref>Reactome:R-HSA-169260</oboInOwl:hasDbXref>
@@ -31983,6 +32346,40 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1237119</owl:annotatedTarget>
         <rdfs:label>Acireductone is oxidized to MOB</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0010420">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2162193</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0010420"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2162193</owl:annotatedTarget>
+        <rdfs:label>COQ3 methylates DHDB</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0010855">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400097</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0010855"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400097</owl:annotatedTarget>
+        <rdfs:label>G-beta:G-gamma inhibits Adenylate cyclase</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0010856">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-163617</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381704</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0010856"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-163617</owl:annotatedTarget>
+        <rdfs:label>G alpha (s) activates adenylate cyclase</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0010856"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381704</owl:annotatedTarget>
+        <rdfs:label>G(s):GTP activates Adenylyl cyclase</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0010945">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6809354</oboInOwl:hasDbXref>
@@ -32296,6 +32693,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-170026</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-74723</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-917841</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9864415</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015078"/>
@@ -32319,7 +32717,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015078"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-170026</owl:annotatedTarget>
-        <rdfs:label>Protons are translocated from the intermembrane space to the matrix</rdfs:label>
+        <rdfs:label>UCP1 imports a proton</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015078"/>
@@ -32332,6 +32730,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-917841</owl:annotatedTarget>
         <rdfs:label>Acidification of Tf:TfR1 containing endosome</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9864415</owl:annotatedTarget>
+        <rdfs:label>AAC1 imports a proton</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015085">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2534359</oboInOwl:hasDbXref>
@@ -32645,6 +33049,7 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015132">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5661188</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-879528</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9032327</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015132"/>
@@ -32657,6 +33062,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-879528</owl:annotatedTarget>
         <rdfs:label>SLCO2A1 transports PGT substrates from extracellular region to cytosol</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015132"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9032327</owl:annotatedTarget>
+        <rdfs:label>5-oxo-EPA, 15d-PGJ3 translocate from cytosol to extracellular region</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015137">
         <oboInOwl:hasDbXref>Reactome:R-HSA-433104</oboInOwl:hasDbXref>
@@ -32690,7 +33101,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015142"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-75849</owl:annotatedTarget>
-        <rdfs:label>Transport of Citrate from Mitochondrial Matrix to cytosol</rdfs:label>
+        <rdfs:label>SLC25A1 exchanges CIT and MAL</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015143">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2872497</oboInOwl:hasDbXref>
@@ -33071,7 +33482,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015172"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-372448</owl:annotatedTarget>
-        <rdfs:label>SLC25A12,13 exchange cytosolic L-Glu for mitochondrial matrix L-Asp</rdfs:label>
+        <rdfs:label>SLC25A12,13 exchange L-Glu and L-Asp</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015174">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8932851</oboInOwl:hasDbXref>
@@ -33219,15 +33630,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-5625674</owl:annotatedTarget>
         <rdfs:label>Defective SLC22A5 does not cotransport CAR, Na+ from extracellular region to cytosol</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015227">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-200424</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015227"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-200424</owl:annotatedTarget>
-        <rdfs:label>Exchange of palmitoylcarnitine and carnitine across the inner mitochondrial membrane</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015228">
         <oboInOwl:hasDbXref>Reactome:R-HSA-199216</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9837333</oboInOwl:hasDbXref>
@@ -33288,6 +33690,8 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015245">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5627891</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-879585</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9032315</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9032323</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015245"/>
@@ -33301,49 +33705,17 @@
         <owl:annotatedTarget>Reactome:R-HSA-879585</owl:annotatedTarget>
         <rdfs:label>SLC27A1,4,6 transport LCFAs from extracellular region to cytosol</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015248">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-265783</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5250531</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5679101</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-5679145</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8867667</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8868402</oboInOwl:hasDbXref>
-    </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015245"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-265783</owl:annotatedTarget>
-        <rdfs:label>ABCG5:ABCG8 transports sterols from cytosol to extracellular region</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9032315</owl:annotatedTarget>
+        <rdfs:label>oxo-DHAs translocate from cytosol to extracellular region</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015245"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5250531</owl:annotatedTarget>
-        <rdfs:label>ARV1 transports CHOL from ER membrane to plasma membrane</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5679101</owl:annotatedTarget>
-        <rdfs:label>Defective ABCG8 (in ABCG5:ABCG8) does not transport sterols from cytosol to extracellular region</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-5679145</owl:annotatedTarget>
-        <rdfs:label>Defective ABCG5 (in ABCG5:ABCG8) does not transport sterols from cytosol to extracellular region</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8867667</owl:annotatedTarget>
-        <rdfs:label>OSBPs transport 25OH-CHOL from ER membrane to plasma membrane</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015248"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8868402</owl:annotatedTarget>
-        <rdfs:label>OSBP exchanges 25OH-CHOL with PI4P from ER membrane to Golgi membrane</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9032323</owl:annotatedTarget>
+        <rdfs:label>oxo-DPAn-3s translocate from cytosol to extracellular region</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015250">
         <oboInOwl:hasDbXref>Reactome:R-HSA-432010</oboInOwl:hasDbXref>
@@ -33490,7 +33862,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015272"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5683209</owl:annotatedTarget>
-        <rdfs:label>Activating ABCC8 mutants cause hyperglycemia in permanent neonatal diabetes mellitus (PNDM) and transient neonatal DM (TNDM).</rdfs:label>
+        <rdfs:label>Activating ABCC8 mutants cause hyperglycemia in permanent neonatal diabetes mellitus (PNDM) and transient neonatal DM (TNDM)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015276">
         <oboInOwl:hasDbXref>Reactome:R-HSA-451310</oboInOwl:hasDbXref>
@@ -33587,7 +33959,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015333"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-427998</owl:annotatedTarget>
-        <rdfs:label>Proton-coupled di- and tri-peptide cotransport</rdfs:label>
+        <rdfs:label>SLC25A1 transports di-/tri-peptides and peptide-like drugs</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015333"/>
@@ -33731,7 +34103,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0015367"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-376851</owl:annotatedTarget>
-        <rdfs:label>SLC25A11 exchanges alpha-ketoglutarate (2-oxoglutarate) and malate across the inner mitochondrial membrane</rdfs:label>
+        <rdfs:label>SLC25A11 exchanges 2-OG and MAL</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0015368">
         <oboInOwl:hasDbXref>Reactome:R-HSA-425822</oboInOwl:hasDbXref>
@@ -34058,6 +34430,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-9672770</owl:annotatedTarget>
         <rdfs:label>SLC25A44 transports Leu, Ile and Val from cytosol to mitochondrial matrix</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016004">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400023</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016004"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400023</owl:annotatedTarget>
+        <rdfs:label>Gq alpha activates Phospholipase C beta</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016034">
         <oboInOwl:hasDbXref>Reactome:R-HSA-71173</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -34065,7 +34446,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016034"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-71173</owl:annotatedTarget>
-        <rdfs:label>maleylacetoacetate =&gt; fumarylacetoacetate</rdfs:label>
+        <rdfs:label>GSTZ1 isomerizes 4-MAA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016153">
         <oboInOwl:hasDbXref>Reactome:R-HSA-70903</oboInOwl:hasDbXref>
@@ -34179,6 +34560,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8955010</owl:annotatedTarget>
         <rdfs:label>LRTOMT transfers Met to DA, forming 3MT</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016208">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-380930</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016208"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-380930</owl:annotatedTarget>
+        <rdfs:label>Phosphorylated AMPK binds AMP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016212">
         <oboInOwl:hasDbXref>Reactome:R-HSA-893583</oboInOwl:hasDbXref>
@@ -34423,6 +34813,8 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8932275</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8932276</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8932413</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9844111</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9854315</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016279"/>
@@ -34477,6 +34869,18 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8932413</owl:annotatedTarget>
         <rdfs:label>METTL10 transfers 3xCH3 from 3xAdoMet to EEF1A1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016279"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9844111</owl:annotatedTarget>
+        <rdfs:label>EHMT1,EHMT2 trimethylates lysine-16 of ATF7IP</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016279"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9854315</owl:annotatedTarget>
+        <rdfs:label>CSKMT methylates Citrate Synthase</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016287">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1483002</oboInOwl:hasDbXref>
@@ -34553,7 +34957,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-2045911</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5672012</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6798174</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9028519</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9670433</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9680389</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -34604,12 +35007,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-6798174</owl:annotatedTarget>
         <rdfs:label>PIK3C3:PIK3R4 phosphorylates PI to PI3P</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016303"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9028519</owl:annotatedTarget>
-        <rdfs:label>NTRK2-activated PI3K generates PIP3</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016303"/>
@@ -34749,7 +35146,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016403"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5693373</owl:annotatedTarget>
-        <rdfs:label>DDAH1,2 hydrolyses ADMA to DMA and L-Cit</rdfs:label>
+        <rdfs:label>DDAH1 hydrolyses ADMA to DMA and L-Cit</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016404">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161662</oboInOwl:hasDbXref>
@@ -34825,6 +35222,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-6792712</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6805638</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-73736</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9854415</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016407"/>
@@ -34862,16 +35260,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-73736</owl:annotatedTarget>
         <rdfs:label>Acetylation of SL1</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016407"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9854415</owl:annotatedTarget>
+        <rdfs:label>ACAT1 tetramer acetylates IDH2 dimer</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016409">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-203567</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5686304</oboInOwl:hasDbXref>
     </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016409"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-203567</owl:annotatedTarget>
-        <rdfs:label>palmitoylation of eNOS</rdfs:label>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016409"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -34880,12 +35277,26 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016410">
         <oboInOwl:hasDbXref>Reactome:R-HSA-177160</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-6792572</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9858752</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016410"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-177160</owl:annotatedTarget>
         <rdfs:label>phenylacetyl-CoA + glutamine =&gt; phenylacetyl glutamine + Coenzyme A</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016410"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-6792572</owl:annotatedTarget>
+        <rdfs:label>LIPT1 transfers lipoyl group from lipoyl-GCSH to DBT/DLST</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016410"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9858752</owl:annotatedTarget>
+        <rdfs:label>LIPT1 transfers lipoyl group from lipoyl-GCSH to DLAT</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016411">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1482647</oboInOwl:hasDbXref>
@@ -34976,7 +35387,9 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-1614362</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-209921</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-209960</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-3095889</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161612</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-265296</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-266051</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-390425</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-390438</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5662660</oboInOwl:hasDbXref>
@@ -34991,6 +35404,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026917</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9027033</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9693722</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9759549</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
@@ -35013,8 +35427,20 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-3095889</owl:annotatedTarget>
-        <rdfs:label>MMACHC dealkylates RCbl</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-2161612</owl:annotatedTarget>
+        <rdfs:label>PGH2 is reduced to PGF2a by FAM213B</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-265296</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is oxidised to 5S-HpETE by ALOX5</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-266051</owl:annotatedTarget>
+        <rdfs:label>5S-HpETE is dehydrated to LTA4 by ALOX5</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
@@ -35056,7 +35482,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9020260</owl:annotatedTarget>
-        <rdfs:label>Hydroperoxy reducatse reduces 7(S)-Hp-17(S)-HDHA to RvD5</rdfs:label>
+        <rdfs:label>Hydroperoxy reductase reduces 7(S)-Hp-17(S)-HDHA to RvD5</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
@@ -35100,6 +35526,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-9693722</owl:annotatedTarget>
         <rdfs:label>Unknown sepiapterin synthase transforms PTHP to sepiapterin</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016491"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9759549</owl:annotatedTarget>
+        <rdfs:label>Cob(I)alamin bound to MMACHC is oxidized to cob(II)alamin</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016504">
         <oboInOwl:hasDbXref>Reactome:R-HSA-168865</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -35108,6 +35540,29 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-168865</owl:annotatedTarget>
         <rdfs:label>NA activation of TGF-beta</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016531">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865449</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865579</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865630</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016531"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865449</owl:annotatedTarget>
+        <rdfs:label>Metallochaperone inserts Cu2+ into MT-CO1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016531"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865579</owl:annotatedTarget>
+        <rdfs:label>MT-CO1 and MT-CO2 complexes associate, installing heme moieties</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016531"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865630</owl:annotatedTarget>
+        <rdfs:label>Metallochaperone inserts 2Cu2+ into MT-CO2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016538">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3215385</oboInOwl:hasDbXref>
@@ -35128,8 +35583,29 @@
         <rdfs:label>Fgd1 reactivates F420</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016616">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027625</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027631</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027632</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-975629</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016616"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027625</owl:annotatedTarget>
+        <rdfs:label>5-HEDH dehydrogenates 7-HDPAn-3 to 7-oxo-DPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016616"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027631</owl:annotatedTarget>
+        <rdfs:label>5-HEDH dehydrogenates 7-HDHA to 7-oxo-DHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016616"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027632</owl:annotatedTarget>
+        <rdfs:label>5-HEDH dehydrogenates 5-HEPE to 5-oxo-EPA</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016616"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -35144,6 +35620,29 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1222583</owl:annotatedTarget>
         <rdfs:label>MscR reduces nitrosomycothiol to ammonia</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016624">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9858321</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9859148</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865121</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016624"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9858321</owl:annotatedTarget>
+        <rdfs:label>DHTKD1 dimer decarboxylates 2-OA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016624"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9859148</owl:annotatedTarget>
+        <rdfs:label>BCKDHA:BCKDHB tetramer decarboxylates KIC, KMVA, KIV</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016624"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865121</owl:annotatedTarget>
+        <rdfs:label>BCKDHA or BCKDHB loss-of-function mutants don&apos;t synthesize BCAA-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016627">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2995334</oboInOwl:hasDbXref>
@@ -35216,6 +35715,206 @@
         <owl:annotatedTarget>Reactome:R-HSA-2213240</owl:annotatedTarget>
         <rdfs:label>Reduction of disulphide bonds in MHC II antigens</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016675">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5340226</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016675"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5340226</owl:annotatedTarget>
+        <rdfs:label>CYGB dioxygenates NO</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016701">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161951</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9018858</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9018859</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9018863</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9018894</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020251</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020255</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020256</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020259</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020261</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020264</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020277</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020278</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9020282</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9024997</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9025995</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9025996</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9025999</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9026005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9026405</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027532</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027607</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027624</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027627</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027628</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9027633</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9028255</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2161951</owl:annotatedTarget>
+        <rdfs:label>Arachidonate is oxidised to 15R-HETE by Acetyl-PTGS2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9018858</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 18(S)-HEPE to 5(S)-Hp-18(S)-HEPE</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9018859</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 5(S)-Hp-18(S)-HEPE to 5S,6S-epoxy-18(S)-HEPE</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9018863</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 18(R)-HEPE to 5(S)-Hp-18(R)-HEPE</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9018894</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 5(S)-Hp-18(R)-HEPE to 5S,6S-epoxy-18(R)-HEPE</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020251</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 17(R)-HDHA to 7(S)-Hp-17(R)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020255</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 7(S)-Hp-17(S)-HDHA to 7S(8)-epoxy-17S-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020256</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 7(S)-Hp-17R-HDHA to 7S(8)-epoxy-17R-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020259</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 17(R)-HDHA to 4(S)-Hp-17(R)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020261</owl:annotatedTarget>
+        <rdfs:label>Ac-PTGS2 dimer oxidises DHA to 17(R)-Hp-DHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020264</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 17(S)-HDHA to 4(S)-Hp-17(S)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020277</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 4(S)-Hp-17(S)-HDHA to 4S(5)-epoxy-17(S)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020278</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 4(S)-Hp-17(R)-HDHA to 4S(5)-epoxy-17(R)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9020282</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 17(S)-HDHA to 7(S)-Hp-17(S)-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9024997</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 14(S)-Hp-DHA to 7(S),14(S)-diHp-DHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9025995</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 7,17-diHp-DPAn-3 to 7,8-epoxy,17-HDPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9025996</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 17(S)-Hp-DPAn-3 to 7,17-diHp-DPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9025999</owl:annotatedTarget>
+        <rdfs:label>ALOX5 dehydrogenates 17(S)-Hp-DPAn-3 to 16(S),17(S)-epoxy-DPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9026005</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 14(S)-Hp-DPAn-3 to MaR3n-3 DPA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9026405</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises 13(R)-HDPAn-3 to RvT1-4</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027532</owl:annotatedTarget>
+        <rdfs:label>PTGS2 dimer oxidises DHA to 13-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027607</owl:annotatedTarget>
+        <rdfs:label>Ac-PTGS2 dimer oxidises DPAn-3 to 17-HDPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027624</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises DHA to 7-HDHA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027627</owl:annotatedTarget>
+        <rdfs:label>Ac-PTGS2 dimer oxidises DHA to 17-HDHA (macrophages)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027628</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises EPA to 5-HEPE</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9027633</owl:annotatedTarget>
+        <rdfs:label>ALOX5 oxidises DPAn-3 to 7-HDPAn-3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016701"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9028255</owl:annotatedTarget>
+        <rdfs:label>PTGS2 dimer oxidises EPA to PGH3</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016702">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161775</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161907</oboInOwl:hasDbXref>
@@ -35225,12 +35924,13 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9020274</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026408</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026918</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9916401</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016702"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161775</owl:annotatedTarget>
-        <rdfs:label>ALOX12 oxidises LTA4 to LXA4/B4</rdfs:label>
+        <rdfs:label>ALOX12 oxidises LTA4 to LXA4</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016702"/>
@@ -35274,6 +35974,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-9026918</owl:annotatedTarget>
         <rdfs:label>Lipoxygenase oxidises 17(S)-Hp-DHA to 7(S),17(S)-diHp-DHA</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016702"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9916401</owl:annotatedTarget>
+        <rdfs:label>ALOX12 oxidises LTA4 to LXB4</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016706">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1234164</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6783455</oboInOwl:hasDbXref>
@@ -35291,24 +35997,45 @@
         <rdfs:label>TYW5 hydroxylates yW-72 yielding OHyW-72 at nucleotide 37 of tRNA(Phe)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016709">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-211951</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2162187</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2162194</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-6786239</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016709"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-211951</owl:annotatedTarget>
+        <rdfs:label>CYP1B1 4-hydroxylates EST17b</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016709"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162187</owl:annotatedTarget>
-        <rdfs:label>DHB is hydroxylated to DHDB by COQ6</rdfs:label>
+        <rdfs:label>COQ6 hydroxylates DHB</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016709"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162194</owl:annotatedTarget>
-        <rdfs:label>COQ9 dimer:COQ7:Fe2+ hydroxylates DMQ10H2 to DeMQ10H2</rdfs:label>
+        <rdfs:label>COQ7:COQ9 octamer hydroxylates DMQ10H2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016709"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-6786239</owl:annotatedTarget>
+        <rdfs:label>CYP4V2 omega-hydroxylates DHA to HDoHE</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016712">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-194678</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-211966</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016712"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-194678</owl:annotatedTarget>
+        <rdfs:label>CYP51A1 demethylates LNSOL</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016712"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -35323,15 +36050,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-917805</owl:annotatedTarget>
         <rdfs:label>CYBRD1:Heme reduces Fe3+ to Fe2+</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016723">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-917811</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016723"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-917811</owl:annotatedTarget>
-        <rdfs:label>STEAP3-like proteins reduce Fe3+ to Fe2+</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016740">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1483089</oboInOwl:hasDbXref>
@@ -35367,7 +36085,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-159431</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-192312</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-193491</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-6792572</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8858298</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
@@ -35391,14 +36108,24 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016746"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-6792572</owl:annotatedTarget>
-        <rdfs:label>LIPT1 transfers lipoyl group from lipoyl-GCSH to DHs</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016746"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8858298</owl:annotatedTarget>
         <rdfs:label>HRASLS transfer acyl group from PC to PE to form NAPE</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016747">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9859163</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865115</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016747"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9859163</owl:annotatedTarget>
+        <rdfs:label>DBT transfers BCAA to CoA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016747"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9865115</owl:annotatedTarget>
+        <rdfs:label>DBT loss-of-function mutants don&apos;t synthesize BCAA-CoA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016757">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5173005</oboInOwl:hasDbXref>
@@ -35433,7 +36160,7 @@
         <rdfs:label>thymine or uracil + 2-deoxy-D-ribose 1-phosphate &lt;=&gt; thymidine or deoxyuridine + orthophosphate [TYMP]</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016765">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-3159253</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3095889</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4419978</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-4755545</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6782893</oboInOwl:hasDbXref>
@@ -35441,8 +36168,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016765"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-3159253</owl:annotatedTarget>
-        <rdfs:label>MMAB adenosylates cob(I)alamin</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-3095889</owl:annotatedTarget>
+        <rdfs:label>MMACHC dealkylates RCbl</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016765"/>
@@ -35807,8 +36534,22 @@
         <rdfs:label>TYW1:FMN:4Fe-4S  transforms 1-methylguanosine yielding yW-187 (4-demethylwyosine) at nucleotide 37 of tRNA(Phe)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016830">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-189425</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-190182</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-389611</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016830"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-189425</owl:annotatedTarget>
+        <rdfs:label>UROD decarboxylates URO3 to COPRO3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016830"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-190182</owl:annotatedTarget>
+        <rdfs:label>UROD decarboxylates URO1 to COPRO1</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016830"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -35862,8 +36603,15 @@
         <rdfs:label>SHMT1 tetramer cleaves HTMLYS to yield TEABL and Gly</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016836">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161659</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9014627</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016836"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2161659</owl:annotatedTarget>
+        <rdfs:label>PGE2 is dehydrated to PGA2</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016836"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -35880,8 +36628,22 @@
         <rdfs:label>Excess homocysteine yields homolanthionine and H2S</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016853">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161666</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161735</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6787623</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016853"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2161666</owl:annotatedTarget>
+        <rdfs:label>PGA2 is isomerised to PGC2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016853"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2161735</owl:annotatedTarget>
+        <rdfs:label>PGC2 is isomerised to PGB2</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016853"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -36082,6 +36844,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-429860</owl:annotatedTarget>
         <rdfs:label>DCP1-DCP2 complex decaps mRNA</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016907">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400012</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016907"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-400012</owl:annotatedTarget>
+        <rdfs:label>Acetylcholine binds Muscarinic Acetylcholine Receptor M3</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0016934">
         <oboInOwl:hasDbXref>Reactome:R-HSA-975389</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -36098,7 +36869,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0016992"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-6793591</owl:annotatedTarget>
-        <rdfs:label>LIAS:2(4Fe-4S) transforms octanoyl-K107-GCSH to lipoyl-K107-GCSH</rdfs:label>
+        <rdfs:label>LIAS synthesizes lipoyl-GCSH</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0017018">
         <oboInOwl:hasDbXref>Reactome:R-HSA-390593</oboInOwl:hasDbXref>
@@ -36313,7 +37084,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0017089"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9697077</owl:annotatedTarget>
-        <rdfs:label>Rv1410c transports lprG:LM,LAM from cytosol to the cell wall</rdfs:label>
+        <rdfs:label>Rv1410c transports LprG:LM,LAM from cytosol to the cell wall</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0017089"/>
@@ -36664,6 +37435,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-8856945</owl:annotatedTarget>
         <rdfs:label>PP2A methylation by LCMT1</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0018484">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856794</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0018484"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856794</owl:annotatedTarget>
+        <rdfs:label>Unknown dehydrogenase oxidizes 4-HBz</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0018547">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9620103</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -36937,15 +37717,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-162914</owl:annotatedTarget>
         <rdfs:label>Myristoylation of Nef</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019120">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9011595</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019120"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9011595</owl:annotatedTarget>
-        <rdfs:label>GSTZ1 dimer dehalogenates DCA to glyoxylate</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019135">
         <oboInOwl:hasDbXref>Reactome:R-HSA-204662</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -36964,6 +37735,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-74207</owl:annotatedTarget>
         <rdfs:label>dA, dG, or dI + ATP =&gt; dAMP, dGMP, or dIMP + ADP (DGUOK)</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019158">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9909159</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019158"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9909159</owl:annotatedTarget>
+        <rdfs:label>HK1 phosphorylates Mannose to Man6P</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019166">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6786720</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6809810</oboInOwl:hasDbXref>
@@ -36973,7 +37753,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019166"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-6786720</owl:annotatedTarget>
-        <rdfs:label>DECR2 reduces LCtE-CoA to t3enoyl-CoA</rdfs:label>
+        <rdfs:label>DECR2 reduces a (2E,4E)-dienoyl-CoA to a 4,5-saturated-(3E)-enoyl-CoA</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019166"/>
@@ -37133,6 +37913,7 @@
         <rdfs:label>ADA deamidates RBV</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019706">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203567</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5682084</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9021072</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9647982</oboInOwl:hasDbXref>
@@ -37140,6 +37921,12 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9829047</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9830875</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019706"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203567</owl:annotatedTarget>
+        <rdfs:label>Palmitoylation of eNOS</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019706"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -38147,7 +38934,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019789"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-4719424</owl:annotatedTarget>
-        <rdfs:label>PIAS1 SUMOylates THRB with SUMO1.</rdfs:label>
+        <rdfs:label>PIAS1 SUMOylates THRB with SUMO1</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019789"/>
@@ -38341,14 +39128,14 @@
         <owl:annotatedTarget>Reactome:R-HSA-2993784</owl:annotatedTarget>
         <rdfs:label>Conjugation of SUMO2 to UBA2:SAE1</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0022803">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-429767</oboInOwl:hasDbXref>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019992">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-400015</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0022803"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0019992"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-429767</owl:annotatedTarget>
-        <rdfs:label>Passive I- efflux mediated by SMCT1</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-400015</owl:annotatedTarget>
+        <rdfs:label>Diacylgycerol activates Protein kinase C, alpha type</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0022843">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2534378</oboInOwl:hasDbXref>
@@ -38434,27 +39221,20 @@
         <rdfs:label>An unknown carrier transports mitochondrial glyoxylate to the cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030060">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-198508</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-70979</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-71783</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856871</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030060"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-198508</owl:annotatedTarget>
-        <rdfs:label>MDH1 oxidizes MAL to OA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030060"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-70979</owl:annotatedTarget>
-        <rdfs:label>(S)-Malate + NAD+ &lt;=&gt; Oxaloacetate + NADH + H+</rdfs:label>
+        <rdfs:label>MDH2 dimer dehydrogenates MAL</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030060"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-71783</owl:annotatedTarget>
-        <rdfs:label>MDH2 reduces OA to MAL</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9856871</owl:annotatedTarget>
+        <rdfs:label>MDH1 reduces OA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030144">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9696980</oboInOwl:hasDbXref>
@@ -38480,6 +39260,22 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1878002</owl:annotatedTarget>
         <rdfs:label>XYLTs transfer Xyl to core protein</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030235">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-202129</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-202144</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030235"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-202129</owl:annotatedTarget>
+        <rdfs:label>HSP90 binds eNOS:Caveolin-1:CaM complex</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030235"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-202144</owl:annotatedTarget>
+        <rdfs:label>Caveolin-1 dissociates from eNOS:CaM:HSP90 complex</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030267">
         <oboInOwl:hasDbXref>Reactome:R-HSA-389826</oboInOwl:hasDbXref>
@@ -38626,6 +39422,36 @@
         <owl:annotatedTarget>Reactome:R-HSA-5226964</owl:annotatedTarget>
         <rdfs:label>ANKH transports PPi from cytosol to extracellular region</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030552">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-111925</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381608</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381668</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381707</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030552"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-111925</owl:annotatedTarget>
+        <rdfs:label>cAMP induces dissociation of inactive PKA tetramers</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030552"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381608</owl:annotatedTarget>
+        <rdfs:label>cAMP activates EPAC2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030552"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381668</owl:annotatedTarget>
+        <rdfs:label>cAMP activates EPAC1</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0030552"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381707</owl:annotatedTarget>
+        <rdfs:label>PKA:AKAP79:IQGAP1 complex dissociates to active PKA subunits in response to cAMP</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030586">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3149518</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -38747,10 +39573,20 @@
         <owl:annotatedTarget>Reactome:R-HSA-1234181</owl:annotatedTarget>
         <rdfs:label>Nuclear PHD1,3 hydroxylates proline residues on HIF1A</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0031956">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8875013</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0031956"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8875013</owl:annotatedTarget>
+        <rdfs:label>ACSM3,ACSM6 ligate CoA to BUT</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0031957">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5695957</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5696007</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8875077</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9914143</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0031957"/>
@@ -38769,6 +39605,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8875077</owl:annotatedTarget>
         <rdfs:label>SLC27A3 ligates CoA-SH to VLCFA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0031957"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9914143</owl:annotatedTarget>
+        <rdfs:label>SLC27A2-mediated ligation of peroxisomal fatty acid and CoASH</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0032217">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3165230</oboInOwl:hasDbXref>
@@ -38989,6 +39831,8 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-1268025</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-1299482</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-1307803</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9902096</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9906955</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0032977"/>
@@ -39007,6 +39851,18 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1307803</owl:annotatedTarget>
         <rdfs:label>TIMM22 inserts proteins into inner membrane</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0032977"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9902096</owl:annotatedTarget>
+        <rdfs:label>COX18 inserts nascent MT-CO2 in COX20:TMEM77</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0032977"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9906955</owl:annotatedTarget>
+        <rdfs:label>MT-ND4 is translated</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0033188">
         <oboInOwl:hasDbXref>Reactome:R-HSA-429786</oboInOwl:hasDbXref>
@@ -39054,6 +39910,8 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8952069</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9626962</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9701565</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9825772</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9841847</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0033558"/>
@@ -39078,6 +39936,18 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9701565</owl:annotatedTarget>
         <rdfs:label>HDACs deacetylate p-STAT3 dimers</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0033558"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9825772</owl:annotatedTarget>
+        <rdfs:label>SIRT1 deacetylates HINT1 dimer</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0033558"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9841847</owl:annotatedTarget>
+        <rdfs:label>SIRT3 deacetylates Ac-K272,K290-FOXO3</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0033560">
         <oboInOwl:hasDbXref>Reactome:R-HSA-197963</oboInOwl:hasDbXref>
@@ -39284,6 +40154,29 @@
         <owl:annotatedTarget>Reactome:R-HSA-204647</owl:annotatedTarget>
         <rdfs:label>DHPS tetramer synthesizes Dhp-K50-EIF5A from EIF5A and spermidine</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034041">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-265783</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5679101</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5679145</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034041"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-265783</owl:annotatedTarget>
+        <rdfs:label>ABCG5:ABCG8 transports sterols from cytosol to extracellular region</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034041"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5679101</owl:annotatedTarget>
+        <rdfs:label>Defective ABCG8 (in ABCG5:ABCG8) does not transport sterols from cytosol to extracellular region</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034041"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5679145</owl:annotatedTarget>
+        <rdfs:label>Defective ABCG5 (in ABCG5:ABCG8) does not transport sterols from cytosol to extracellular region</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034062">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5696807</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6786881</oboInOwl:hasDbXref>
@@ -39423,22 +40316,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-6810410</owl:annotatedTarget>
         <rdfs:label>PI(4,5)P2 is dephosphorylated to PI5P by TMEM55B in the nucleus</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034602">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-71037</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-71401</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034602"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-71037</owl:annotatedTarget>
-        <rdfs:label>alpha-ketoadipate + CoASH + NAD+ =&gt; glutaryl-CoA + CO2 + NADH + H+</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034602"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-71401</owl:annotatedTarget>
-        <rdfs:label>alpha-ketoglutarate + CoASH + NAD+ =&gt; succinyl-CoA + CO2 + NADH + H+</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034611">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9009950</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9615042</oboInOwl:hasDbXref>
@@ -39454,6 +40331,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9615042</owl:annotatedTarget>
         <rdfs:label>Viral 2&apos;,5&apos;-PDE cleaves 2&apos;-5&apos; oligoadenylates</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034617">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1497784</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034617"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1497784</owl:annotatedTarget>
+        <rdfs:label>The cofactor BH4 is required for electron transfer in the eNOS catalytic cycle</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034632">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1467466</oboInOwl:hasDbXref>
@@ -39495,6 +40381,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-5688294</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9620532</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9667952</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9854463</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034979"/>
@@ -39537,6 +40424,35 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9667952</owl:annotatedTarget>
         <rdfs:label>ANKLE2 is deacetylated by SIRT2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034979"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9854463</owl:annotatedTarget>
+        <rdfs:label>SIRT3 deacetylates AcK-IDH2 dimer</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0034986">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9854405</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9854984</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9866272</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034986"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9854405</owl:annotatedTarget>
+        <rdfs:label>Frataxin transfers Fe2+ to ACO2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034986"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9854984</owl:annotatedTarget>
+        <rdfs:label>Transfer of Fe-S clusters to SDHB</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0034986"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9866272</owl:annotatedTarget>
+        <rdfs:label>2Fe-2S is inserted in UQCRFS1</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0035005">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1675928</oboInOwl:hasDbXref>
@@ -39673,6 +40589,22 @@
         <owl:annotatedTarget>Reactome:R-HSA-8857692</owl:annotatedTarget>
         <rdfs:label>RNA demethylases demethylate N6-methyladenosine RNA</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0035516">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-112118</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-112123</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0035516"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-112118</owl:annotatedTarget>
+        <rdfs:label>Oxidative demethylation of 1-meA damaged DNA by ALKBH2</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0035516"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-112123</owl:annotatedTarget>
+        <rdfs:label>Oxidative demethylation of 1-meA damaged DNA By ALKBH3</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0035529">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6809287</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -39768,15 +40700,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-2161614</owl:annotatedTarget>
         <rdfs:label>PGD2 is reduced to 11-epi-PGF2a by AKRIC3</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0036132">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2161692</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0036132"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2161692</owl:annotatedTarget>
-        <rdfs:label>15k-PGE2/F2a is reduced to dhk-PGE2/F2a by PTGR1</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0036133">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161732</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -39818,7 +40741,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0036169"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162195</owl:annotatedTarget>
-        <rdfs:label>MHDB is decarboxylated to DMPhOH by MHDB decarboxylase</rdfs:label>
+        <rdfs:label>COQ4 decarboxylates MHDB</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0036175">
         <oboInOwl:hasDbXref>Reactome:R-HSA-111742</oboInOwl:hasDbXref>
@@ -39976,7 +40899,17 @@
         <owl:annotatedTarget>Reactome:R-HSA-2564828</owl:annotatedTarget>
         <rdfs:label>CIA Targeting Complex transfers 4Fe-4S cluster to apoproteins</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0036487">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203712</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0036487"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203712</owl:annotatedTarget>
+        <rdfs:label>eNOS associates with Caveolin-1</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0038024">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203716</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3000103</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3000112</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3000122</oboInOwl:hasDbXref>
@@ -39985,6 +40918,12 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9759202</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9759209</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0038024"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203716</owl:annotatedTarget>
+        <rdfs:label>eNOS:Caveolin-1 complex binds to Nostrin</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0038024"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -40026,6 +40965,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9759209</owl:annotatedTarget>
         <rdfs:label>LRP2 binds extracellular TCN2:RCbl</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0038186">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5340195</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0038186"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5340195</owl:annotatedTarget>
+        <rdfs:label>NR1H4 binds DCA, CDCA, LCHA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042054">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5205861</oboInOwl:hasDbXref>
@@ -40078,9 +41026,16 @@
         <rdfs:label>UBE2L6:TRIM25 ISGylates monoUb:K164-PCNA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042392">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-428664</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-428690</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-428696</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042392"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-428664</owl:annotatedTarget>
+        <rdfs:label>SGPP1,2 dephosphorylate sphingoid-1-phosphates</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042392"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -40113,6 +41068,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-1467457</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161506</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161538</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-390393</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9033499</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9033505</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9659680</oboInOwl:hasDbXref>
@@ -40143,6 +41099,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161538</owl:annotatedTarget>
         <rdfs:label>abacavir [cytosol] + ATP + H2O =&gt; abacavir[extracellular] + ADP + phosphate</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042626"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-390393</owl:annotatedTarget>
+        <rdfs:label>Peroxisomal uptake of very long-chain fatty acyl CoA</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042626"/>
@@ -40240,6 +41202,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8936621</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8937016</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8937050</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9843121</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042800"/>
@@ -40282,6 +41245,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-8937050</owl:annotatedTarget>
         <rdfs:label>Core MLL complex methylates H3K4Me2-Nucleosome at the MIR27A gene promoter</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0042800"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9843121</owl:annotatedTarget>
+        <rdfs:label>KMT2D,(KMT2C) complex monomethylates nucleosomes at PPARG:RXRA-bound enhancers</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042903">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5618331</oboInOwl:hasDbXref>
@@ -40432,15 +41401,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-1483063</owl:annotatedTarget>
         <rdfs:label>PG and CDP-DAG are converted to CL by CRLS1</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0043430">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2162188</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0043430"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2162188</owl:annotatedTarget>
-        <rdfs:label>MDMQ10H2 is methylated to DMQ10H2 by COQ5</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0043682">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3697838</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6803545</oboInOwl:hasDbXref>
@@ -40470,22 +41430,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-936895</owl:annotatedTarget>
         <rdfs:label>ATP7B transports cytosolic Cu2+ to Golgi lumen</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0043734">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-112118</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-112123</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0043734"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-112118</owl:annotatedTarget>
-        <rdfs:label>Oxidative demethylation of 1-meA damaged DNA by ALKBH2</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0043734"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-112123</owl:annotatedTarget>
-        <rdfs:label>Oxidative demethylation of 1-meA damaged DNA By ALKBH3</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0043813">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1675836</oboInOwl:hasDbXref>
@@ -40553,6 +41497,9 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0044183">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9018785</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9855212</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9865893</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9866253</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044183"/>
@@ -40560,23 +41507,23 @@
         <owl:annotatedTarget>Reactome:R-HSA-9018785</owl:annotatedTarget>
         <rdfs:label>RHOBTB2 binds GTP</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0044595">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2162193</oboInOwl:hasDbXref>
-    </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044595"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044183"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2162193</owl:annotatedTarget>
-        <rdfs:label>DHDB is methylated to MHDB by COQ3</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9855212</owl:annotatedTarget>
+        <rdfs:label>SDHA binds to SDHB</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0044596">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2162186</oboInOwl:hasDbXref>
-    </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044596"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044183"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2162186</owl:annotatedTarget>
-        <rdfs:label>DeMQ10H2 is methylated to Q10H2 by COQ3</rdfs:label>
+        <owl:annotatedTarget>Reactome:R-HSA-9865893</owl:annotatedTarget>
+        <rdfs:label>MT-CYB is translated</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044183"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9866253</owl:annotatedTarget>
+        <rdfs:label>apo-UQCRFS1 binds LYRM7</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0044600">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9765952</oboInOwl:hasDbXref>
@@ -40620,15 +41567,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2395965</owl:annotatedTarget>
         <rdfs:label>NUDT18 hydrolyses 8-oxo-dADP to 8-oxo-dAMP</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0044736">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2671885</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0044736"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2671885</owl:annotatedTarget>
-        <rdfs:label>ASIC trimers:H+ transport extracellular Na+ to cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0045127">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6803771</oboInOwl:hasDbXref>
@@ -40860,6 +41798,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-5655323</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8852019</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9021627</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9028519</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9603445</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9664664</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9664940</oboInOwl:hasDbXref>
@@ -40867,6 +41806,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9672162</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9672177</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9712084</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860816</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
@@ -40920,7 +41860,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1839107</owl:annotatedTarget>
-        <rdfs:label>BCR-FGFR1-associated PI3K phosphorylates PIP2 to PIP3.</rdfs:label>
+        <rdfs:label>BCR-FGFR1-associated PI3K phosphorylates PIP2 to PIP3</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
@@ -41099,6 +42039,12 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9028519</owl:annotatedTarget>
+        <rdfs:label>NTRK2-activated PI3K generates PIP3</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9603445</owl:annotatedTarget>
         <rdfs:label>Activated NTRK3 stimulates PI3K activity</rdfs:label>
     </owl:Axiom>
@@ -41138,6 +42084,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-9712084</owl:annotatedTarget>
         <rdfs:label>PI3K synthesizes PIP3 downstream of ALK mutants</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046934"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860816</owl:annotatedTarget>
+        <rdfs:label>Phospho-PI3K in p-Y713-PECAM1:CDH5:PIK3CA,B,D:p-Y464-PIK3R2:p-Y801,Y1054,Y1175-KDR:p-Y1063,Y1230-FLT4:CTNNB1 phosphorylates phosphoinositol-4,5-bisphosphate to yield phosphoinositol-3,4,5-trisphosphate</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0046943">
         <oboInOwl:hasDbXref>Reactome:R-HSA-390347</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -41173,7 +42125,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046974"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-427336</owl:annotatedTarget>
-        <rdfs:label>TTF1:rRNA promoter:ERCC6:EHMT2 complex dimethylates histone H3 at lysine-9.</rdfs:label>
+        <rdfs:label>TTF1:rRNA promoter:ERCC6:EHMT2 complex dimethylates histone H3 at lysine-9</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0046974"/>
@@ -41457,15 +42409,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-9846501</owl:annotatedTarget>
         <rdfs:label>B3GNT5 transfers GlcNAc to LacCer</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047263">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-6785933</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047263"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-6785933</owl:annotatedTarget>
-        <rdfs:label>UGT8 transfers Gal from UDP-Gal to CERA</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047273">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8878914</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -41522,12 +42465,19 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047323">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5693148</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9912480</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047323"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5693148</owl:annotatedTarget>
         <rdfs:label>BCKDK phosphorylates BCKDH</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047323"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9912480</owl:annotatedTarget>
+        <rdfs:label>BCKDK loss-of-function mutations do not phosphorylate BCKDH</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047325">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1855162</oboInOwl:hasDbXref>
@@ -41722,13 +42672,20 @@
         <rdfs:label>GLCE epimerises more GlcA to IdoA as sulfate content rises</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047498">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-111881</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-111883</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047498"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-111881</owl:annotatedTarget>
+        <rdfs:label>Phospho-cPLA2 translocates to membranes when intracellular calcium levels increase</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047498"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-111883</owl:annotatedTarget>
-        <rdfs:label>Hydrolysis of phosphatidylcholine</rdfs:label>
+        <rdfs:label>PLA2G4A (cPLA2) hydrolyzes phosphatidylcholine</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047499">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8952251</oboInOwl:hasDbXref>
@@ -41747,6 +42704,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2465941</owl:annotatedTarget>
         <rdfs:label>A REH hydrolyses 11cRE to 11cROL</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047522">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2161692</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047522"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2161692</owl:annotatedTarget>
+        <rdfs:label>15k-PGE2/F2a is reduced to dhk-PGE2/F2a by PTGR1</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047536">
         <oboInOwl:hasDbXref>Reactome:R-HSA-508561</oboInOwl:hasDbXref>
@@ -41967,15 +42933,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-2022052</owl:annotatedTarget>
         <rdfs:label>Dermatan-sulfate epimerase (DSE) converts chondroitin sulfate (CS) to dermatan sulfate (DS)</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047760">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-8875013</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047760"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-8875013</owl:annotatedTarget>
-        <rdfs:label>ACSM3,ACSM6 ligate CoA to BUT</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047800">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6814153</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -42066,6 +43023,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-893616</owl:annotatedTarget>
         <rdfs:label>glutamine + pyruvate =&gt; 2-oxoglutaramate + alanine</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047952">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-75889</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0047952"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-75889</owl:annotatedTarget>
+        <rdfs:label>DHAP is converted to G3P by GPD1/GPD1L</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0047961">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2534040</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -42150,6 +43116,31 @@
         <owl:annotatedTarget>Reactome:R-HSA-6788611</owl:annotatedTarget>
         <rdfs:label>HYKK phosphorylates 5HLYS</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0048018">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-163625</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-381612</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0048018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-163625</owl:annotatedTarget>
+        <rdfs:label>Glucagon binds to Glucagon receptor</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0048018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-381612</owl:annotatedTarget>
+        <rdfs:label>GLP1R binds GLP1</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0048040">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8863761</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0048040"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8863761</owl:annotatedTarget>
+        <rdfs:label>UXS1 tetramer decarboxylates UDP-glucuronate to UDP-xylose</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0048244">
         <oboInOwl:hasDbXref>Reactome:R-HSA-389639</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -42158,6 +43149,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-389639</owl:annotatedTarget>
         <rdfs:label>phytanoyl-CoA + 2-oxoglutarate + O2 =&gt; 2-hydroxyphytanoyl-CoA + succinate + CO2</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0048763">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2855020</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0048763"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2855020</owl:annotatedTarget>
+        <rdfs:label>RYR tetramers transport Ca2+ from sarcoplasmic reticulum lumen to cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050031">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6783880</oboInOwl:hasDbXref>
@@ -42356,7 +43356,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050211"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1981120</owl:annotatedTarget>
-        <rdfs:label>Galactosylation of collagen propeptide hydroxylysines by procollagen galactosyltransferases 1, 2.</rdfs:label>
+        <rdfs:label>Galactosylation of collagen propeptide hydroxylysines by procollagen galactosyltransferases 1, 2</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050211"/>
@@ -42583,10 +43583,8 @@
         <rdfs:label>PXLP-K278-ETNPPL tetramer hydrolyses PETA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050473">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2161951</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2162002</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9018907</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9020261</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9020262</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9020275</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9020610</oboInOwl:hasDbXref>
@@ -42594,34 +43592,18 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9024881</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9025152</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9026003</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027532</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027607</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9027627</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9028255</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2161951</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to 15R-HETE by Acetyl-PTGS2</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162002</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is oxidised to 15S-HpETE by ALOX15/15B</rdfs:label>
+        <rdfs:label>Arachidonate is oxidised to 15S-HpETE by ALOX15/15B</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9018907</owl:annotatedTarget>
         <rdfs:label>ALOX15 oxidises 18(R)-HEPE to 18(R)-RvE3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9020261</owl:annotatedTarget>
-        <rdfs:label>Ac-PTGS2 dimer oxidises DHA to 17(R)-Hp-DHA</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
@@ -42664,30 +43646,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9026003</owl:annotatedTarget>
         <rdfs:label>ALOX15 oxidises DPAn-3 to 17(S)-Hp-DPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027532</owl:annotatedTarget>
-        <rdfs:label>PTGS2 dimer oxidises DHA to 13-HDHA</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027607</owl:annotatedTarget>
-        <rdfs:label>Ac-PTGS2 dimer oxidises DPAn-3 to 17-HDPAn-3</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9027627</owl:annotatedTarget>
-        <rdfs:label>Ac-PTGS2 dimer oxidises DHA to 17-HDHA (macrophages)</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050473"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9028255</owl:annotatedTarget>
-        <rdfs:label>PTGS2 dimer oxidises EPA to PGH3</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050479">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5696119</oboInOwl:hasDbXref>
@@ -42836,6 +43794,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-6787642</owl:annotatedTarget>
         <rdfs:label>TSTA3 dimer reduces GDP-KDGal to GDP-Fuc</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050585">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856718</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050585"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856718</owl:annotatedTarget>
+        <rdfs:label>HPDL dioxygenates HPPA</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050610">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5696230</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -42930,7 +43897,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0050833"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-372342</owl:annotatedTarget>
-        <rdfs:label>MPC1:MPC2 cotransports PYR, H+ from cytosol to mitochondrial matrix</rdfs:label>
+        <rdfs:label>MPC1:MPC2 imports PYR, H+ to mitochondrial matrix</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0051033">
         <oboInOwl:hasDbXref>Reactome:R-HSA-203906</oboInOwl:hasDbXref>
@@ -42988,7 +43955,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0051120"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2161794</owl:annotatedTarget>
-        <rdfs:label>Arachidonic acid is converted to HXA3/B3 by ALOX12</rdfs:label>
+        <rdfs:label>Arachidonate is converted to HXA3/B3 by ALOX12</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0051120"/>
@@ -43044,6 +44011,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-162798</owl:annotatedTarget>
         <rdfs:label>mannose(a1-4)glucosaminyl-acyl-PI + phosphatidylethanolamine -&gt; (ethanolamineP) mannose(al1-4)glucosaminyl-acyl-PI + diacylglycerol</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0051536">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5690873</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0051536"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5690873</owl:annotatedTarget>
+        <rdfs:label>ACO1 binds 4Fe-4S</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0051717">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1855200</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-1855205</oboInOwl:hasDbXref>
@@ -43072,6 +44048,7 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0051719">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5334097</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5334152</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9845308</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0051719"/>
@@ -43084,6 +44061,12 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-5334152</owl:annotatedTarget>
         <rdfs:label>DNMT3A:DNMT3L methylates cytosine in DNA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0051719"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9845308</owl:annotatedTarget>
+        <rdfs:label>DNMT3A:DNMT3L in nascent RNA transcript:MeR-PIWIL4:2&apos;-O-methyl-piRNA:SPOCD1:DNMT3A:DNMT3L methylates cytosine in DNA</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0051722">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8856951</oboInOwl:hasDbXref>
@@ -43269,7 +44252,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-2465921</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2465940</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-2466861</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-2471670</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5419165</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5615668</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5623643</oboInOwl:hasDbXref>
@@ -43303,12 +44285,6 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0052650"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2466861</owl:annotatedTarget>
-        <rdfs:label>Defective RDH12 does not reduce atRAL to atROL and causes LCA13</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0052650"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-2471670</owl:annotatedTarget>
         <rdfs:label>Defective RDH12 does not reduce atRAL to atROL</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
@@ -43366,15 +44342,6 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-1855218</owl:annotatedTarget>
         <rdfs:label>I(1,3,4,5)P4 is dephosphorylated to I(1,3,4)P3 by INPP5[3]/ITPK1 in the cytosol</rdfs:label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0052665">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-6788707</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0052665"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-6788707</owl:annotatedTarget>
-        <rdfs:label>TRMT44 2&apos;-O-methylates uridine-44 in tRNA(Ser)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0052689">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5693691</oboInOwl:hasDbXref>
@@ -43646,6 +44613,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-2023971</owl:annotatedTarget>
         <rdfs:label>1/3 PP-IP5 is dephosphorylated to IP6 by NUDT(1) in the cytosol</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0052851">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-917811</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0052851"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-917811</owl:annotatedTarget>
+        <rdfs:label>STEAP3,STEAP4 reduce Fe3+ to Fe2+</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0052857">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6806966</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -43819,6 +44795,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-3257122</owl:annotatedTarget>
         <rdfs:label>SLC37A1, SLC37A2 exchange G6P for Pi across the ER membrane</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061542">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2162186</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061542"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2162186</owl:annotatedTarget>
+        <rdfs:label>COQ3 methylates DeMQ10H2</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061547">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3780994</oboInOwl:hasDbXref>
@@ -44047,7 +45032,6 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8956026</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8956684</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9008076</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Reactome:R-HSA-9008479</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9009308</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9009403</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9011300</oboInOwl:hasDbXref>
@@ -44490,12 +45474,6 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061630"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-9008479</owl:annotatedTarget>
-        <rdfs:label>FBXW7 polyubiquitinates RUNX2</rdfs:label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061630"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9009308</owl:annotatedTarget>
         <rdfs:label>STUB1 polyubiquitinates RUNX2</rdfs:label>
     </owl:Axiom>
@@ -44639,12 +45617,28 @@
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061665">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9834809</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842868</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061665"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9834809</owl:annotatedTarget>
         <rdfs:label>SUMOylation of PKR</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061665"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842868</owl:annotatedTarget>
+        <rdfs:label>TRIM28 in TRIM28:KRAB-ZFP:retroelement chromatin autoSUMOylates with SUMO2</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061690">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9861626</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061690"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9861626</owl:annotatedTarget>
+        <rdfs:label>SIRT4 cleaves lipoyl from DLAT</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061708">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6787447</oboInOwl:hasDbXref>
@@ -44672,6 +45666,7 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-9626945</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9701531</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9756494</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9825747</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061733"/>
@@ -44715,6 +45710,12 @@
         <owl:annotatedTarget>Reactome:R-HSA-9756494</owl:annotatedTarget>
         <rdfs:label>CREBBP acetylates SARS-CoV-2 N at K375</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061733"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9825747</owl:annotatedTarget>
+        <rdfs:label>CREBBP acetylates HINT1 dimer</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061769">
         <oboInOwl:hasDbXref>Reactome:R-HSA-8869606</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8869607</oboInOwl:hasDbXref>
@@ -44731,11 +45732,25 @@
         <owl:annotatedTarget>Reactome:R-HSA-8869607</owl:annotatedTarget>
         <rdfs:label>NMRK2 phosphorylates NAR to yield NAMN</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061810">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0061809">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8870346</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8938076</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9637699</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061810"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061809"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8870346</owl:annotatedTarget>
+        <rdfs:label>BST1 hydrolyzes NAD+ to yield NAM and ADP-ribose</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061809"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8938076</owl:annotatedTarget>
+        <rdfs:label>CD38 hydrolyses NAD+ to NAM and ADP-ribose</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0061809"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9637699</owl:annotatedTarget>
         <rdfs:label>CpnT hydrolyses NAD+</rdfs:label>
@@ -44908,19 +45923,19 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0070573"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022398</owl:annotatedTarget>
-        <rdfs:label>ACE hydrolyzes Angiotensin-(1-9) to Angiotensin-(1-7)</rdfs:label>
+        <rdfs:label>ACE:Zn2+ hydrolyzes Angiotensin-(1-9) to Angiotensin-(1-7)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0070573"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2022405</owl:annotatedTarget>
-        <rdfs:label>ACE hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-8)</rdfs:label>
+        <rdfs:label>ACE:Zn2+ hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-8)</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0070573"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2065355</owl:annotatedTarget>
-        <rdfs:label>Secreted ACE hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-8)</rdfs:label>
+        <rdfs:label>Secreted ACE:Zn2+ hydrolyzes Angiotensin-(1-10) to Angiotensin-(1-8)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0070579">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5220952</oboInOwl:hasDbXref>
@@ -45029,15 +46044,6 @@
         <owl:annotatedTarget>Reactome:R-HSA-428262</owl:annotatedTarget>
         <rdfs:label>ACER3 hydrolyzes phytoceramide</rdfs:label>
     </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0070780">
-        <oboInOwl:hasDbXref>Reactome:R-HSA-428664</oboInOwl:hasDbXref>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0070780"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-        <owl:annotatedTarget>Reactome:R-HSA-428664</owl:annotatedTarget>
-        <rdfs:label>SGPP1,2 dephosphorylate sphingoid-1-phosphates</rdfs:label>
-    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0070815">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9630022</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -45083,6 +46089,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9822985</owl:annotatedTarget>
         <rdfs:label>KDM6A (UTX) demethylates histone H3 trimethyllysine-27 (H3K27me3)</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0071714">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-428990</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0071714"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-428990</owl:annotatedTarget>
+        <rdfs:label>SLC27A1 transports arachidonate across the ER membrane</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0072345">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2685505</oboInOwl:hasDbXref>
@@ -45188,6 +46203,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-6800797</owl:annotatedTarget>
         <rdfs:label>The PIDDosome activates CASP2</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0097159">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1497796</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0097159"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1497796</owl:annotatedTarget>
+        <rdfs:label>BH2 binding can lead to eNOS uncoupling</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0097257">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2161567</oboInOwl:hasDbXref>
     </rdf:Description>
@@ -45274,7 +46298,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0097269"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-2162253</owl:annotatedTarget>
-        <rdfs:label>FPP and IPPP are combined into all-E-10PrP2 by PDSS1/2 tetramer</rdfs:label>
+        <rdfs:label>PDSS1,2 ligates FPP to IPPP</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0097363">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9687828</oboInOwl:hasDbXref>
@@ -45556,6 +46580,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-9756177</owl:annotatedTarget>
         <rdfs:label>PON1,3 hydrolyse ATVL to ATV</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0102039">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1222526</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0102039"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1222526</owl:annotatedTarget>
+        <rdfs:label>AhpC reduces peroxidated lipids</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0106050">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6788668</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-6788684</oboInOwl:hasDbXref>
@@ -45652,10 +46685,29 @@
         <owl:annotatedTarget>Reactome:R-HSA-1972385</owl:annotatedTarget>
         <rdfs:label>ADP-Ribosylation of HNP-1</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0106309">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-193964</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-193981</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106309"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-193964</owl:annotatedTarget>
+        <rdfs:label>CYP21A2 21-hydroxylates PROG</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106309"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-193981</owl:annotatedTarget>
+        <rdfs:label>CYP21A2 oxidises 17HPROG</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0106310">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9729330</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9821967</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9821982</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9841265</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860792</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9860808</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106310"/>
@@ -45674,6 +46726,33 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9821982</owl:annotatedTarget>
         <rdfs:label>SRPK1 phosphorylates PRM1 in PRM1:dsDNA</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106310"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9841265</owl:annotatedTarget>
+        <rdfs:label>p-S473-AKT1 phosphorylates ESR1 on serine-167</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106310"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860792</owl:annotatedTarget>
+        <rdfs:label>Phospho-AKT1 phosphorylates NOS3 (eNOS) on serine-1177</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106310"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9860808</owl:annotatedTarget>
+        <rdfs:label>p-T816-PKN2 phosphorylates NOS3 (eNOS) on serine-1179</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0106340">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9024161</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106340"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9024161</owl:annotatedTarget>
+        <rdfs:label>FTSJ1 2&apos;-O-methylates guanosine-34 in tRNA(Phe)</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0106377">
         <oboInOwl:hasDbXref>Reactome:R-HSA-2395872</oboInOwl:hasDbXref>
@@ -45711,7 +46790,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106435"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9619024</owl:annotatedTarget>
-        <rdfs:label>CES1trimer hydrolyses ACEI pro-drugs to ACEIs</rdfs:label>
+        <rdfs:label>CES1 trimer hydrolyses ACEI pro-drugs to ACEIs</rdfs:label>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0106435"/>
@@ -45724,6 +46803,68 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-9749647</owl:annotatedTarget>
         <rdfs:label>CES2 hydrolyzes ASA-</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0120013">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856502</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9856510</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120013"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856502</owl:annotatedTarget>
+        <rdfs:label>mito-STARD7 transports Q10 to outer mitochondrial membrane</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120013"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9856510</owl:annotatedTarget>
+        <rdfs:label>STARD7 transports Q10 to plasma membrane</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0120015">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5250531</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8867667</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-8868402</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120015"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5250531</owl:annotatedTarget>
+        <rdfs:label>ARV1 transports CHOL from ER membrane to plasma membrane</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120015"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8867667</owl:annotatedTarget>
+        <rdfs:label>OSBPs transport 25OH-CHOL from ER membrane to plasma membrane</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120015"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-8868402</owl:annotatedTarget>
+        <rdfs:label>OSBP exchanges 25OH-CHOL with PI4P from ER membrane to Golgi membrane</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0120019">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1483087</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1483211</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1483219</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120019"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1483087</owl:annotatedTarget>
+        <rdfs:label>PI is exchanged with PC by PITPNB</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120019"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1483211</owl:annotatedTarget>
+        <rdfs:label>PC:PITPNB is transported from the Golgi membrane to the ER membrane</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0120019"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1483219</owl:annotatedTarget>
+        <rdfs:label>PC is exchanged with PI by PITPNB</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0120020">
         <oboInOwl:hasDbXref>Reactome:R-HSA-1454928</oboInOwl:hasDbXref>
@@ -45776,9 +46917,47 @@
         <owl:annotatedTarget>Reactome:R-HSA-8951850</owl:annotatedTarget>
         <rdfs:label>TSPO:BZRAP1 transports CHOL from outer mitochondrial membrane to inner mitochondrial membrane</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140104">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-1449687</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3149494</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3149563</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3159259</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-3204318</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-1449687</owl:annotatedTarget>
+        <rdfs:label>Corticosteroids bind to CBG in blood</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-3149494</owl:annotatedTarget>
+        <rdfs:label>MMACHC:cob(II)alamin binds MMADHC</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-3149563</owl:annotatedTarget>
+        <rdfs:label>MMADHC targets transport of cytosolic cob(II)alamin to mitochondria</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-3159259</owl:annotatedTarget>
+        <rdfs:label>MMAA:MUT binds AdoCbl</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-3204318</owl:annotatedTarget>
+        <rdfs:label>cob(II)alamin is transferred from MMACHC:MMADHC:cob(II)alamin to MTRR:MTR</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140135">
         <oboInOwl:hasDbXref>Reactome:R-HSA-9659380</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-9663363</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9855089</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140135"/>
@@ -45792,9 +46971,45 @@
         <owl:annotatedTarget>Reactome:R-HSA-9663363</owl:annotatedTarget>
         <rdfs:label>Mechanoelectrical transduction (MET) channel transports cations into the cytosol of stereocilia of cochlear outer hair cell</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140135"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9855089</owl:annotatedTarget>
+        <rdfs:label>PIEZO1 trimer passively transports cations across the plasma membrane according to their electrochemical gradients</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140312">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203565</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203662</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140312"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203565</owl:annotatedTarget>
+        <rdfs:label>eNOS:Caveolin-1:NOSTRIN:dynamin-2 complex binds N-WASP</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140312"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203662</owl:annotatedTarget>
+        <rdfs:label>eNOS:Caveolin-1:NOSTRIN complex binds dynamin-2</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140313">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203553</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-203680</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3245898</oboInOwl:hasDbXref>
     </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140313"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203553</owl:annotatedTarget>
+        <rdfs:label>eNOS binds NOSIP</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140313"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-203680</owl:annotatedTarget>
+        <rdfs:label>eNOS:NOSIP translocation from caveolae to intracellular compartments</rdfs:label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140313"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
@@ -45925,6 +47140,15 @@
         <owl:annotatedTarget>Reactome:R-HSA-9822185</owl:annotatedTarget>
         <rdfs:label>HIRA and NPM2 assemble H3.3-containing nucleosomes on paternal DNA</rdfs:label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140767">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-202137</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140767"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-202137</owl:annotatedTarget>
+        <rdfs:label>AKT1 binds eNOS complex via HSP90</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140938">
         <oboInOwl:hasDbXref>Reactome:R-HSA-3788745</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-3788748</oboInOwl:hasDbXref>
@@ -45951,6 +47175,9 @@
         <oboInOwl:hasDbXref>Reactome:R-HSA-8936608</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8937022</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-8937113</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9842833</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9844006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9844057</oboInOwl:hasDbXref>
     </rdf:Description>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140938"/>
@@ -46102,6 +47329,24 @@
         <owl:annotatedTarget>Reactome:R-HSA-8937113</owl:annotatedTarget>
         <rdfs:label>PRMT6 arginine methylates H3K4me2-Nucleosome at the MIR27A gene promoter</rdfs:label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140938"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9842833</owl:annotatedTarget>
+        <rdfs:label>SETDB1 in ATF7IP:SETDB1:SUMO2-6K-TRIM28:KRAB-ZFP:retroelement trimethylates lysine-9 of histone H3 in nucleosomes</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140938"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9844006</owl:annotatedTarget>
+        <rdfs:label>SETDB1 in me3-K16-ATF7IP:SETDB1:MORC2:HUSH complex:L1 RNA trimethylates lysine-9 of histone H3 (H3K9me3)</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0140938"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9844057</owl:annotatedTarget>
+        <rdfs:label>SETDB1 in me3-K16-ATF7IP:SETDB1:MORC2:HUSH complex:L1HS,L1PA2,3 heterochromatin trimethylates lysine-9 of histone H3 in adjacent nucleosome</rdfs:label>
+    </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0140939">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5423038</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>Reactome:R-HSA-5651654</oboInOwl:hasDbXref>
@@ -46133,6 +47378,42 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-548818</owl:annotatedTarget>
         <rdfs:label>HSD17B3,12 hydrogenates 3OOD-CoA to 3HODC-CoA</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0141101">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-6788707</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0141101"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-6788707</owl:annotatedTarget>
+        <rdfs:label>TRMT44 2&apos;-O-methylates uridine-44 in tRNA(Ser)</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0141133">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-5358484</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0141133"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-5358484</owl:annotatedTarget>
+        <rdfs:label>DPH5 transfers four methyl groups from AdoMet to aminocarboxypropyl EEF2</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0141192">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-9825790</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0141192"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-9825790</owl:annotatedTarget>
+        <rdfs:label>p-S207 KARS1 dimer synthesizes A(5&apos;)p4(5&apos;)A</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0160081">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-429767</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0160081"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-429767</owl:annotatedTarget>
+        <rdfs:label>Passive I- efflux mediated by SLC5A8</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0160102">
         <oboInOwl:hasDbXref>Reactome:R-HSA-6786501</oboInOwl:hasDbXref>
@@ -46176,6 +47457,15 @@
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
         <owl:annotatedTarget>Reactome:R-HSA-6787525</owl:annotatedTarget>
         <rdfs:label>TRMT61B methylates adenosine-58 in tRNA yielding 1-methyladenosine-58</rdfs:label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0160128">
+        <oboInOwl:hasDbXref>Reactome:R-HSA-2671885</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_0160128"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>Reactome:R-HSA-2671885</owl:annotatedTarget>
+        <rdfs:label>ASIC trimers:H+ transport extracellular Na+ to cytosol</rdfs:label>
     </owl:Axiom>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_1902388">
         <oboInOwl:hasDbXref>Reactome:R-HSA-5339535</oboInOwl:hasDbXref>


### PR DESCRIPTION
For #29249.

I thought this was being refreshed when the ontology was built in the pipeline, however when I run it locally the xref to the obsolete term does not appear. Hopefully this will unstick things, but I think the workflow here needs a little more investigation.