### PR TITLE
Add AI-assisted curation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ Instructions for editing the ontology can be found in the [GO wiki/Ontology sect
     * The S3 bucket for go-data-product-snapshot/ontology/, mapped to http://snapshot.geneontology.org/ontology/, is redirected to from the OBO Library PURL (http://purl.obolibrary.org/obo/go/snapshot/FOO)
  - A Jenkins job produces monthly production releases (https://build.geneontology.org/job/geneontology/job/pipeline/job/release/)
 
+## AI-Assisted Curation
 
+This repository supports AI-assisted ontology curation via the @dragon-ai-agent.


### PR DESCRIPTION
**Please close after validation rules, this is a test**

## Summary

Added a new line to README.md documenting the availability of AI-assisted ontology curation via @dragon-ai-agent.

## Changes

- Added a new "AI-Assisted Curation" section to README.md

Closes #31415

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-5-20251101`
- Agent harness: claude-code
- Triggered by: @cmungall
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/21424734855)