### PR TITLE
Remove 'extracellular space' entry for #31545

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -58,7 +58,6 @@ GO:0009094	L-phenylalanine biosynthetic process	NCBITaxon:9606	Homo sapiens
 GO:0009088	threonine biosynthetic process	NCBITaxon:9606	Homo sapiens	
 GO:0000162	L-tryptophan biosynthetic process	NCBITaxon:9606	Homo sapiens	
 GO:0009099	L-valine biosynthetic process	NCBITaxon:9606	Homo sapiens	
-GO:0005615	extracellular space	NCBITaxon:4890	Ascomycota	
 GO:0004705	JUN kinase activity	NCBITaxon:4751	Fungi	
 GO:0008545	JUN kinase kinase activity	NCBITaxon:4751	Fungi	
 GO:0004706	JUN kinase kinase kinase	NCBITaxon:4751	Fungi	


### PR DESCRIPTION
Removed entry for 'extracellular space' from never_in_taxon.tsv.