### PR TITLE
Add /odk-make skill for running Makefile targets in the ODK Docker image

### DIFF
--- a/.claude/skills/odk-make/SKILL.md
+++ b/.claude/skills/odk-make/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: odk-make
+description: Use whenever you run a Makefile target (e.g. `make travis_build`, `make test`, `make reasoned.ofn`) or any one-off ROBOT / owltools / dosdp-tools / scala-cli command derived from a Makefile recipe. These must run inside the pinned ODK Docker image, not against host tools. Covers validation, reasoning, imports, and release builds in src/ontology.
+---
+
+## The core rule
+
+Every Makefile target and every one-off command copied from a Makefile recipe
+**must run inside the ODK Docker image** (`obolibrary/odkfull`). The Makefile
+recipes call `robot`, `owltools`, `dosdp-tools`, and `scala-cli`; the ODK image
+is what provides those tools **at the exact versions GO's build and CI expect**.
+Running `make` or `robot` against whatever happens to be on the host PATH is not
+reproducible — host tools may be missing, or be the wrong version, and you will
+get results that don't match CI.
+
+The canonical console invocation is the wrapper `src/ontology/run.sh`, which a
+human editor runs **from inside `src/ontology`**:
+
+```sh
+cd src/ontology
+./run.sh make test
+./run.sh robot --version
+```
+
+`run.sh` is just `docker run ... obolibrary/odkfull:<pinned-version> "$@"`, with
+the repo mounted at `/work` and the working directory set to
+`/work/src/ontology`. It mounts `$PWD/../../`, so it only mounts correctly when
+invoked from `src/ontology`.
+
+## How YOU (an agent) should run these commands
+
+`run.sh` requests an interactive TTY (`docker run -ti`). That fails in a
+non-interactive shell — the normal case when you run commands — with:
+
+```
+cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+```
+
+So do **not** call `./run.sh` directly. Use the bundled TTY-free wrapper in this
+skill instead. It mirrors `run.sh` exactly (same image tag — read live from
+`run.sh` so it never drifts — same mount, same workdir) but omits `-ti`, and it
+works from any directory in the repo:
+
+```sh
+.claude/skills/odk-make/odk-run.sh make travis_build
+.claude/skills/odk-make/odk-run.sh make reasoned.ofn
+.claude/skills/odk-make/odk-run.sh robot --version
+```
+
+Decision rule:
+
+- **Local development / agent on a workstation** (Docker available, you are NOT
+  already inside the ODK container): always go through `odk-run.sh`.
+- **Already inside the ODK image** (GitHub Actions / `dragon-ai-agent`, where the
+  job itself runs in the ODK container; or you launched an interactive
+  `./run.sh bash` shell): the tools are already on PATH, so call `make` / `robot`
+  directly with **no** wrapper. Don't nest Docker.
+
+If you're unsure which environment you're in: `robot --version` succeeding on the
+bare PATH and a `/work` working directory are signs you're already inside ODK.
+Otherwise assume you need `odk-run.sh`.
+
+> Note on CLAUDE.md: the project guide writes validation as
+> `cd src/ontology && make travis_build`. That shorthand assumes the ODK
+> environment is already active (as in CI). On a local machine, run the
+> equivalent through the wrapper:
+> `.claude/skills/odk-make/odk-run.sh make travis_build`.
+
+## Common targets
+
+| Goal | Command (local) |
+| --- | --- |
+| Full validation (CI gate) | `.claude/skills/odk-make/odk-run.sh make travis_build` |
+| Test suite | `.claude/skills/odk-make/odk-run.sh make test` |
+| Reason the edit file | `.claude/skills/odk-make/odk-run.sh make reasoned.ofn` |
+| Regenerate an import | `.claude/skills/odk-make/odk-run.sh make imports/<name>.owl` |
+| Regenerate all imports | `.claude/skills/odk-make/odk-run.sh make all_imports` |
+| Simulate a release build | `.claude/skills/odk-make/odk-run.sh make` |
+
+`make travis_build` is the primary post-edit validation gate. **Allow at least
+~10 minutes** for it to run; don't kill it early. If it times out, you can run
+the SPARQL verification checks and the ELK reasoning step on their own (see the
+AUTOMATED-VALIDATION section of CLAUDE.md) — those are also Makefile-derived
+commands, so run them through `odk-run.sh` too, e.g.:
+
+```sh
+.claude/skills/odk-make/odk-run.sh \
+  robot reason -r ELK -i go-edit.obo -o go-edit.reasoned.obo
+```
+
+## One-off ROBOT / owltools commands
+
+Anything you'd lift from a Makefile recipe — a `robot verify`, `robot explain`,
+`robot convert -vvv` for a syntax stack trace, an `owltools` diff — goes through
+the same wrapper. Paths are relative to `src/ontology` (the container's working
+directory), so reference files the way the Makefile does (`go-edit.obo`,
+`imports/...`, `../sparql/...`, `../taxon_constraints/...`):
+
+```sh
+# Syntax error stack trace
+.claude/skills/odk-make/odk-run.sh robot convert -vvv -i go-edit.obo -f obo -o go-edit.TMP.obo
+
+# Explain unsatisfiable classes
+.claude/skills/odk-make/odk-run.sh \
+  robot explain --input go-edit.obo --reasoner ELK -M unsatisfiability \
+  --unsatisfiable all explanations.md
+```
+
+## Gotchas
+
+- **Use ELK, never a DL reasoner (HermiT) on the full ontology** — GO is large and
+  only has EL axioms; ELK is the default and is sufficient. HermiT will not scale.
+- **Run from the repo, not a stray subdir.** `odk-run.sh` figures out the repo
+  root from its own path, but the *paths you pass to commands* are interpreted
+  inside `/work/src/ontology`. Keep the repo as your working tree.
+- **First run pulls the image.** If the ODK image isn't cached locally, the first
+  `docker` invocation downloads it (can take a while). This is expected.
+- **Don't commit build artifacts.** Targets write many derived files (`*.ofn`,
+  `*.owl`, `reasoned.*`, reports). Only commit the source files you actually
+  edited (normally `src/ontology/go-edit.obo`), per CLAUDE.md.
+- **Don't edit `run.sh` to drop `-ti`** — console editors rely on the interactive
+  shell. Use `odk-run.sh` for non-interactive runs instead.

--- a/.claude/skills/odk-make/odk-run.sh
+++ b/.claude/skills/odk-make/odk-run.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Non-interactive ODK runner for agents.
+#
+# This mirrors src/ontology/run.sh (same image, same mount, same workdir) but
+# DROPS the `-ti` flags. run.sh requests an interactive TTY, which fails when
+# there is no terminal attached (the usual case for an agent running commands):
+#
+#   cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+#
+# Use this wrapper to run Makefile targets or one-off ODK tool commands. It can
+# be invoked from anywhere in the repo (it locates the repo root from its own
+# path) and reads the pinned ODK image tag straight from run.sh so it never
+# drifts from what console users / CI use.
+#
+#   .claude/skills/odk-make/odk-run.sh make travis_build
+#   .claude/skills/odk-make/odk-run.sh robot --version
+#   .claude/skills/odk-make/odk-run.sh make reasoned.ofn
+
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+RUN_SH="$REPO/src/ontology/run.sh"
+
+if [ ! -f "$RUN_SH" ]; then
+  echo "odk-run.sh: cannot find $RUN_SH (is this the go-ontology repo?)" >&2
+  exit 1
+fi
+
+# Extract the pinned image, e.g. obolibrary/odkfull:v1.6.1, from run.sh.
+IMG="$(grep -o 'obolibrary/odkfull:[^ "]*' "$RUN_SH" | head -n1)"
+if [ -z "$IMG" ]; then
+  echo "odk-run.sh: could not determine ODK image from $RUN_SH" >&2
+  exit 1
+fi
+
+# Same memory limit and mount as run.sh, but no -ti.
+exec docker run --rm -m 12g -v "$REPO:/work" -w /work/src/ontology "$IMG" "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The general procedure is:
 - checking in will update the edit file and remove the file from `terms/`
 - Commits are then made on src/ontology/go-edit.obo as appropriate
 - `obo-checkout.pl` and `obo-checkin.pl` come from the same obo-scripts tooling (`cmungall/obo-scripts` / the `editing-obo-ontologies` skill) and are likewise only on PATH once it's installed/loaded. If not found, install/locate them and call by full path — don't work around their absence by editing the megafile directly; the checkin/checkout procedure is required.
-- Always validate after checkin via `cd src/ontology && make travis_build`
+- Always validate after checkin via `cd src/ontology && make travis_build` (this must run in the ODK Docker image — see the /odk-make skill)
 
 ### Creation of new terms
 
@@ -362,6 +362,8 @@ property_value: term_tracker_item "https://github.com/geneontology/go-ontology/i
 ## AUTOMATED-VALIDATION using Makefile
 
 This ontology uses standard ODK/ROBOT tests plus custom tests to ensure the ontology is logically, syntactically, and stylistically valid.
+
+IMPORTANT: every `make` target and every one-off `robot`/`owltools` command in this section must run inside the pinned ODK Docker image (`obolibrary/odkfull`), NOT against host tools — otherwise results won't match CI. Use the /odk-make skill, which explains this and provides a non-interactive runner (`.claude/skills/odk-make/odk-run.sh make travis_build`, etc). The bare `cd src/ontology && make ...`/`robot ...` forms shown below assume you are already inside the ODK environment (as in GitHub Actions); locally, wrap them via /odk-make.
 
 Ensure that full validation is performed, using `cd src/ontology && make travis_build` (being sure you are in the right folder)
 


### PR DESCRIPTION
Makefile targets and one-off ROBOT/owltools/dosdp-tools/scala-cli commands must run inside the pinned obolibrary/odkfull image (not host tools) to match CI. This adds a skill documenting that workflow plus a non-interactive runner.

- .claude/skills/odk-make/SKILL.md: explains the core rule, the console (run.sh) vs agent invocation, common targets, one-off ROBOT commands, and gotchas (ELK-not-HermiT, paths relative to src/ontology, image pull, etc).
- .claude/skills/odk-make/odk-run.sh: TTY-free wrapper that mirrors run.sh (same image read live from run.sh, same mount/workdir) but drops -ti, which otherwise fails in a non-interactive shell ("stdin is not a terminal").
- CLAUDE.md: reference /odk-make from the AUTOMATED-VALIDATION section and the post-checkin validation step.