### PR TITLE
Add taxon constraint for GO:0097708 intracellular vesicle

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -558,7 +558,8 @@ GO:0097683	dinoflagellate apex	NCBITaxon:2864	Dinophyceae
 GO:0097684	dinoflagellate antapex	NCBITaxon:2864	Dinophyceae	
 GO:0097685	dinoflagellate apical groove	NCBITaxon:2864	Dinophyceae	
 GO:0097691	bacterial extracellular vesicle	NCBITaxon:2	Bacteria	
-GO:0097693	ocelloid	NCBITaxon:2864	Dinophyceae	
+GO:0097693	ocelloid	NCBITaxon:2864	Dinophyceae
+GO:0097708	intracellular vesicle	NCBITaxon:2759	Eukaryota
 GO:0097716	copper ion transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:0097727	blepharoplast	NCBITaxon:35493	Streptophyta	
 GO:0097736	aerial mycelium formation	NCBITaxon:Union_0000020	Fungi or Bacteria	


### PR DESCRIPTION
## Summary

This PR adds taxon constraints for GO:0097708 (intracellular vesicle) and verifies GO:0097693 (ocelloid), both of which are inferred children of GO:0043231 (intracellular membrane-bounded organelle).

## Changes

✅ **Added constraint for GO:0097708 (intracellular vesicle)**:
- Added `only_in_taxon` NCBITaxon:2759 (Eukaryota)
- Rationale: Intracellular vesicles are membrane-bounded structures found in the intracellular region. While prokaryotes produce outer membrane vesicles (OMVs), these are extracellular. Prokaryotes lack internal membrane compartmentalization and do not have intracellular vesicles in the same way eukaryotes do.

✅ **Verified constraint for GO:0097693 (ocelloid)**:
- Already has appropriate constraint: `only_in_taxon` NCBITaxon:2864 (Dinophyceae)
- Dinophyceae is a eukaryotic lineage (dinoflagellates)
- No changes needed

## Context

Both terms are inferred children of GO:0043231 (intracellular membrane-bounded organelle) through reasoner inference:
- GO:0097708: is_a GO:0031982 (vesicle) + part_of GO:0005622 (intracellular)
- GO:0097693: is_a GO:0043229 (intracellular organelle) + has_part mitochondrion + has_part plastid

## Important Note

GO:0043231 (intracellular membrane-bounded organelle) is **NOT** being obsoleted as part of this work.

Fixes #31236

@dragon-ai-agent