### PR TITLE
Taxon constraints for GO:0097723 amoeboid sperm motility (#32337)

### DIFF
--- a/src/ontology/imports/go-taxon-constraint-classes.ofn
+++ b/src/ontology/imports/go-taxon-constraint-classes.ofn
@@ -11,6 +11,7 @@ Ontology(<http://purl.obolibrary.org/obo/go/imports/go-taxon-constraint-classes.
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_10090>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_10239>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1117>))
+Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_131567>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_147537>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_147554>))
@@ -72,6 +73,7 @@ Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/N
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6231>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6237>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656>))
+Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_71193>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_7147>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_716545>))
@@ -88,6 +90,7 @@ Declaration(Class(<http://geneontology.org/internal/taxon-constraints/never-in/N
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_10090>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_10239>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1117>))
+Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_131567>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_147537>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_147554>))
@@ -149,6 +152,7 @@ Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NC
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6237>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656>))
+Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_71193>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_7147>))
 Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_716545>))
@@ -180,6 +184,7 @@ Declaration(Class(<http://geneontology.org/internal/taxon-constraints/only-in/NC
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_10090>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_10239>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_1117>))
+Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_1206794>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_131567>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_147537>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_147554>))
@@ -241,6 +246,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_6073>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_6231>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_6237>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_6656>))
+Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_6960>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_71193>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_7147>))
 Declaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_716545>))
@@ -297,6 +303,15 @@ AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constrain
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1117> ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1117>)))
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> ObjectComplementOf(<http://purl.obolibrary.org/obo/NCBITaxon_1117>)))
 DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1117>))
+
+# Class: <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> (never in Ecdysozoa)
+
+AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> "never in Ecdysozoa")
+EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1206794>)))
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6231>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> ObjectComplementOf(<http://purl.obolibrary.org/obo/NCBITaxon_1206794>)))
+DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1206794>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_131567> (never in cellular organisms)
 
@@ -470,9 +485,8 @@ DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCB
 
 AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> "never in Protostomia")
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_33317>)))
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_1206794>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_27896>)
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6231>)
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> ObjectComplementOf(<http://purl.obolibrary.org/obo/NCBITaxon_33317>)))
 DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_33317> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_33317>))
 
@@ -786,9 +800,17 @@ DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCB
 
 AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> "never in Arthropoda")
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6656>)))
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_50557>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> ObjectComplementOf(<http://purl.obolibrary.org/obo/NCBITaxon_6656>)))
 DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6656>))
+
+# Class: <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> (never in Hexapoda)
+
+AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> "never in Hexapoda")
+EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6960>)))
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_50557>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> ObjectComplementOf(<http://purl.obolibrary.org/obo/NCBITaxon_6960>)))
+DisjointClasses(<http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_6960> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6960>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/never-in/NCBITaxon_71193> (never in Elateroidea)
 
@@ -912,6 +934,13 @@ EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NC
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1117> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_2>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1117> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_Union_0000002>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1117> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1117>))
+
+# Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794> (only in Ecdysozoa)
+
+AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794> "only in Ecdysozoa")
+EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1206794>))
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_33317>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_1206794>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_131567> (only in cellular organisms)
 
@@ -1231,7 +1260,7 @@ SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon
 
 AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_50557> "only in Insecta")
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_50557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_50557> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_50557> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_50557> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_50557>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_554915> (only in Amoebozoa)
@@ -1330,7 +1359,7 @@ SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon
 
 AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231> "only in Nematoda")
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6231>))
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_33317>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6231> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6231>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6237> (only in Caenorhabditis)
@@ -1344,8 +1373,15 @@ SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon
 
 AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656> "only in Arthropoda")
 EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6656>))
-SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_33317>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_1206794>)
 SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6656>))
+
+# Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960> (only in Hexapoda)
+
+AnnotationAssertion(rdfs:label <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960> "only in Hexapoda")
+EquivalentClasses(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6960>))
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960> <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6656>)
+SubClassOf(<http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_6960> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_6960>))
 
 # Class: <http://geneontology.org/internal/taxon-constraints/only-in/NCBITaxon_71193> (only in Elateroidea)
 

--- a/src/ontology/imports/taxon_constraints_seed.txt
+++ b/src/ontology/imports/taxon_constraints_seed.txt
@@ -10,6 +10,7 @@
 NCBITaxon:10090 ## Mus musculus
 NCBITaxon:10239 ## Viruses
 NCBITaxon:1117 ## Cyanobacteria
+NCBITaxon:1206794 ## Ecdysozoa
 NCBITaxon:131567 ## cellular organisms
 NCBITaxon:147537 ## Saccharomycotina
 NCBITaxon:147554 ## Schizosaccharomycetes
@@ -71,6 +72,7 @@ NCBITaxon:6073 ## Cnidaria
 NCBITaxon:6231 ## Nematoda
 NCBITaxon:6237 ## Caenorhabditis
 NCBITaxon:6656 ## Arthropoda
+NCBITaxon:6960 ## Hexapoda
 NCBITaxon:71193 ## Elateroidea
 NCBITaxon:7147 ## Diptera
 NCBITaxon:716545 ## saccharomyceta


### PR DESCRIPTION
[Written by Claude]

## Taxon constraints for GO:0097723 amoeboid sperm motility

Closes #32337.

### Changes
- `src/ontology/go-edit.obo` — GO:0097723 amoeboid sperm motility:
  - `is_a: onlyin:1206794 {source="PMID:20803732"}` (only in Ecdysozoa, NCBITaxon:1206794)
  - `is_a: neverin:6960 {source="PMID:20803732"}` (never in Hexapoda, NCBITaxon:6960)
- `src/ontology/imports/taxon_constraints_seed.txt` — added NCBITaxon:1206794 (Ecdysozoa) and NCBITaxon:6960 (Hexapoda), which had no materialized constraint classes yet.
- `src/ontology/imports/go-taxon-constraint-classes.ofn` — regenerated from the seed (`make imports/go-taxon-constraint-classes.ofn`).

### Rationale
Amoeboid (aflagellate, MSP-based crawling) *motile* sperm are rare in metazoans and characteristic of nematodes (⊂ Ecdysozoa). No credible evidence of amoeboid *motile* sperm outside Ecdysozoa — non-nematode "amoeboid sperm" reports (flatworms, crustaceans) concern aflagellate but largely immotile sperm. `only_in Ecdysozoa` (rather than Nematoda) is the cautious choice per the requester's "sporadically in a few other ecdysozoa" note.

Hexapoda ⊂ Ecdysozoa, so `never_in Hexapoda` is a non-redundant carve-out: `only_in Ecdysozoa` alone would permit insects, which have flagellated (or rarely immotile aflagellate) sperm. This is the practical guard against erroneous insect annotations.

Source: PMID:20803732 (Fraire-Zamora & Cardullo 2010, Mol Reprod Dev).

### Note on the issue's "remove never_in Ascomycota" ask
`never_in Ascomycota` is not asserted on GO:0097723; it is inherited from GO:0048870 cell motility (`is_a: neverin:4890`), which is correct for that branch and left untouched. With `only_in Ecdysozoa` now on the term, the inherited Ascomycota exclusion is logically redundant (Ascomycota ∩ Ecdysozoa = ∅) but harmless — nothing to remove. Confirmed no unsatisfiability from the interaction with inherited fungal constraints (neverin:4890 Ascomycota, neverin:451864 Dikarya), all disjoint from Ecdysozoa.

### Checklist
- [x] PLAN: issue analyzed, intent clear
- [x] PRE-VALIDATION: n/a targeted TC edit; validated post-edit
- [x] RESEARCH: phylogeny of amoeboid motile sperm; PMID:20803732 verified genuine and on-topic
- [x] TERM-SEARCH: GO:0097723 and ancestors (sperm motility, cell motility, locomotion) checked
- [x] DESIGN-PATTERNS: taxon-constraint skill (onlyin:/neverin: superclass assertions)
- [x] EDITS: checkout/checkin procedure via obo-checkout.pl / obo-checkin.pl
- [x] RELATIONSHIPS: onlyin:/neverin: is_a axioms with source annotations
- [x] METADATA: source=PMID on axioms; no created_by/creation_date change (existing term)
- [x] AUTOMATED-VALIDATION: ELK reasoning passed (no unsatisfiable classes); `make travis_build` passed (all 21 SPARQL QC rules 0 violations)
- [x] REFERENCE-VALIDATION: PMID:20803732 confirmed via NCBI
- [x] ISSUE-ALIGNMENT: matches request; Ascomycota clarification communicated on issue
