### PR TITLE
Lock linkml-runtime in YAML schema checks workflow

### DIFF
--- a/.github/workflows/yaml-schema-checks.yml
+++ b/.github/workflows/yaml-schema-checks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install packages
       run: apt-get update -qq && apt-get install -y python3 python3-pip mmv -qq
     - name: Install python stuff
-      run: pip3 install pyyaml typing linkml==1.7.4
+      run: pip3 install pyyaml typing linkml==1.7.4 linkml-runtime==1.7.4
     ## Validate YAML schema for https://github.com/geneontology/go-ontology/issues/27399
     - name: Validate YAML schema
       run: |


### PR DESCRIPTION
Lock linkml-runtime package installation for YAML schema checks.

For https://github.com/geneontology/go-ontology/issues/31648