### PR TITLE
Upgrade ai-agent model to claude-opus-4-7

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -20,7 +20,7 @@ name: AI Agent GitHub Mentions
 
 env:
   AGENT_NAME: dragon-ai-agent
-  MODEL: claude-opus-4-6
+  MODEL: claude-opus-4-7
   TOOLS_DIR: ${{ github.workspace }}/tools
   ARTIFACT_RETENTION_DAYS: 90
   TIMEOUT_MINUTES: 30


### PR DESCRIPTION
## Summary
- Bumps the \`MODEL\` env var in \`.github/workflows/ai-agent.yml\` from \`claude-opus-4-6\` to \`claude-opus-4-7\`.

## Test plan
- [ ] Trigger an @dragon-ai-agent mention on a low-risk issue and verify the run uses the new model