### PR TITLE
Remove specific taxon entries from only_in_taxon.tsv

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -1,6 +1,4 @@
 defined_class	defined_class_label	taxon	taxon_label	source
-GO:0019283	L-methionine biosynthetic process from O-phospho-L-homoserine and cystathionine	NCBITaxon:33090	Viridiplantae	
-GO:0019279	L-methionine biosynthetic process from L-homoserine via cystathionine	NCBITaxon:2	Bacteria	
 GO:0001772	immunological synapse	NCBITaxon:7742	Vertebrata	
 GO:0031911	cytoproct	NCBITaxon:5878	Ciliophora	
 GO:0008088	axo-dendritic transport	NCBITaxon:33208	Metazoa	


### PR DESCRIPTION
Removed two entries related to L-methionine biosynthetic processes.