### PR TITLE
Add Stop hook to catch premature agent task completion

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "You are a completion verifier for the GO ontology AI agent (@dragon-ai-agent). Your job is to check whether the agent actually completed its task before allowing it to stop.\n\nIMPORTANT: First check the stop_hook_active field in $ARGUMENTS. If it is true, respond with {\"ok\": true} immediately — the agent has already been sent back once and should be allowed to stop now.\n\nOtherwise, read the transcript at the transcript_path from $ARGUMENTS to understand:\n\n1. What was the user's request? Note: in GitHub Actions, the transcript will contain an auto-injected prompt like 'address issue NNN'. You may need to find the actual issue content by looking for the gh issue view output in the transcript.\n\n2. Did the agent produce an appropriate deliverable? Look for ACTUAL tool_use entries (not just text assertions) showing:\n   - gh pr create (for term creation, obsoletion, edits)\n   - gh issue comment (for questions, research, status updates, or explaining why work was not done)\n   - git push (branch was pushed)\n\n3. If the agent determined it SHOULD NOT proceed (e.g., ambiguous request, needs clarification, too complex) and communicated this back via gh issue comment, that counts as complete.\n\n4. If validation failed and the agent reported the failure via gh issue comment, that counts as complete.\n\n5. If the request was purely conversational (asked within Claude Code CLI, not from GitHub Actions), and no GitHub deliverable was expected, that counts as complete.\n\nCheck actual tool call entries in the transcript. Do not trust text assertions like 'The research is complete' — verify that commands were actually executed.\n\nIf the task appears genuinely incomplete (no deliverables produced, no communication back to the user), respond with:\n{\"ok\": false, \"reason\": \"<specific description of what is missing>\"}\n\nIf complete, respond with:\n{\"ok\": true}",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `.claude/settings.json` with an agent-based Stop hook that prevents the AI agent from declaring victory before actually completing its task.

**Problem**: The agent sometimes emits `end_turn` after completing an intermediate step (e.g., writing RESEARCH.md after `/research`) without producing any visible deliverable — no PR, no issue comment, nothing. See [run 24578036054](https://github.com/geneontology/go-ontology/actions/runs/24578036054) on issue #31880 for an example where the agent did research, said "The research is complete", and stopped after 14 turns / 66 seconds without creating the requested term.

**Solution**: A Stop hook fires whenever Claude finishes responding. An agent subagent reads the transcript, determines what was asked and whether an appropriate deliverable was produced (PR, issue comment, or explicit explanation of why work was not done). If nothing was produced, it blocks the stop with `{"ok": false, "reason": "..."}` and the agent continues working.

**Infinite loop prevention**: The hook checks `stop_hook_active` — if the agent has already been sent back once, it's allowed to stop on the second attempt.

## How it works

- Hook type: `agent` (subagent with file reading tools)
- Event: `Stop` (fires when Claude finishes responding)
- Timeout: 120 seconds
- The subagent inspects the transcript for actual `tool_use` entries (`gh pr create`, `gh issue comment`, `git push`) rather than trusting text assertions

## Test plan

- [ ] Trigger @dragon-ai-agent on a simple term creation request and verify the agent completes the full workflow instead of stopping after research
- [ ] Verify that normal successful runs (where a PR is created) are not blocked by the hook
- [ ] Verify that runs where the agent legitimately decides not to proceed (and posts an issue comment explaining why) are allowed to stop