### PR TITLE
Remove L-methionine biosynthetic process entry

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -49,7 +49,6 @@ GO:0004122	cystathionine beta-synthase	NCBITaxon:4896	Schizosaccharomyces pombe
 GO:0004123	cystathionine gamma-lyase	NCBITaxon:4896	Schizosaccharomyces pombe	
 GO:1990604	IRE1-TRAF2-ASK1 complex	NCBITaxon:4896	Schizosaccharomyces pombe	
 GO:1990604	IRE1-TRAF2-ASK1 complex	NCBITaxon:4896	Saccharomyces cerevisiae	
-GO:0019280	L-methionine biosynthetic process from homoserine via O-acetyl-L-homoserine and cystathionine	NCBITaxon:33208	Metazoa	
 GO:0009098	L-leucine biosynthetic process	NCBITaxon:9606	Homo sapiens	
 GO:0009085	lysine biosynthetic process	NCBITaxon:9606	Homo sapiens	
 GO:0009094	L-phenylalanine biosynthetic process	NCBITaxon:9606	Homo sapiens	


### PR DESCRIPTION
Removed entry for L-methionine biosynthetic process from never_in_taxon.tsv.