### PR TITLE
Add local-setup instructions to CLAUDE.md (issue #32124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,33 +27,45 @@ in `.claude/skills/`
 
 ## Local Setup (skip if running in a GitHub Action)
 
-The editing workflow below relies on three Perl scripts (`obo-grep.pl`, `obo-checkout.pl`, `obo-checkin.pl`) and `robot`. When this repo is driven by the `ai-agent` / `copilot-setup-steps` workflows, these are installed automatically — skip this section.
+The editing workflow below relies on two sets of tools:
 
-If you are running locally (e.g. from an editor-driven Claude Code session), check whether the tools are already available **before doing anything else**:
+1. **ODK-provided tools** — `robot`, `owltools`, `dosdp-tools`, etc. These come from the pinned `obolibrary/odkfull` Docker image and **must not** be installed from Homebrew, the upstream releases page, or any other source. CI runs against the pinned image, and any other copy will drift in version and may give results that don't match CI. See the AUTOMATED-VALIDATION section and the `/odk-make` skill below for how to invoke them.
+2. **obo-scripts** — three Perl scripts (`obo-grep.pl`, `obo-checkout.pl`, `obo-checkin.pl`) used for stanza-aware search and the checkout/checkin procedure. These are not part of ODK and have to be on `PATH` separately.
+
+When this repo is driven by the `ai-agent` / `copilot-setup-steps` workflows, both are taken care of (the job runs inside the ODK container, and obo-scripts is cloned in) — skip this section.
+
+For a local editor-driven Claude Code session:
+
+**ODK tools.** Install Docker if you do not already have it. Do not install `robot` or other ODK tools on the host. Drive every `make` / `robot` / `owltools` / `dosdp-tools` invocation through the `/odk-make` skill's non-interactive wrapper, e.g.
 
 ```bash
-which obo-grep.pl obo-checkout.pl obo-checkin.pl robot
+.claude/skills/odk-make/odk-run.sh robot --version
+.claude/skills/odk-make/odk-run.sh make travis_build
 ```
 
-If any of the `obo-*.pl` scripts are missing, install them from https://github.com/cmungall/obo-scripts. The fastest, least-invasive option is:
+The wrapper uses the same image tag as `src/ontology/run.sh` (the canonical console invocation), so the version of `robot` you run matches the one CI uses. See the `/odk-make` skill for details and common targets.
+
+**obo-scripts.** Check whether they are on `PATH`:
 
 ```bash
-# pick any persistent location; ~/.local/share is a reasonable default
+which obo-grep.pl obo-checkout.pl obo-checkin.pl
+```
+
+If any are missing, install from https://github.com/cmungall/obo-scripts:
+
+```bash
 mkdir -p ~/.local/share
 git clone --depth 1 https://github.com/cmungall/obo-scripts.git ~/.local/share/obo-scripts
 
-# symlink the three scripts into a directory already on PATH
 mkdir -p ~/bin
 ln -sf ~/.local/share/obo-scripts/obo-grep.pl     ~/bin/obo-grep.pl
 ln -sf ~/.local/share/obo-scripts/obo-checkout.pl ~/bin/obo-checkout.pl
 ln -sf ~/.local/share/obo-scripts/obo-checkin.pl  ~/bin/obo-checkin.pl
 ```
 
-If `~/bin` is not already on `PATH`, either add it (`export PATH="$HOME/bin:$PATH"` in `~/.bashrc` / `~/.zshrc`) or substitute a directory that is (e.g. `/usr/local/bin`).
+If `~/bin` is not already on `PATH`, add it (`export PATH="$HOME/bin:$PATH"` in your shell rc) or substitute a directory that is. The `editing-obo-ontologies` skill, if available, also bundles these.
 
-If `robot` is missing, install per https://robot.obolibrary.org/ (the easiest route on macOS is `brew install robot`; otherwise download the jar + launcher script and put both on `PATH`). `robot` requires Java 11+.
-
-After installation, re-run the `which` check above and confirm all four resolve before continuing. Do not fall back to manually grepping `go-edit.obo` or hand-editing it — that path is much slower and error-prone, and the rest of this guide assumes the tools are present.
+Do not fall back to plain `grep` or to hand-editing `go-edit.obo` — that path is much slower and error-prone, and the rest of this guide assumes the tools are in place.
 
 ## PLAN: Analyze Issue, Plan Approach, and create a TODO/checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,36 @@ The project follows standard ODK layout:
 These instructions are optimized for claude code. Skills are used, and defined
 in `.claude/skills/`
 
+## Local Setup (skip if running in a GitHub Action)
+
+The editing workflow below relies on three Perl scripts (`obo-grep.pl`, `obo-checkout.pl`, `obo-checkin.pl`) and `robot`. When this repo is driven by the `ai-agent` / `copilot-setup-steps` workflows, these are installed automatically — skip this section.
+
+If you are running locally (e.g. from an editor-driven Claude Code session), check whether the tools are already available **before doing anything else**:
+
+```bash
+which obo-grep.pl obo-checkout.pl obo-checkin.pl robot
+```
+
+If any of the `obo-*.pl` scripts are missing, install them from https://github.com/cmungall/obo-scripts. The fastest, least-invasive option is:
+
+```bash
+# pick any persistent location; ~/.local/share is a reasonable default
+mkdir -p ~/.local/share
+git clone --depth 1 https://github.com/cmungall/obo-scripts.git ~/.local/share/obo-scripts
+
+# symlink the three scripts into a directory already on PATH
+mkdir -p ~/bin
+ln -sf ~/.local/share/obo-scripts/obo-grep.pl     ~/bin/obo-grep.pl
+ln -sf ~/.local/share/obo-scripts/obo-checkout.pl ~/bin/obo-checkout.pl
+ln -sf ~/.local/share/obo-scripts/obo-checkin.pl  ~/bin/obo-checkin.pl
+```
+
+If `~/bin` is not already on `PATH`, either add it (`export PATH="$HOME/bin:$PATH"` in `~/.bashrc` / `~/.zshrc`) or substitute a directory that is (e.g. `/usr/local/bin`).
+
+If `robot` is missing, install per https://robot.obolibrary.org/ (the easiest route on macOS is `brew install robot`; otherwise download the jar + launcher script and put both on `PATH`). `robot` requires Java 11+.
+
+After installation, re-run the `which` check above and confirm all four resolve before continuing. Do not fall back to manually grepping `go-edit.obo` or hand-editing it — that path is much slower and error-prone, and the rest of this guide assumes the tools are present.
+
 ## PLAN: Analyze Issue, Plan Approach, and create a TODO/checklist
 
 Read the entire issue and all associated comments. Be aware that some issues may have auxhiliary discussions, your must first infer the


### PR DESCRIPTION
Closes #32124 (proposes one of the three options the issue laid out — see below for why).

## Summary

Adds a **Local Setup** section near the top of `CLAUDE.md` that:

- Tells the agent to first check whether `obo-grep.pl`, `obo-checkout.pl`, `obo-checkin.pl`, and `robot` are on `PATH`.
- If the Perl scripts are missing, walks through cloning [`cmungall/obo-scripts`](https://github.com/cmungall/obo-scripts) into `~/.local/share/obo-scripts` and symlinking the three scripts into `~/bin`.
- Points at the upstream install docs for `robot` (and notes the macOS `brew install robot` shortcut).
- Explicitly says to skip the section when running inside the `ai-agent` / `copilot-setup-steps` workflows, since those already install the tools.

## Why option 1

The issue lists three options:

1. **Add install instructions to `CLAUDE.md`.** ← this PR
2. Pull in `ai4curation/curation-skills/editing-obo-ontologies`, which bundles the same three scripts alongside a generic SKILL.md.
3. Vendor copies of the skill + scripts into this repo and customize for GO.

Option 1 is the smallest, lowest-risk change and resolves the immediate friction without committing to a new external dependency or duplicating skill content. The `ai4curation` skill (option 2) is good but more generic than the existing GO-specific CLAUDE.md content — adopting it cleanly would mean either reconciling overlapping guidance or letting the two drift. Option 3 is the most self-contained but means owning a fork of scripts that already live in a maintained upstream.

Happy to switch to option 2 or 3 if you'd rather; this PR is deliberately scoped narrowly so it's easy to revert and replace.

## Checklist

- [x] PLAN — analyzed issue, picked option 1
- [N/A] PRE-VALIDATION — no ontology edits
- [N/A] RESEARCH — no biology content
- [N/A] TERM-SEARCH — no terms touched
- [N/A] DESIGN-PATTERNS — n/a, docs change
- [x] EDITS — single edit to `CLAUDE.md`, no `go-edit.obo` changes
- [N/A] RELATIONSHIPS / SPECIALIZED-EDITS / METADATA
- [N/A] AUTOMATED-VALIDATION — `make travis_build` would not exercise this change; skipped
- [N/A] REFERENCE-VALIDATION — no PMIDs introduced
- [x] CHANGES-COMMITTED — single commit on `CLAUDE.md`
- [x] PR created
- [x] Commented on originating issue

## Test plan

- [ ] On a fresh local checkout without `obo-scripts` on `PATH`, follow the new section verbatim and confirm `which obo-grep.pl obo-checkout.pl obo-checkin.pl` resolves afterwards.
- [ ] Confirm an editor-driven Claude Code session, given only this CLAUDE.md, would detect the missing tools and run the install steps before trying to edit terms.

---
🤖 **Generated by @dragon-ai-agent**
- Model: \`claude-opus-4-7\`
- Agent harness: claude-code
- Triggered by: @cmungall
- Run: [View workflow run](https://github.com/geneontology/go-ontology/actions/runs/26196737124)