### PR TITLE
Issue #22994: add never_in_taxon Metazoa to GO:0160109

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -745,3 +745,4 @@ GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:6656	Arthropoda
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:4751	Fungi	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:6656	Arthropoda	
 GO:0160108	animal gross anatomical part developmental process	NCBITaxon:33090	Viridiplantae	
+GO:0160109	plant gross anatomical part developmental process	NCBITaxon:33208	Metazoa	


### PR DESCRIPTION
## Summary

Adds a `never_in_taxon Metazoa` constraint on `GO:0160109 plant gross anatomical part developmental process`. Symmetric counterpart of PR #32149, which added `never_in_taxon Viridiplantae` on GO:0160108.

## What this does

- Adds one row to `src/taxon_constraints/never_in_taxon.tsv`:

  ```
  GO:0160109  plant gross anatomical part developmental process  NCBITaxon:33208  Metazoa
  ```

- Propagates the `never_in_taxon Metazoa` constraint to every descendant of GO:0160109 (the 76 plant developmental terms anchored in #32162)
- Provides a permanent guard against future regressions where someone might assert a Metazoa-tagged term under GO:0160109

## Rationale

GO:0160109 doesn't yet have a logical definition. Once Planteome issue [718](https://github.com/Planteome/plant-ontology/issues/718) resolves and PO adds a "plant gross anatomical part" grouping class, GO:0160109's LD could use that as differentia. PO terms aren't formally taxon-constrained to Viridiplantae at the OWL level, so the term name's "plant" scope is enforced only by curator discipline today.

This taxon constraint makes the plant-only scope formal, parallel to how PR #32149 formalized GO:0160108's animal-only scope.

## Validation

- `check_all_taxon_constraints_columns` Makefile target passes (column count valid)
- 1-line diff to `src/taxon_constraints/never_in_taxon.tsv`
- Runtime taxon constraint validation runs in CI

## Checklist

- [x] PLAN: symmetric guardrail to #32149
- [x] EDITS: 1 row appended to `src/taxon_constraints/never_in_taxon.tsv`
- [x] METADATA: file header preserved; source column blank per existing convention
- [x] AUTOMATED-VALIDATION: column-count check passes; CI will run full taxon-constraint validation
- [x] CHANGES-COMMITTED: 1-line diff only

🤖 Generated with [Claude Code](https://claude.com/claude-code)