### PR TITLE
Issue #31051: scope secondary sexual characteristic terms to Metazoa (Option A)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -378,6 +378,7 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
+GO:0045136	development of secondary sexual characteristics, sensu Metazoa	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	


### PR DESCRIPTION
Closes geneontology/go-ontology#31051 (subject to review)

Implements **Option A** as agreed by @raymond91125 in https://github.com/geneontology/go-ontology/issues/31051#issuecomment-4375423361.

## Summary

- Rename the three "development of secondary sexual characteristics" terms with a `, sensu Metazoa` suffix
- Add `only_in_taxon Metazoa` for the parent GO:0045136 (propagates to children GO:0046543 and GO:0046544)
- Keep original labels as EXACT synonyms for backward compatibility
- Soften definitions: "In [male/female] humans, these include..." -> "In [male/female] mammals, examples include..."

The `sensu Metazoa` nomenclature follows @cmungall's recommendation in https://github.com/geneontology/go-ontology/issues/31051#issuecomment-3553493823: it acts as editorial disambiguation with zero ontological commitment, and avoids implying homology between metazoan and (potential) plant secondary sexual characteristics.

The `only_in_taxon Metazoa` constraint at the parent level supersedes the per-species `never_in_taxon` entries that were previously inferred via `GO:0032501` (multicellular organismal process), addressing the original request to broaden the constraint beyond just S. pombe and S. cerevisiae — without the whack-a-mole problem of adding individual TCs to every non-metazoan group.

## Term changes

| ID | Old name | New name |
|---|---|---|
| GO:0045136 | development of secondary sexual characteristics | development of secondary sexual characteristics, sensu Metazoa |
| GO:0046543 | development of secondary female sexual characteristics | development of secondary female sexual characteristics, sensu Metazoa |
| GO:0046544 | development of secondary male sexual characteristics | development of secondary male sexual characteristics, sensu Metazoa |

GO:0042695 (thelarche, mammary-specific child of GO:0046543) was deliberately left unchanged — it remains scoped via inheritance.

## Files changed

- `src/ontology/go-edit.obo` — three terms updated (rename, synonym, definition softening, `term_tracker_item`)
- `src/taxon_constraints/only_in_taxon.tsv` — one new entry for GO:0045136

## Test plan

- [x] `make travis_build` passes — all 20 SPARQL rules report 0 violations
- [x] ELK reasoning succeeds (covered by travis_build)
- [x] Original labels are preserved as EXACT synonyms so existing AmiGO/QuickGO lookups continue to resolve
- [ ] Curator review of label change (this is a user-facing rename of three terms)

## Checklist

- [x] PLAN: Issue and comments analyzed; intent confirmed by @raymond91125 ("implement option A")
- [x] PRE-VALIDATION: Ontology validated cleanly before changes
- [x] RESEARCH: N/A — discussion in issue thread covers the relevant biology (papers cited by @tberardini and @Antonialock)
- [x] TERM-SEARCH: Relevant terms inspected via `obo-grep.pl`
- [x] DESIGN-PATTERNS: N/A — this is a relabel and TC change, no compositional pattern affected
- [x] EDITS: Used `obo-checkout.pl` / `obo-checkin.pl` workflow; no direct edits to `go-edit.obo`
- [x] RELATIONSHIPS: `is_a` parent reference updated to reflect new parent name
- [x] SPECIALIZED-EDITS: `/taxon-constraint` — entry added to `only_in_taxon.tsv` with source URL
- [x] METADATA: `term_tracker_item` added on all three terms; no `created_by`/`creation_date` (these are existing terms)
- [x] AUTOMATED-VALIDATION: `make travis_build` passes
- [x] REFERENCE-VALIDATION: N/A — no new PMIDs introduced
- [x] CHANGES-COMMITTED

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-7`
- Agent harness: claude-code
- Triggered by: @raymond91125
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/25349956274)