### PR TITLE
Upgrade AI agent model to claude-opus-4-6

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -20,7 +20,7 @@ name: AI Agent GitHub Mentions
 
 env:
   AGENT_NAME: dragon-ai-agent
-  MODEL: claude-opus-4-5-20251101
+  MODEL: claude-opus-4-6
   TOOLS_DIR: ${{ github.workspace }}/tools
   ARTIFACT_RETENTION_DAYS: 90
   TIMEOUT_MINUTES: 30


### PR DESCRIPTION
## Summary
- Updates the `MODEL` env variable in `.github/workflows/ai-agent.yml` from `claude-opus-4-5-20251101` to `claude-opus-4-6`
- This picks up the latest Opus model release for the AI agent workflow

## Test plan
- [ ] Verify the workflow file parses correctly
- [ ] Trigger a test run of the AI agent to confirm the new model works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)