### PR TITLE
Fix spacing issues in only_in_taxon.tsv

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -835,11 +835,11 @@ GO:0080175	phragmoplast microtubule organization	NCBITaxon:33090	Viridiplantae
 GO:1902896	terminal web assembly	NCBITaxon:6072	Eumetazoa	
 GO:1990357	terminal web	NCBITaxon:6072	Eumetazoa	
 GO:0160062	cutin-based cuticle development	NCBITaxon:3193	Embryophyta	
-GO:0060417 	yolk	NCBITaxon:6072	Eumetazoa	
-GO:0005883 	neurofilament	NCBITaxon:6072	Eumetazoa	
-GO:0120098 	procentriole	NCBITaxon:6072	Eumetazoa	  
-GO:0120099 	procentriole replication complex	NCBITaxon:6072	Eumetazoa	
-GO:0071142 	homomeric SMAD protein complex	NCBITaxon:6072	Eumetazoa	
+GO:0060417	yolk	NCBITaxon:6072	Eumetazoa	
+GO:0005883	neurofilament	NCBITaxon:6072	Eumetazoa	
+GO:0120098	procentriole	NCBITaxon:6072	Eumetazoa	
+GO:0120099	procentriole replication complex	NCBITaxon:6072	Eumetazoa	
+GO:0071142	homomeric SMAD protein complex	NCBITaxon:6072	Eumetazoa	
 GO:0036457	keratohyalin granule	NCBITaxon:6072	Eumetazoa	
 GO:0045169	fusome	NCBITaxon:6072	Eumetazoa	
 GO:0019812	type I site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	


### PR DESCRIPTION
## Summary
Fixed column count errors in `src/taxon_constraints/only_in_taxon.tsv` caused by spaces after GO IDs where tabs were expected.

## Changes
- Removed trailing spaces from GO IDs in lines 838-842
- All lines now have proper tab separation between fields

## Details
The error "wrong number of columns in only_in_taxon.tsv. Check for spaces where tabs should be" was caused by 5 lines that had spaces immediately after the GO ID before the tab character. This made the parser interpret the space as part of the GO ID field, potentially causing issues.

### Affected GO terms:
- `GO:0060417` (yolk)
- `GO:0005883` (neurofilament)  
- `GO:0120098` (procentriole)
- `GO:0120099` (procentriole replication complex)
- `GO:0071142` (homomeric SMAD protein complex)

All lines now have exactly 5 tab-separated columns as expected.

Fixes #31236

@dragon-ai-agent