### PR TITLE
Boosting dragon-ai-agent permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,27 +1,14 @@
 {
   "permissions": {
     "allow": [
-        "FileEdit",
-        "Edit",
-        "Edit(*)",
-        "Bash",
         "Bash(*)",
-        "Bash(obo-checkout.pl:*)",
-        "Bash(obo-checkin.pl:*)",
-        "Bash(obo-grep.pl:*)",
-        "Bash(curl:*)",
-        "Bash(runoak:*)",
-        "Bash(aurelian:*)",
-        "Bash(make:*)",
-        "Bash(robot:*)",
-        "Bash(head:*)",
-        "Bash(tail:*)",
-        "Bash(echo:*)",
-        "Bash(sort:*)",
-        "Bash(mkdir:*)",
-        "Bash(grep:*)",
-        "Bash(git:*)",
-        "Bash(gh:*)"
+        "Edit",
+        "MultiEdit",
+        "NotebookEdit",
+        "FileEdit",
+        "WebFetch",
+        "WebSearch",
+        "Write"
     ]
   }
 }

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -213,7 +213,7 @@ jobs:
 
           # Run Claude with proper permissions
           claude -p "$(cat /tmp/claude-input/claude_prompt.txt)" \
+            --permission-mode bypassPermissions \
             --output-format stream-json \
-            --allowedTools "Bash(git:*)" "Bash(gh:*)" "FileSystem(*)" \
             --verbose 
           


### PR DESCRIPTION
It seems there was a recent change in Claude Code that changes how the various
permission files are interpreted. See:
https://github.com/ai4curation/aidocs/issues/39

This PR restores sufficient privileges to claude code to
allow for file edits, web searches
