### PR TITLE
Add 'only in Insecta' taxon constraints for sclerotizing precursor biosynthetic terms

### DIFF
--- a/src/taxon_constraints/only_in_taxon.ofn
+++ b/src/taxon_constraints/only_in_taxon.ofn
@@ -849,6 +849,8 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120309>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120310>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120324>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120549>))
+Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120576>))
+Declaration(Class(<http://purl.obolibrary.org/obo/GO_0120577>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140007>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140022>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140040>))
@@ -5223,6 +5225,16 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0120324> ObjectAllValuesFrom(<http
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0120549> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0120549> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
+
+# Class: <http://purl.obolibrary.org/obo/GO_0120576> (<http://purl.obolibrary.org/obo/GO_0120576>)
+
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:19932179"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:32709620"^^xsd:string) <http://purl.obolibrary.org/obo/GO_0120576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:19932179"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:32709620"^^xsd:string) <http://purl.obolibrary.org/obo/GO_0120576> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
+
+# Class: <http://purl.obolibrary.org/obo/GO_0120577> (<http://purl.obolibrary.org/obo/GO_0120577>)
+
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:19932179"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:32709620"^^xsd:string) <http://purl.obolibrary.org/obo/GO_0120577> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
+SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:19932179"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMID:32709620"^^xsd:string) <http://purl.obolibrary.org/obo/GO_0120577> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
 
 # Class: <http://purl.obolibrary.org/obo/GO_0140007> (<http://purl.obolibrary.org/obo/GO_0140007>)
 

--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -953,3 +953,5 @@ GO:0000958	mitochondrial mRNA catabolic process	NCBITaxon:2759	Eukaryota
 GO:0000956	nuclear-transcribed mRNA catabolic process	NCBITaxon:2759	Eukaryota	
 GO:0140400	embryonic sheath	NCBITaxon:6231	Nematoda	PMID:28526752
 GO:0019658	bifid shunt	NCBITaxon:2	Bacteria	
+GO:0120576	1,2-dehydro-N-beta-alanyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620
+GO:0120577	1,2-dehydro-N-acetyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620


### PR DESCRIPTION
Closes part of #32029.

## Summary

Adds `only_in_taxon` constraints (NCBITaxon:50557 Insecta) to two recently created sclerotizing precursor biosynthesis terms:

- GO:0120576 — 1,2-dehydro-N-beta-alanyldopamine biosynthetic process
- GO:0120577 — 1,2-dehydro-N-acetyldopamine biosynthetic process

## Rationale

NBAD- and NADA-derived sclerotizing precursors and their dehydro derivatives feed into cuticle sclerotization (cross-linking of cuticular proteins) and cuticle pigmentation in insects. These processes are specific to insect cuticle biology — see PMID:19932179 (Andersen 2010 review on insect cuticle sclerotization) and PMID:32709620.

## Files changed

- `src/taxon_constraints/only_in_taxon.tsv` — two new rows, sourced to PMID:19932179|PMID:32709620
- `src/taxon_constraints/only_in_taxon.ofn` — regenerated from the TSV via `dosdp-tools`

## Checklist

- [x] PLAN
- [x] PRE-VALIDATION — ontology validates prior to changes
- [x] RESEARCH — N/A; constraint scope is direct from issue + cited references already vetted on parent terms
- [x] TERM-SEARCH — confirmed both terms exist in `go-edit.obo`; checked NCBITaxon:50557 Insecta is the canonical taxon used elsewhere (~150 prior `only_in_taxon` rows for Insecta)
- [x] DESIGN-PATTERNS — N/A (TC change, not term creation)
- [x] EDITS — TSV edited directly per skill guidance (taxon constraints are not in `go-edit.obo`)
- [x] RELATIONSHIPS — N/A
- [x] SPECIALIZED-EDITS — used /taxon-constraint skill
- [x] METADATA — sources cited (PMID:19932179, PMID:32709620)
- [x] AUTOMATED-VALIDATION — `make check_all_taxon_constraints_columns` passed; full `make travis_build` completed with all SPARQL rules passing (0 violations)
- [x] REFERENCE-VALIDATION — PMIDs reused from the term definitions added in this same issue thread
- [x] CHANGES-COMMITTED

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-7`
- Agent harness: claude-code
- Triggered by: @pgaudet
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/25493119167)