### PR TITLE
Update GO:0160274 beige fat cell differentiation with logical definition

### DIFF
--- a/src/ontology/imports/cl_terms.txt
+++ b/src/ontology/imports/cl_terms.txt
@@ -18,3 +18,4 @@ http://purl.obolibrary.org/obo/CL_0002301 ## type B synovial cell
 http://purl.obolibrary.org/obo/CL_0011025 ## exhausted T cell
 http://purl.obolibrary.org/obo/CL_2000089 ## dentate gyrus of hippocampal formation granule cell
 http://purl.obolibrary.org/obo/CL_0002204 ## brush cell
+http://purl.obolibrary.org/obo/CL_0001070 ## beige adipocyte


### PR DESCRIPTION
## Summary
- Updated GO:0160274 beige fat cell differentiation to use logical definition instead of is_a relationship
- Removed `is_a: GO:0045444 \! fat cell differentiation` 
- Added logical definition using intersection_of relationships:
  - `intersection_of: GO:0030154 \! cell differentiation`
  - `intersection_of: results_in_acquisition_of_features_of CL:0001070 \! beige adipocyte`
- Added CL:0001070 beige adipocyte to cl_terms.txt for proper import support

## Rationale
This change follows the compositional pattern used by other cell differentiation terms in GO and provides a more logically precise definition. The term is now defined as cell differentiation that results in acquisition of beige adipocyte features, properly referencing CL:0001070 as requested.

## Note
The Docker-based CL import file regeneration (`./run.sh make imports/cl_import.obo`) could not be completed due to TTY requirements in the CI environment. The cl_terms.txt file has been updated to include the required CL:0001070 term, but the actual import files will need to be regenerated in an environment with proper Docker TTY support.

## Test plan
- [ ] Verify GO:0160274 term has correct logical definition
- [ ] Verify CL:0001070 is properly added to cl_terms.txt
- [ ] Regenerate CL import files using Docker in appropriate environment
- [ ] Validate ontology consistency after changes

🤖 Generated with [Claude Code](https://claude.ai/code)