### PR TITLE
Add taxon constraint for GO:0061708 excluding fungi

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -686,4 +686,5 @@ GO:0097271	protein localization to bud neck	NCBITaxon:4896	Schizosaccharomyces p
 GO:0097271	protein localization to bud neck	NCBITaxon:33208	Metazoa	
 GO:0141152	glycerol-3-phosphate dehydrogenase (NAD+) activity	NCBITaxon:2157	Archaea	
 GO:0000105	L-histidine biosynthetic process	NCBITaxon:7742	Vertebrata	
-GO:0071266	'de novo' L-methionine biosynthetic process	NCBITaxon:40674	Mammalia	
+GO:0071266	'de novo' L-methionine biosynthetic process	NCBITaxon:40674	Mammalia
+GO:0061708	tRNA-5-taurinomethyluridine 2-sulfurtransferase	NCBITaxon:4751	Fungi	


### PR DESCRIPTION
## Summary
- Added `never_in_taxon` constraint for GO:0061708 (tRNA-5-taurinomethyluridine 2-sulfurtransferase) excluding fungi (NCBITaxon:4751)
- This addresses the request in issue #30500

## Details
- Added entry to `src/taxon_constraints/never_in_taxon.tsv`
- GO term: GO:0061708  < /dev/null |  tRNA-5-taurinomethyluridine 2-sulfurtransferase  
- Taxon restriction: NCBITaxon:4751 | Fungi

## Evidence
The constraint was requested with supporting evidence from https://github.com/geneontology/go-annotation/issues/5781 indicating this enzyme activity is not found in fungi.

## Test plan
- [x] Verify the GO term exists and has correct definition
- [x] Follow existing format in never_in_taxon.tsv file
- [x] Use correct NCBITaxon ID for fungi (4751)
- [ ] Verify syntax and format are correct via automated checks

Fixes #30500

🤖 Generated with [Claude Code](https://claude.ai/code)

@dragon-ai-agent