### PR TITLE
Add taxon constraint for GO:0048489 synaptic vesicle transport

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -428,7 +428,8 @@ GO:0048477	oogenesis	NCBITaxon:33208	Metazoa
 GO:0048479	style development	NCBITaxon:33090	Viridiplantae	
 GO:0048480	stigma development	NCBITaxon:33090	Viridiplantae	
 GO:0048481	plant ovule development	NCBITaxon:33090	Viridiplantae	
-GO:0048482	plant ovule morphogenesis	NCBITaxon:33090	Viridiplantae	
+GO:0048482	plant ovule morphogenesis	NCBITaxon:33090	Viridiplantae
+GO:0048489	synaptic vesicle transport	NCBITaxon:33208	Metazoa
 GO:0048493	plasma membrane-derived thylakoid ribulose bisphosphate carboxylase complex	NCBITaxon:1117	Cyanobacteria	
 GO:0048501	signal recognition particle, plasma membrane targeting	NCBITaxon:Union_0000004	Prokaryota	
 GO:0048507	meristem development	NCBITaxon:33090	Viridiplantae	


### PR DESCRIPTION
## Summary

This PR adds a taxon constraint to restrict GO:0048489 (synaptic vesicle transport) to Metazoa (NCBITaxon:33208).

## Rationale

Synaptic vesicles are specialized neurosecretory vesicles found exclusively in neurons of animals (Metazoa). They are not present in fungi, plants, or other non-metazoan eukaryotes.

## Changes

- Added `GO:0048489 synaptic vesicle transport NCBITaxon:33208 Metazoa` to `src/taxon_constraints/only_in_taxon.tsv`

## Consistency with Related Terms

This constraint aligns with existing taxon restrictions on related synaptic terms:
- GO:0045202 (synapse) → restricted to Metazoa
- GO:0099003 (vesicle-mediated transport in synapse) → restricted to Metazoa
- Multiple other synaptic process terms → restricted to Metazoa

## Issue Resolution

This change prevents incorrect automated annotations like the S. pombe (fission yeast) protein pef1 being annotated to "synaptic vesicle transport" via TreeGrafter pipelines, as reported in the linked annotation issue.

Fixes #29069
Related: geneontology/go-annotation#5036

@dragon-ai-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)