### PR TITLE
De-anchor reproductive system development; add only_in_taxon Metazoa to GO:0160108

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -955,3 +955,4 @@ GO:0019658	bifid shunt	NCBITaxon:2	Bacteria
 GO:0120576	1,2-dehydro-N-beta-alanyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620
 GO:0120577	1,2-dehydro-N-acetyldopamine biosynthetic process	NCBITaxon:50557	Insecta	PMID:19932179|PMID:32709620
 GO:0160109	plant gross anatomical part developmental process	NCBITaxon:33090	Viridiplantae	
+GO:0160108	animal gross anatomical part developmental process	NCBITaxon:33208	Metazoa	


### PR DESCRIPTION
Follow-on to #32216 (which fixed GO:0160108's invalid logical definition and converted it to an asserted animal grouping).

## Goal
Add `only_in_taxon Metazoa` to **GO:0160108 "animal gross anatomical part developmental process"** — symmetric with `GO:0160109`'s `only_in Viridiplantae`, and a reasoner-enforced guarantee that the grouping is animal-only.

## Blocker found and fixed
Adding the constraint initially made the ontology **inconsistent**. Root cause: **`GO:0061458 reproductive system development`** was asserted `is_a GO:0160108`, but `reproductive structure development` (GO:0048608) is `part_of` it, and GO's taxon machinery propagates a whole's taxon to its parts (`part_of ⊑ overlaps`; `overlaps o in_taxon → in_taxon`). So `only_in Metazoa` propagated down to **57 cross-kingdom** reproductive-structure terms (plant flower/endosperm/seed/meristem; fungal spore-bearing structure), which are disjoint from Metazoa.

`GO:0061458`'s `is_a GO:0160108` was never a curated animal judgement: it originated as an inference from the original over-broad equivalence axiom (2023) and was frozen as an asserted link in the phase-2 anchoring commit `b89ebb13b`. Reproductive systems/structures are cross-kingdom, so it didn't belong under the animal grouping.

## Changes
- **GO:0061458 reproductive system development** — removed `is_a GO:0160108` (now `is_a GO:0048731 system development` only).
- **only_in_taxon.tsv** — added `GO:0160108 → NCBITaxon:33208 (Metazoa)`.

## Audit & validation
- `GO:0061458` was the **sole** `part_of`-leaking anchor — verified by graph traversal (reasoned `is_a` + asserted `part_of`) and corroborated by ROBOT's unsatisfiability explanations (all leak chains funnelled through it).
- De-anchoring dropped **only `GO:0061458` itself** (724→723 descendants); every animal reproductive term (gonad, prostate, uterus, … development) keeps its grouping via other paths, so **no re-anchoring was needed**.
- [x] ELK reasoning over go-edit + go_taxon_constraints (incl. Metazoa) + NCBITaxon disjointness: **no unsatisfiable classes**
- [x] taxon-constraint column check passes; OBO syntax OK
- [x] only the source TSV + go-edit.obo committed; derived files (`only_in_taxon.ofn`, `go_taxon_constraints.owl`) regenerated by CI

## Result
GO:0160108 is now a clean, primitive, **Metazoa-constrained** animal grouping (723 animal descendants), with the reasoner enforcing animal-only membership going forward.

Re #22994