### PR TITLE
Issue #22994: add never_in_taxon Viridiplantae to GO:0160108

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -744,3 +744,4 @@ GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:4751	Fungi
 GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:6656	Arthropoda	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:4751	Fungi	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:6656	Arthropoda	
+GO:0160108	animal gross anatomical part developmental process	NCBITaxon:33090	Viridiplantae	


### PR DESCRIPTION
## Summary

Adds a `never_in_taxon Viridiplantae` constraint on `GO:0160108 animal gross anatomical part developmental process`.

The differentia in GO:0160108's LD is `UBERON:0010000 multicellular anatomical structure`, which is part of UBERON's `common_anatomy` subset (taxon-neutral; explicitly applicable to plants and animals). So the "animal" scope of GO:0160108 is currently enforced only by curator discipline. This commit makes it formal.

## What this does

- Adds one row to `src/taxon_constraints/never_in_taxon.tsv`:
  ```
  GO:0160108  animal gross anatomical part developmental process  NCBITaxon:33090  Viridiplantae
  ```
- Propagates the constraint to every descendant of GO:0160108
- Provides a permanent guard against future regressions (any attempt to assert a Viridiplantae-tagged term under GO:0160108 surfaces as a CI violation)

## What this does NOT do

This is **standalone**; it does not by itself remove the 13 plant terms currently wrongly classified under GO:0160108 via reasoning. Those are:

| Plant GO term | Path to GO:0160108 |
|---|---|
| GO:0009960 endosperm dev | is_a GO:0009888 tissue dev (whose LD's UBERON:0000479 tissue is_a UBERON:0010000) |
| GO:0010479 stele dev | is_a GO:0009888 |
| GO:0048507 meristem dev | is_a GO:0009888 |
| GO:0080060 integument dev | is_a GO:0009888 |
| GO:0090558 plant epidermis dev | is_a GO:0009888 |
| GO:0010087 phloem/xylem histogenesis | is_a GO:0009888 |
| GO:0010088 phloem dev | via GO:0010087 |
| GO:0010089 xylem dev | via GO:0010087 |
| GO:0090058 metaxylem dev | via GO:0010089 |
| GO:0090059 protoxylem dev | via GO:0010089 |
| GO:0048624 plantlet formation | via GO:0048507 |
| GO:1902182 shoot apical meristem dev | reasoner-inferred via GO:0048507 (PO subclass) |
| GO:0010374 stomatal complex dev | reasoner-inferred via GO:0090558 (PO subclass) |
| GO:0048825 cotyledon dev | is_a GO:0009793 ending-in-seed-dormancy is_a GO:0009790 embryo dev |

These need structural re-parenting (move the asserted is_a edges off the animal-flavored groupers `GO:0009888 tissue development` and `GO:0009790 embryo development` onto `GO:0048856 anatomical structure development` directly). That work is planned as a follow-up PR — about 7 re-parenting edits with cascade effect.

## Validation

- `check_all_taxon_constraints_columns` Makefile target passes (column count check)
- Runtime taxon-constraint violation check happens in CI via `make travis_build`; if any of the 13 plant terms above (or others) carry an explicit `present_in_taxon Viridiplantae` annotation, they will surface as violations and identify additional structural fixes
- Plant GO terms typically don't carry explicit Viridiplantae annotations at the OWL level (their plant-ness is anchored on PO LDs, not on NCBITaxon assertions), so it's expected that **no new violations will be raised by this PR alone**. The 13 contamination cases above will still classify under GO:0160108 until the structural follow-up

## Why this PR is worth landing standalone

- One-line change, low risk
- Permanent guardrail — future curators get an immediate CI signal if they try to assert a `present_in_taxon Viridiplantae` term under GO:0160108
- Makes intent explicit before the structural fix lands (any review of the structural fix can then point to this constraint as the authoritative scope statement)

## Checklist

- [x] PLAN: surgical taxon-constraint addition, separated from structural re-parenting work
- [x] PRE-VALIDATION: ontology builds; this is taxon-constraints only, not go-edit.obo
- [x] EDITS: 1 row appended to `src/taxon_constraints/never_in_taxon.tsv`
- [x] METADATA: file header (`defined_class | label | taxon | taxon_label | source`) preserved; source column left blank consistent with most existing rows
- [x] AUTOMATED-VALIDATION: `check_all_taxon_constraints_columns` passes locally; CI will run full taxon-constraint validation
- [x] CHANGES-COMMITTED: 1-line diff to `src/taxon_constraints/never_in_taxon.tsv` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)