### PR TITLE
Update never_in_taxon.tsv for #22455

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -420,7 +420,6 @@ GO:2000097	regulation of smooth muscle cell-matrix adhesion	NCBITaxon:4751	Fungi
 GO:0035994	response to muscle stretch	NCBITaxon:4751	Fungi	
 GO:0035995	detection of muscle stretch	NCBITaxon:4751	Fungi	
 GO:0033651	host cell plastid	NCBITaxon:4751	Fungi	
-GO:1902949	positive regulation of tau-protein kinase activity	NCBITaxon:4751	Fungi	
 GO:1902947	regulation of tau-protein kinase activity	NCBITaxon:4751	Fungi	
 GO:1902948	negative regulation of tau-protein kinase activity	NCBITaxon:4751	Fungi	
 GO:0061302	smooth muscle cell-matrix adhesion	NCBITaxon:4751	Fungi	


### PR DESCRIPTION
removed GO:1902949 positive regulation of tau-protein kinase activity as it is being obsoleted