### PR TITLE
Strengthen term_tracker_item instructions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Create a plan for addressing the issue. The plan MUST have the following compone
     - /chemical-entity skill; for any request involving CHEBI or chemical terms or nomenclature
     - /reaction skill; for any request involving RHEA, EC, or the catalytic activity branch of GO
     - /taxon-constraint skill; for any request involving restricting usage of a term or branch to a taxon/clade
+- [ ] TERM-TRACKER: Every term stanza you created or modified has a `term_tracker_item` linking to the issue
 - [ ] METADATA: The metadata for the changes is correct
 - [ ] AUTOMATED-VALIDATION: The ontology validates correctly using `make travis_build` after changes have been made
 - [ ] REFERENCE-VALIDATION: All references (eg PMIDs) introduced have been validated, and are relevant, and not typos or hallucinations; always use /research for this
@@ -128,6 +129,7 @@ The general procedure is:
 - This will create a single stanza obo files `terms/go_1234567.obo` which you can easily edit
      - (note the colon is replaced with an underscore)
 - You can go ahead and edit the smallers files in the `terms/` folder
+- **Before checking in**, verify every modified stanza contains a `property_value: term_tracker_item` line linking to the issue. This applies to ALL terms you touched, not just new ones.
 - After edits, check back in: `obo-checkin.pl src/ontology/go-edit.obo GO:1234567 [OTHER IDS]`
 - if you like you can edit multiple terms in one batch, e.g. `terms/my_batch.obo`
      - `obo-checkout.pl src/ontology/go-edit.obo terms/my_batch.obo`
@@ -253,10 +255,21 @@ Here the DP, label (and synonyms), text def, logical def all align, and the OWL 
 
 ## METADATA
 
+### term_tracker_item (required on ALL modified terms)
+
+**EVERY term you modify or create MUST have a `term_tracker_item` linking to the GitHub issue that motivated the change.** This is not optional metadata -- it is a required annotation on any stanza you touch, whether you are creating a new term, adding a synonym, updating a definition, or making any other edit. If a term already has a `term_tracker_item` for the current issue, do not add a duplicate.
+
+```
+property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/<NUMBER>" xsd:anyURI
+```
+
+A term may accumulate multiple `term_tracker_item` entries over time (one per issue that modified it). This is expected and correct.
+
+### Other metadata rules
+
 - ALWAYS include created_by and creation_date for terms YOU CREATE
 - NEVER add or modify these properties if you are simply editing an existing term
 - Unlike other obo ontologies, there is always a `namespace:` tag in GO (including on obsolete terms)
-- Link back to the issue you are dealing with using the `term_tracker_item`
 - All terms should have definitions, with at least one definition xref, ideally a PMID
 
 You are a GO ontology metadata validation specialist with deep expertise in OBO format standards and GO-specific curation requirements. Your primary responsibility is to ensure that all newly added or modified terms comply with GO's strict metadata standards.
@@ -329,15 +342,7 @@ In GO, sometimes a GOC:<userId> is acceptable for definition provenance.
 
 NEVER guess ORCIDs or PMIDs or GOC IDs. Always validate PMIDs and conform that these are validated. Never guess an ORCID based on a person in an issue.
 
-4. **Check Term Tracker Links**:
-   - Verify presence of term_tracker_item property linking to the relevant GitHub issue
-   - Ensure the URL format is correct: https://github.com/geneontology/go-ontology/issues/[NUMBER]
-
-These MUST have the following format:
-
-```
-property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/<NUMBER>" xsd:anyURI
-```
+4. **Check Term Tracker Links**: see the "term_tracker_item (required on ALL modified terms)" section above. Every term you touched must have one.
 
 
 ## SPECIALIZED-EDITS: appropriate skills should be used for special cases


### PR DESCRIPTION
## Summary

Addresses #31812 -- repeated omission of `term_tracker_item` in agent edits to existing terms.

Root cause: the instruction to add `term_tracker_item` was a single bullet point in the METADATA section, surrounded by guidance about `created_by`/`creation_date` that explicitly says "NEVER add these for existing terms." This proximity created an association that `term_tracker_item` was also new-term-only metadata.

## Changes

Three targeted modifications to `CLAUDE.md`:

1. **New checklist item (TERM-TRACKER)**: Added as a standalone item in the plan checklist, separate from METADATA. This makes it a discrete verification step that cannot be skipped.

2. **Pre-checkin reminder in EDITS procedure**: Added a step right before the `obo-checkin.pl` instruction reminding to verify every modified stanza has a `term_tracker_item`. This catches the issue at the point of action.

3. **Elevated subsection under METADATA**: `term_tracker_item` now has its own subsection with a heading ("required on ALL modified terms") and explicit language that it applies to any stanza you touch -- new or existing. The old section 4 in the metadata checklist now references this subsection instead of duplicating the guidance.

## What this does NOT change

- No deterministic/SPARQL validation changes (per @cmungall's feedback that the deterministic approach was overly complex)
- No changes to any other instructions or procedures

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-6`
- Agent harness: claude-code
- Triggered by: @cmungall
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/23916048853)