### PR TITLE
Obsolete pre-composed conjugation terms (issue #31335)

### DIFF
--- a/src/ontology/imports/go_taxon_constraints.owl
+++ b/src/ontology/imports/go_taxon_constraints.owl
@@ -561,26 +561,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
-
-    <!-- http://purl.obolibrary.org/obo/GO_0000750 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0000750">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
 
 
     <!-- http://purl.obolibrary.org/obo/GO_0000751 -->

--- a/src/taxon_constraints/only_in_taxon.ofn
+++ b/src/taxon_constraints/only_in_taxon.ofn
@@ -23,7 +23,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000426>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000747>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000748>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000749>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000750>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000751>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000755>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0000908>))
@@ -1085,11 +1084,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0000748> ObjectAllValuesFrom(<http
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0000749> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0000749> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-
-# Class: <http://purl.obolibrary.org/obo/GO_0000750> (<http://purl.obolibrary.org/obo/GO_0000750>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0000750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0000750> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 
 # Class: <http://purl.obolibrary.org/obo/GO_0000751> (<http://purl.obolibrary.org/obo/GO_0000751>)
 

--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -19,7 +19,6 @@ GO:0000426	micropexophagy	NCBITaxon:716545	saccharomyceta
 GO:0000747	conjugation with cellular fusion	NCBITaxon:Union_0000022	Fungi or Dictyostelium	
 GO:0000748	conjugation with mutual genetic exchange	NCBITaxon:5878	Ciliophora	
 GO:0000749	response to pheromone triggering conjugation with cellular fusion	NCBITaxon:4751	Fungi	
-GO:0000750	pheromone-dependent signal transduction involved in conjugation with cellular fusion	NCBITaxon:4751	Fungi	
 GO:0000751	mitotic cell cycle G1 arrest in response to pheromone	NCBITaxon:4751	Fungi	
 GO:0000755	cytogamy	NCBITaxon:4751	Fungi	
 GO:0000911	cytokinesis by cell plate formation	NCBITaxon:33090	Viridiplantae	


### PR DESCRIPTION
## Summary

Obsoletes 7 pre-composed conjugation-related terms that should be represented as GO-CAM models, plus adds a `replaced_by` to the already-obsoleted GO:0090028.

## Terms obsoleted

| Obsoleted term | Name | Replaced by |
|---|---|---|
| GO:1900237 | positive regulation of induction of conjugation with cellular fusion | GO:0031139 |
| GO:0090029 | negative regulation of pheromone-dependent signal transduction involved in conjugation with cellular fusion | GO:0180040 |
| GO:0000750 | pheromone-dependent signal transduction involved in conjugation with cellular fusion | GO:0071507 |
| GO:0010514 | induction of conjugation with cellular fusion | GO:0031139 |
| GO:0010515 | negative regulation of induction of conjugation with cellular fusion | GO:0031138 |
| GO:0010969 | regulation of pheromone-dependent signal transduction involved in conjugation with cellular fusion | GO:0180039 |
| GO:0032005 | signal transduction involved in positive regulation of conjugation with cellular fusion | GO:0071507 |
| GO:0090028 (already obsoleted) | positive regulation of pheromone-dependent signal transduction involved in conjugation with cellular fusion | GO:0062038 (added replaced_by) |

## Rewiring

- **GO:0071507** (pheromone response MAPK cascade): removed `relationship: part_of GO:0000750` since the target is now obsolete
- **GO:0031140** (induction of conjugation upon nutrient starvation): rewired `is_a` from GO:0010514 to GO:0031139 (positive regulation of conjugation with cellular fusion)
- **12 already-obsolete terms** (GO:0000174, GO:0007244-GO:0007248, GO:0030455-GO:0030460): updated `replaced_by`/`consider` pointers from GO:0000750 to GO:0071507

## Taxon constraints

Removed GO:0000750 `only_in_taxon` Fungi constraint from:
- `src/taxon_constraints/only_in_taxon.tsv`
- `src/taxon_constraints/only_in_taxon.ofn`
- `src/ontology/imports/go_taxon_constraints.owl`

## Annotations

These terms carry annotations (mostly IEA, some EXP). Annotation review is being handled separately per discussion in the issue. Key points from the issue discussion:
- GO:0000750 has ~57 EXP annotations requiring individual review
- GO:0032005 has 3 EXP annotations (PomBase), being handled by @ValWood
- @ValWood noted that most GO:0000750 annotations should migrate to positive or negative regulation of pheromone response MAPK cascade

## Checklist

- [x] PLAN: Issue analyzed, intent clear, plan created
- [x] PRE-VALIDATION: Ontology validated before changes
- [x] TERM-SEARCH: All 8 terms and their replacements verified
- [x] EDITS: Checkout/checkin procedure followed
- [x] RELATIONSHIPS: All logical axioms removed from obsoleted terms; rewiring done for affected terms
- [x] METADATA: All obsoleted terms have correct metadata (obsolete prefix on name, OBSOLETE prefix on def, comment, term_tracker_item, is_obsolete, replaced_by, namespace preserved)
- [x] AUTOMATED-VALIDATION: `make travis_build` passes (all 20 SPARQL rules, reasoning with ELK)
- [x] REFERENCE-VALIDATION: N/A (no new references introduced)
- [x] CHANGES-COMMITTED: Changes committed with detailed message
- [x] ISSUE-ALIGNMENT: Changes match the request from @raymond91125

Closes #31335

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-6`
- Agent harness: claude-code
- Triggered by: @raymond91125
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/24216756857)