### PR TITLE
Fix broken connection from EMAPA to Uberon

### DIFF
--- a/src/ontology/extensions/go-lego-edit.ofn
+++ b/src/ontology/extensions/go-lego-edit.ofn
@@ -121,6 +121,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/ZFA_0100000> ObjectIntersectio
 SubClassOf(<http://purl.obolibrary.org/obo/ZFS_0100000> <http://purl.obolibrary.org/obo/UBERON_0000105>)
 
 
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/emapa#ends_at> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/emapa#starts_at> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
+SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002493> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
+SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002489> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
 )


### PR DESCRIPTION
EMAPA switched to use RO terms for starts and ends.

For https://github.com/geneontology/noctua/issues/1091