### PR TITLE
[bot] Repoint Thalassiosirophycidae to Thalassiosirophyceae in ncbitaxon import (fix go-gaf unsat). #32308

### DIFF
--- a/src/ontology/imports/ncbitaxon_import.obo
+++ b/src/ontology/imports/ncbitaxon_import.obo
@@ -6838,11 +6838,21 @@ property_value: has_rank NCBITaxon:kingdom
 property_value: TAXRANK:1000000 TAXRANK:0000017
 
 [Term]
+id: NCBITaxon:589449
+name: Thalassiosirophyceae
+namespace: ncbi_taxonomy
+xref: GC_ID:1
+is_a: NCBITaxon:2836 ! Bacillariophyta
+relationship: RO:0002162 NCBITaxon:589449 ! Thalassiosirophyceae
+property_value: has_rank NCBITaxon:class
+property_value: TAXRANK:1000000 TAXRANK:0000002
+
+[Term]
 id: NCBITaxon:33846
 name: Thalassiosirophycidae
 namespace: ncbi_taxonomy
 xref: GC_ID:1
-is_a: NCBITaxon:33836 ! Coscinodiscophyceae
+is_a: NCBITaxon:589449 ! Thalassiosirophyceae
 relationship: RO:0002162 NCBITaxon:33846 ! Thalassiosirophycidae
 property_value: has_rank NCBITaxon:subclass
 property_value: TAXRANK:1000000 TAXRANK:0000007

--- a/src/ontology/imports/ncbitaxon_import.owl
+++ b/src/ontology/imports/ncbitaxon_import.owl
@@ -16117,10 +16117,30 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_589449 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_589449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2836"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_589449"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:TAXRANK_1000000 rdf:resource="http://purl.obolibrary.org/obo/TAXRANK_0000002"/>
+        <ncbitaxon:has_rank rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_class"/>
+        <oboInOwl:hasDbXref>GC_ID:1</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>ncbi_taxonomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>NCBITaxon:589449</oboInOwl:id>
+        <rdfs:label>Thalassiosirophyceae</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_33846 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33846">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33836"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_589449"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Closes #32308.

## What & why

NCBI reclassified the Thalassiosirales diatoms: it created a new class **Thalassiosirophyceae** (NCBITaxon:589449) under Bacillariophyta and moved this clade into it. Our checked-in `imports/ncbitaxon_import.obo` (last refreshed in #32035, 2026-05-05) still asserted the old parent **Coscinodiscophyceae** (NCBITaxon:33836).

When `extensions/go-gaf.owl` merges the freshly-downloaded `mirror/taxslim.owl` (`33846 is_a 589449`) and `mirror/taxslim-disjoint-over-in-taxon.owl` (`33836 disjointWith 589449`), `Thalassiosirophycidae` ends up under two disjoint parents:

```
33846 ⊑ Coscinodiscophyceae (33836)    [stale — our import]
33846 ⊑ Thalassiosirophyceae (589449)  [fresh taxslim]
33836 disjointWith 589449              [fresh taxslim-disjoint]
⇒ 33846 ⊑ ⊥, propagating to its 17 descendants = 18 unsatisfiable classes
```

That is the `reason -r ELK` failure at `Makefile:258` (it likewise blocks go-lego / go-amigo, which merge the same disjointness mirror). Full analysis and the 18-class list are in #32308.

## Change

Surgical correction of the drifted edge in both serializations of the import module:

- `imports/ncbitaxon_import.obo` and `.owl`: `Thalassiosirophycidae (33846)` `is_a` `33836` → `589449`.
- Add the new `Thalassiosirophyceae (589449)` class stanza (`is_a Bacillariophyta`, rank class) so the import is self-consistent and go-plus carries a properly labelled term.

Net diff: +32 / −2 across the two files. No `go-edit.obo` changes.

## Verification

Reproduced and fixed the exact failing step in isolation, using the pinned ODK image and the fresh mirrors:

```
robot merge -i imports/ncbitaxon_import.owl \
            -i mirror/taxslim.owl \
            -i mirror/taxslim-disjoint-over-in-taxon.owl \
            reason -r ELK
```

- Before the patch: 18 unsatisfiable classes — identical set to the release log.
- After the patch: **exit 0, zero unsatisfiable classes.**
- Both patched files pass `robot convert` (obo and ofn).

Full `make travis_build` was not run locally (long-running; `go-edit.obo` is untouched) — relying on PR CI for the complete build.

## Scope note / follow-up

Targeted fix for the single drifted clade, chosen over a full `make imports/ncbitaxon_import.*` regen to keep the diff reviewable and avoid pulling in unrelated NCBI churn. A full refresh at the next convenient point would catch this and any other silent drift wholesale (as #32035 did); noted in #32308.

@balhoff — you own the taxon import pipeline, so flagging in case you'd prefer to fold this into a full ncbitaxon refresh rather than merge the surgical patch.

## Checklist

- [x] PRE-VALIDATION: failure reproduced in isolation before changes (18 unsat)
- [x] EDITS: import module only; no `go-edit.obo` change; obo checkin/checkout N/A (this is a generated import, not the edit file)
- [x] RELATIONSHIPS: single `is_a` repointed to the current NCBI parent; new parent class added with correct rank; no over-assertion
- [x] METADATA: subjects are NCBITaxon classes, not GO terms — `created_by`/`creation_date`/`term_tracker_item` not applicable
- [x] AUTOMATED-VALIDATION: targeted ELK reason step verified 0 unsat (was 18); both files parse; full `travis_build` deferred to CI
- [ ] N/A: RESEARCH / TERM-SEARCH / DESIGN-PATTERNS / REFERENCE-VALIDATION / chemical / reaction / taxon-constraint / mapping / obsoletion — not a term-curation change
- [x] ISSUE-ALIGNMENT: directly unblocks the go-gaf build; single coherent change
- [x] Communicated a biologist-friendly summary on #32308

_— Opened by a Claude Code agent on behalf of @kltm._
