### PR TITLE
Add only_in_taxon Viridiplantae constraint for GO:0160109

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -954,3 +954,4 @@ GO:0140400	embryonic sheath	NCBITaxon:6231	Nematoda	PMID:28526752
 GO:0019658	bifid shunt	NCBITaxon:2	Bacteria	
 GO:0120576	1,2-dehydro-N-beta-alanyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620
 GO:0120577	1,2-dehydro-N-acetyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620
+GO:0160109	plant gross anatomical part developmental process	NCBITaxon:33090	Viridiplantae	


### PR DESCRIPTION
Adds only_in_taxon Viridiplantae (NCBITaxon:33090) for GO:0160109 'plant gross anatomical part developmental process'. Follows GO convention for plant terms; validated via column check + ELK reasoning (no unsatisfiable classes). Only the source TSV is committed; derived files regenerated by CI. Re #22994