### PR TITLE
Fix spacing issue: Add taxon constraint for GO:0097708 intracellular vesicle

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -553,6 +553,7 @@ GO:0097684	dinoflagellate antapex	NCBITaxon:2864	Dinophyceae
 GO:0097685	dinoflagellate apical groove	NCBITaxon:2864	Dinophyceae	
 GO:0097691	bacterial extracellular vesicle	NCBITaxon:2	Bacteria	
 GO:0097693	ocelloid	NCBITaxon:2864	Dinophyceae	
+GO:0097708	intracellular vesicle	NCBITaxon:2759	Eukaryota	
 GO:0097716	copper ion transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:0097727	blepharoplast	NCBITaxon:35493	Streptophyta	
 GO:0097736	aerial mycelium formation	NCBITaxon:Union_0000020	Fungi or Bacteria	


### PR DESCRIPTION
## Summary

This PR fixes the spacing/formatting issues in PR #31324 that caused CI checks to fail. It adds a taxon constraint for GO:0097708 (intracellular vesicle) with proper TSV formatting.

## Changes

✅ **Added constraint for GO:0097708 (intracellular vesicle)**:
- Added `only_in_taxon` NCBITaxon:2759 (Eukaryota)
- Rationale: Intracellular vesicles are membrane-bounded structures found in the intracellular region of eukaryotic cells. While prokaryotes produce outer membrane vesicles (OMVs), these are extracellular. Prokaryotes lack internal membrane compartmentalization and do not have intracellular vesicles in the same way eukaryotes do.

✅ **Fixed TSV formatting**:
- Ensured all lines have consistent trailing tabs as required by the TSV format
- This was the root cause of the CI failure in PR #31324

## Context

GO:0097708 is an inferred child of GO:0043231 (intracellular membrane-bounded organelle) through reasoner inference:
- GO:0097708: is_a GO:0031982 (vesicle) + part_of GO:0005622 (intracellular)

## Testing

The change maintains proper TSV format with trailing tabs on all lines, which should resolve the ontology_qc CI check failure.

Fixes #31236
Supersedes #31324

@dragon-ai-agent