### PR TITLE
Add gluconate shunt term and constrain ED pathway taxonomically (#29539)

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -749,3 +749,5 @@ GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:4751	Fungi
 GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:6656	Arthropoda	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:4751	Fungi	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:6656	Arthropoda	
+GO:0061678	Entner-Doudoroff pathway	NCBITaxon:4751	Fungi	PMID:27114545
+GO:0061678	Entner-Doudoroff pathway	NCBITaxon:33208	Metazoa	PMID:27114545


### PR DESCRIPTION
## Summary

Resolves #29539 (Entner-Doudoroff pathway vs gluconate pathway).

- Creates **GO:7770062 'gluconate shunt'** (biological_process) — a distinct two-step pathway converting glucose → gluconate → 6-phosphogluconate via glucose 1-dehydrogenase + gluconokinase. This addresses @ValWood's request for a proper home for processes like the S. pombe Gcd1/Idn1 route.
- Adds **`never_in_taxon` Fungi and Metazoa** to GO:0061678 'Entner-Doudoroff pathway'. Plants/cyanobacteria are explicitly **not** excluded (PMID:27114545).
- Removes the misleading `'gluconate pathway' RELATED` synonym from GO:0061679 and GO:0061688 (those terms describe variants of the ED pathway, not the literature's 'gluconate pathway'/'gluconate shunt') and replaces it with a clarifying comment pointing to the new term.

## Background

The literature uses 'gluconate pathway' / 'gluconate shunt' to mean a two-step bypass:
1. glucose 1-dehydrogenase (D-glucose → D-glucono-1,5-lactone → D-gluconate)
2. gluconokinase (D-gluconate + ATP → 6-phospho-D-gluconate)

The 6-phosphogluconate then enters the **oxidative pentose phosphate pathway**, bypassing hexokinase and the rate-limiting glucose-6-phosphate dehydrogenase. In some organisms (Pseudomonas) the same gluconate pathway feeds the ED pathway, but in others (B. megaterium, S. pombe, mouse) it feeds the PPP. The two pathways are mechanistically distinct, even though they share 6-phosphogluconate as an intermediate.

The Entner-Doudoroff pathway requires two diagnostic enzymes — 6-phosphogluconate dehydratase and KDPG aldolase — that are absent natively in fungi and animals. The PMID:27114545 paper explicitly demonstrated active ED pathway in cyanobacteria and plants (KDPG detected in vivo), so those clades are not constrained.

## Changes

1. **New term GO:7770062 'gluconate shunt'**
   - Definition: 'The metabolic process in which D-glucose is converted to 6-phospho-D-gluconate in two steps: oxidation of D-glucose to D-gluconate by glucose 1-dehydrogenase, followed by phosphorylation of D-gluconate to 6-phospho-D-gluconate by gluconokinase. The 6-phospho-D-gluconate produced enters the oxidative pentose phosphate pathway, providing an alternative route for glucose catabolism that bypasses hexokinase and glucose-6-phosphate dehydrogenase.'
   - References: PMID:7840611, PMID:28667014, PMID:30524402
   - Parent: GO:0006007 ! glucose catabolic process
   - Relationships: has_part gluconokinase + glucose 1-dehydrogenase [NAD(P)+]; has_primary_input D-glucopyranose; has_primary_output 6-phosphonatooxy-D-gluconate
   - Synonym: 'gluconate pathway' EXACT
   - Weak axiomatization (no `intersection_of`) to avoid over-classification — follows the precedent of GO:0061678 itself.

2. **Taxon constraints in `src/taxon_constraints/never_in_taxon.tsv`**
   - GO:0061678 never_in NCBITaxon:4751 (Fungi), source PMID:27114545
   - GO:0061678 never_in NCBITaxon:33208 (Metazoa), source PMID:27114545

3. **Synonym/comment cleanup on GO:0061679 and GO:0061688**
   - Removed misleading 'gluconate pathway' RELATED synonym
   - Added comment explaining the distinction
   - Added term_tracker_item link

## Out of scope (deferred)

@ValWood also raised concerns that the cluster of ED-pathway-through-X subtypes (GO:0061679, GO:0009255, GO:0061680, GO:0061681) is over-granular and unhelpful for curators. That refactoring would involve obsoleting several MetaCyc-derived terms and deserves its own ticket and stakeholder review. Not addressed here.

## Test plan

- [x] Pre-validation: ontology validates before edits (`robot convert -vvv` succeeds)
- [x] PLAN: issue analyzed, plan created, checklist tracked
- [x] RESEARCH: see RESEARCH.md (not committed); 11 SUPPORT quotes validated against PMID abstracts via `linkml-reference-validator`
- [x] TERM-SEARCH: confirmed no existing 'gluconate shunt' term; checked existing ED pathway and gluconokinase/glucose dehydrogenase activity terms
- [x] DESIGN-PATTERNS: see DESIGN_PATTERNS.md (not committed); no DP applies; weak axiomatization is the right precedent
- [x] EDITS: used `obo-checkout.pl` / `obo-checkin.pl` workflow for ED pathway terms; new term created in `terms/GO_7770062.obo` and checked in
- [x] RELATIONSHIPS: weak axiomatization (no over-asserted intersection_of); is_a + has_part + has_primary_input/output
- [x] SPECIALIZED-EDITS:
  - [x] /chemical-entity skill: confirmed CHEBI:4167, CHEBI:18391, CHEBI:58759 are pH7.3 forms (`chebi_pH7_3_mapping.tsv`)
  - [x] /taxon-constraint skill: format confirmed; constraints added to `never_in_taxon.tsv`
  - [ ] /reaction skill — N/A (no MF reactions modified)
  - [ ] /term-obsoletion skill — N/A
- [x] METADATA: created_by, creation_date, term_tracker_item present on new term; term_tracker_item added to modified existing terms
- [x] AUTOMATED-VALIDATION: `make travis_build` passes (all 20 SPARQL rules PASS, ELK reasoning succeeds, no unsatisfiable classes)
- [x] REFERENCE-VALIDATION: all PMIDs cached and validated via `linkml-reference-validator cache`

🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-6`
- Agent harness: claude-code
- Triggered by: @raymond91125
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/24174670339)