### PR TITLE
Authenticate AI agent as the ai4c-agent GitHub App

### DIFF
--- a/.claude/skills/odk-make/SKILL.md
+++ b/.claude/skills/odk-make/SKILL.md
@@ -51,7 +51,7 @@ Decision rule:
 
 - **Local development / agent on a workstation** (Docker available, you are NOT
   already inside the ODK container): always go through `odk-run.sh`.
-- **Already inside the ODK image** (GitHub Actions / `dragon-ai-agent`, where the
+- **Already inside the ODK image** (GitHub Actions / `ai4c-agent`, where the
   job itself runs in the ODK container; or you launched an interactive
   `./run.sh bash` shell): the tools are already on PATH, so call `make` / `robot`
   directly with **no** wrapper. Don't nest Docker.

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -9,7 +9,7 @@ You can use normal web search tools to find relevant literature. You can also us
 as wikipedia but it's good to follow up with the publications themselves. All research must be summarized in a file RESEARCH.md.
 This file is NOT to be committed, however, it MUST be communicated back appropriately to the user.
 
-Remember, most of the time you are likely to be running in a GitHub actions context, when triggered from an issue (via a `@dragon-ai-agent` invocation). If this is the case, the RESEARCH.md contents
+Remember, most of the time you are likely to be running in a GitHub actions context, when triggered from an issue (via a `@ai4c-agent` invocation). If this is the case, the RESEARCH.md contents
 should be copied onto the issue comments. Otherwise, the user has no way of seeing the RESEARCH.md file, as it disappears alongside the temporary github actions workspace.
 
 This is especially true if the user asks you explicitly to research a topic  - they want to see the full report! Even if you make the RESEARCH.md as part of a broader task, it is good to post the contents.

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -6,8 +6,10 @@
 # Authenticates as the `ai4c-agent` GitHub App (installation token minted per
 # job), not as a machine account PAT.
 #
-# Required secrets: ANTHROPIC_API_KEY, AI4C_AGENT_PRIVATE_KEY
-# Required variables: AI4C_AGENT_APP_ID
+# Required secrets: ANTHROPIC_API_KEY, AI4C_AGENT_APP_ID, AI4C_AGENT_PRIVATE_KEY
+# (the app id is not actually sensitive, but is stored as a secret for
+# consistency with the private key; note this is the *app* id, distinct from
+# the AGENT_USER_ID below, which is the bot account's user id)
 # Configuration: .github/ai-controllers.json (list of authorized usernames)
 #
 # ============================================================================
@@ -31,8 +33,9 @@ env:
   # once curators have moved to @ai4c-agent.
   AGENT_MENTION_LEGACY: dragon-ai-agent
   # GitHub App bot identity, used for commit attribution. AGENT_USER_ID is the
-  # numeric id of ai4c-agent[bot] (`gh api /users/ai4c-agent%5Bbot%5D`); without
-  # it, commits are not linked back to the app.
+  # numeric id of the ai4c-agent[bot] *account* (`gh api /users/ai4c-agent%5Bbot%5D`),
+  # NOT the app id in AI4C_AGENT_APP_ID -- they are different numbers. It is
+  # public, hence plain env. Without it commits are not linked back to the app.
   AGENT_LOGIN: ai4c-agent[bot]
   AGENT_USER_ID: 242316268
   MODEL: claude-opus-4-7
@@ -79,7 +82,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.AI4C_AGENT_APP_ID }}
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
       - name: Check for qualifying mention
         id: check
@@ -283,7 +286,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.AI4C_AGENT_APP_ID }}
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -3,7 +3,11 @@
 # Listens for @<agent-name> please <request> mentions from authorized users
 # and runs Claude Code to respond.
 #
-# Required secrets: ANTHROPIC_API_KEY, PAT_FOR_PR
+# Authenticates as the `ai4c-agent` GitHub App (installation token minted per
+# job), not as a machine account PAT.
+#
+# Required secrets: ANTHROPIC_API_KEY, AI4C_AGENT_PRIVATE_KEY
+# Required variables: AI4C_AGENT_APP_ID
 # Configuration: .github/ai-controllers.json (list of authorized usernames)
 #
 # ============================================================================
@@ -19,7 +23,18 @@
 name: AI Agent GitHub Mentions
 
 env:
-  AGENT_NAME: dragon-ai-agent
+  # The handle curators type to invoke the agent. Note this is NOT a real
+  # GitHub account: the app's login is AGENT_LOGIN (`<name>[bot]`), and apps
+  # cannot be @-mentioned, so "@ai4c-agent" renders as plain text.
+  AGENT_MENTION: ai4c-agent
+  # Deprecated handles still honoured as triggers (comma-separated). Drop this
+  # once curators have moved to @ai4c-agent.
+  AGENT_MENTION_LEGACY: dragon-ai-agent
+  # GitHub App bot identity, used for commit attribution. AGENT_USER_ID is the
+  # numeric id of ai4c-agent[bot] (`gh api /users/ai4c-agent%5Bbot%5D`); without
+  # it, commits are not linked back to the app.
+  AGENT_LOGIN: ai4c-agent[bot]
+  AGENT_USER_ID: 242316268
   MODEL: claude-opus-4-7
   TOOLS_DIR: ${{ github.workspace }}/tools
   ARTIFACT_RETENTION_DAYS: 90
@@ -57,12 +72,20 @@ jobs:
       result: ${{ steps.check.outputs.result }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4        
+        uses: actions/checkout@v4
+      # Minted per-job: installation tokens are short-lived (1h) and must not be
+      # passed between jobs, since GitHub's log masking does not follow job outputs.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
       - name: Check for qualifying mention
         id: check
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_FOR_PR }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
 
@@ -76,7 +99,13 @@ jobs:
               allowedUsers = ['cmungall']; // Fallback
             }
 
-            const agentName = process.env.AGENT_NAME || 'dragon-ai-agent';
+            // Trigger on the canonical handle plus any legacy aliases, with an
+            // optional [bot] suffix (people paste back what they see the bot signing as).
+            const agentName = process.env.AGENT_MENTION;
+            const legacyNames = (process.env.AGENT_MENTION_LEGACY || '')
+              .split(',').map(s => s.trim()).filter(Boolean);
+            const escapeRe = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const mentionAlternation = [agentName, ...legacyNames].map(escapeRe).join('|');
 
             // Handle workflow_dispatch (manual trigger)
             if (context.eventName === 'workflow_dispatch') {
@@ -145,15 +174,24 @@ jobs:
               commentId = context.payload.comment.id;
             }
 
+            // Never act on our own output. Unlike GITHUB_TOKEN, events authored
+            // with an app installation token do retrigger workflows.
+            if (userLogin.endsWith('[bot]')) {
+              console.log(`Ignoring bot author: ${userLogin}`);
+              return { qualifiedMention: false };
+            }
+
             // Check authorization and extract prompt
             const isAllowed = allowedUsers.includes(userLogin);
-            const mentionRegex = new RegExp(`@${agentName}\\s+please\\s+(.*)`, 'is');
+            const mentionRegex = new RegExp(`@(${mentionAlternation})(?:\\[bot\\])?\\s+please\\s+(.*)`, 'is');
             const mentionMatch = content.match(mentionRegex);
 
             const qualifiedMention = isAllowed && mentionMatch !== null;
-            const prompt = qualifiedMention ? mentionMatch[1].trim() : '';
+            const prompt = qualifiedMention ? mentionMatch[2].trim() : '';
+            const mentionUsed = mentionMatch ? mentionMatch[1] : '';
+            const usedLegacyMention = qualifiedMention && mentionUsed.toLowerCase() !== agentName.toLowerCase();
 
-            console.log(`User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}`);
+            console.log(`User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}, Handle: ${mentionUsed}`);
 
             if (!qualifiedMention) {
               return { qualifiedMention: false };
@@ -184,7 +222,10 @@ jobs:
             // Post "working on it" comment immediately
             try {
               const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-              const commentBody = `🤖 Working on it...\n\nFollow along: [View workflow run](${runUrl})\n\n*— @${agentName}*`;
+              const deprecationNote = usedLegacyMention
+                ? `\n\n> [!NOTE]\n> \`@${mentionUsed}\` is deprecated and will stop working. Please use \`@${agentName} please ...\` from now on.`
+                : '';
+              const commentBody = `🤖 Working on it...\n\nFollow along: [View workflow run](${runUrl})${deprecationNote}\n\n*— @${agentName}*`;
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -235,16 +276,26 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ fromJSON(needs.check-mention.outputs.result).useOdkContainer && 'obolibrary/odkfull:latest' || null }}
     steps:
+      # Must precede checkout: the token is persisted as the git credential and
+      # is what later `git push` calls authenticate with. Valid for 1h, which
+      # bounds how far timeout-minutes above can safely be raised.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.PAT_FOR_PR }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
-          git config --global user.name "${{ env.AGENT_NAME }}[bot]"
-          git config --global user.email "${{ env.AGENT_NAME }}[bot]@users.noreply.github.com"
+          git config --global user.name "${{ env.AGENT_LOGIN }}"
+          git config --global user.email "${{ env.AGENT_USER_ID }}+${{ env.AGENT_LOGIN }}@users.noreply.github.com"
 
       - name: Create tools directory
         run: mkdir -p ${{ env.TOOLS_DIR }}
@@ -263,7 +314,7 @@ jobs:
 
       - name: Set up GitHub token for gh CLI
         env:
-          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "GH_TOKEN=$GH_TOKEN" >> $GITHUB_ENV
 
@@ -276,7 +327,7 @@ jobs:
         uses: anthropics/claude-code-base-action@main
         with:
           prompt: |
-            You are @${{ env.AGENT_NAME }}, responding to a request from @${{ fromJSON(needs.check-mention.outputs.result).user }} on GitHub ${{ fromJSON(needs.check-mention.outputs.result).itemType }} #${{ fromJSON(needs.check-mention.outputs.result).itemNumber }}.
+            You are @${{ env.AGENT_MENTION }}, responding to a request from @${{ fromJSON(needs.check-mention.outputs.result).user }} on GitHub ${{ fromJSON(needs.check-mention.outputs.result).itemType }} #${{ fromJSON(needs.check-mention.outputs.result).itemNumber }}.
 
             ${{ fromJSON(needs.check-mention.outputs.result).skipOdkNote }}
 
@@ -311,7 +362,7 @@ jobs:
             Always include the following signature block in (1) git commit message and (2) comments on the GitHub issue (3) comments on the GitHub PR
             ```
             ---
-            🤖 **Generated by @${{ env.AGENT_NAME }}**
+            🤖 **Generated by @${{ env.AGENT_MENTION }}**
             - Model: `${{ env.MODEL }}`
             - Agent harness: claude-code
             - Triggered by: @${{ fromJSON(needs.check-mention.outputs.result).user }}
@@ -329,5 +380,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: claude-response-${{ github.run_id }}
-          path: /home/runner/work/_temp/claude-execution-output.json
+          # runner.temp, not the host path: inside the ODK container this is /__w/_temp
+          path: ${{ runner.temp }}/claude-execution-output.json
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,7 @@ These should ALWAYS be added for NEW terms, but NEVER added to existing terms.
 Whenever you are creating an entirely new term, ensure that the following are generated:
 
    ```
-   created_by: dragon-ai-agent
+   created_by: ai4c-agent
    creation_date: <YYYY-MM-DD>T<HH:MM:DD>Z
    ```
 


### PR DESCRIPTION
Migrates `.github/workflows/ai-agent.yml` off the `dragon-ai-agent` machine account and onto the `ai4c-agent` GitHub App.

## Auth

`secrets.PAT_FOR_PR` is replaced in all four places by a short-lived installation token from `actions/create-github-app-token@v2`.

The token is minted **per job** rather than minted once and passed as a job output — GitHub's secret log masking does not follow outputs across job boundaries, so the downstream job would print it in plaintext. In `respond-to-mention` the mint step precedes `actions/checkout`, since checkout persists the token as the git credential that later `git push` calls authenticate with.

Installation tokens expire after 1 hour. `timeout-minutes` is 30, so there is headroom, but it can't safely be raised much past ~55 without pushes failing mid-run on a 401.

## Identity

`AGENT_NAME` was doing four jobs at once: mention handle, git author, branch prefix, and signature. The app breaks that conflation — its login is `ai4c-agent[bot]`, and apps cannot be @-mentioned at all, so `@ai4c-agent` renders as inert plain text (there is no user account by that name; `gh api /users/ai4c-agent` 404s). The trigger string and the account name are now genuinely different things and are stored separately:

| Var | Value | Used for |
|---|---|---|
| `AGENT_MENTION` | `ai4c-agent` | trigger regex, branch prefix, signature |
| `AGENT_MENTION_LEGACY` | `dragon-ai-agent` | comma-separated deprecated aliases |
| `AGENT_LOGIN` | `ai4c-agent[bot]` | git commit author |
| `AGENT_USER_ID` | `242316268` | git commit email |

The numeric id matters: `<id>+<login>@users.noreply.github.com` is what makes GitHub attribute commits to the app rather than showing an unlinked stranger.

## Trigger handling

Both `@ai4c-agent please` and `@dragon-ai-agent please` fire during the transition, with an optional `[bot]` suffix tolerated (people paste back what they see the bot signing as). Runs invoked through the legacy handle get a deprecation note in the acknowledgement comment, so the migration nudges itself rather than needing to be policed. Retiring the old handle later is a one-line env deletion.

Also added an explicit early return for `[bot]` comment authors. Unlike `GITHUB_TOKEN`, events authored with an app installation token *do* retrigger workflows, so the loop guard shouldn't rest on `ai-controllers.json` happening not to list the bot.

## Drive-by fix

The output artifact path hardcoded `/home/runner/work/_temp/`, the host path. Inside the ODK container the temp dir is `/__w/_temp`, so that upload has been silently capturing nothing on every container run. Now uses `${{ runner.temp }}`.

## Docs

`created_by` for new terms becomes `ai4c-agent`, plus two prose mentions in skill files. The 87 existing `dragon-ai-agent` stamps in `go-edit.obo` are deliberately untouched — historical provenance, not config.

## Before merging — setup required

- [ ] Install `ai4c-agent` on `geneontology/go-ontology` with Contents / Issues / Pull requests **write**, Metadata read, Workflows **write**
- [ ] Add secret `AI4C_AGENT_APP_ID` — the *app* id, `2242960`. Distinct from `AGENT_USER_ID` (`242316268`), which is the `ai4c-agent[bot]` account id used only for the commit email.
- [ ] Add secret `AI4C_AGENT_PRIVATE_KEY` (full PEM, including the `-----BEGIN`/`-----END` lines)
- [ ] Delete `PAT_FOR_PR` only after a live run is confirmed working

Without Workflows: write, any push whose diff touches `.github/workflows/**` is rejected outright by GitHub, which surfaces as a confusing generic failure.

## Verification

- YAML parses; job and env structure confirmed
- Mention regex hand-tested against seven inputs: both handles match, `[bot]` suffix matches, multiline prompts survive, non-matching handles rejected, and the bot's own `**Generated by @ai4c-agent**` signature does **not** match (no self-trigger)
- `actionlint` was **not** run — not installed locally. No full Actions-schema check has been done, and the first live `@ai4c-agent please ...` invocation is the real test.

## Out of scope

`PR_ACTION_TOKEN` is used by ten other workflows (`design-patterns.yml`, `refresh-*.yml`, `update_*.yml`, `new_pr.yml`) and is untouched here. If that PAT also belongs to the dragon machine account, those will break when the account is deactivated and need their own migration.

`MODEL: claude-opus-4-7` is stale but left alone as unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)