### PR TITLE
Clean up .tmp intermediates from subset build

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -114,7 +114,7 @@ prepare_release:
 	cp external2go/* $(RELEASEDIR)/external2go &&\
 	cp go-basic.* $(RELEASEDIR) &&\
 	cp go-base.owl $(RELEASEDIR) &&\
-	cp subsets/* $(RELEASEDIR)/subsets &&\
+	find subsets/ -maxdepth 1 -type f ! -name '*.tmp' -exec cp {} $(RELEASEDIR)/subsets/ \; &&\
 	cp reports/* $(RELEASEDIR)/reports &&\
 	echo "Release files are now in $(RELEASEDIR)"
 
@@ -341,10 +341,10 @@ subsets/subset-terms.tsv: $(ONT).owl $(SPARQLDIR)/subset-terms.sparql
 	$(ROBOT) query -i $< -f tsv --query $(word 2,$^) $@
 
 subsets/subset-properties.tsv: $(ONT).owl $(SPARQLDIR)/subset-properties.sparql
-	$(ROBOT) query -i $< -f tsv --query $(word 2,$^) $@.tmp && sed 's/"//g' $@.tmp >$@
+	$(ROBOT) query -i $< -f tsv --query $(word 2,$^) $@.tmp && sed 's/"//g' $@.tmp >$@ && rm -f $@.tmp
 
 subsets/%-terms.txt: subsets/subset-terms.tsv subsets/subset-properties.tsv
-	grep '"$*"' $< | cut -f1 | sed 's/"//g' >$@.tmp && cat $@.tmp $(word 2,$^) >$@
+	grep '"$*"' $< | cut -f1 | sed 's/"//g' >$@.tmp && cat $@.tmp $(word 2,$^) >$@ && rm -f $@.tmp
 
 # Also generates %.obo and %.json
 subsets/%.owl: $(ONT).ofn subsets/%-terms.txt


### PR DESCRIPTION
Fixes #31762
Related: https://github.com/geneontology/pipeline/issues/425

## Summary

The subset build rules introduced in #29705 (Feb 2025) leave behind `.tmp` intermediate files in `subsets/`. The `prepare_release` target then blindly copies everything via `cp subsets/*`, publishing these temporaries to the release site. This was reported by an external user via https://github.com/geneontology/helpdesk/discussions/578.

## Changes

1. **Add `rm -f $@.tmp` cleanup** to the two Makefile rules that produce intermediates (`subset-properties.tsv` and `%-terms.txt`)
2. **Exclude `.tmp` from release copy** by replacing `cp subsets/*` with a `find`-based copy that skips `*.tmp` files

Verified via `make -n subset-owls` dry run that the Makefile parses correctly and the cleanup commands chain as expected.

---

Mediated by Claude on behalf of @kltm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)