### PR TITLE
Add ai4c-reviewer PR review workflow

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -116,8 +116,9 @@ switched off.
 
 ## Report coverage, not just findings
 
-Open the review with what you actually verified, so a reader can distinguish
-coverage from silence:
+Open the report with what you actually verified, so a reader can distinguish
+coverage from silence. Write it once, wherever the caller says the report
+goes:
 
 - Scope of review (full or sampled, and why)
 - References checked: N verified, M unverifiable

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: pr-review
+description: For reviewing a pull request against the GO ontology, whether from a local checkout or from the automated reviewer in CI. Covers what to check, how to grade severity, and how to report coverage honestly. Use whenever asked to review, critique, or check a PR or a diff to go-edit.obo.
+---
+
+## What this skill is for
+
+Reviewing a change to the ontology for the things that automated validation
+cannot catch. It says nothing about *how* to deliver the review — posting a
+GitHub review, writing a comment, or answering in chat are all callers'
+concerns.
+
+CLAUDE.md is the authoritative statement of this project's editing
+conventions, and most of what you are checking is specified there. Read it
+first. Consult `design-pattern`, `term-obsoletion`, `chemical-entity`,
+`reaction`, and `taxon-constraint` when the diff touches those areas.
+
+## Do not re-derive what CI already covers
+
+`master` requires the `ontology_qc` status check, which runs the full ODK
+build: OBO syntax, ELK reasoning, unsatisfiable classes, and the SPARQL QC
+suite. If the diff has a passing build, those properties hold. Reporting them
+as findings is noise, and reporting them as *verified by you* is a false claim.
+
+Review what CI structurally cannot see.
+
+## Size the change before reviewing it
+
+Measure the diff first. On anything very large (>2000 changed lines) or
+obviously mechanical, do not attempt a stanza-by-stanza pass. Say plainly that
+you sampled, spot-check a representative selection, and scope the verdict to
+what you actually examined.
+
+Never imply coverage you did not achieve. A review that reads as thorough but
+silently skipped most of the diff is worse than no review, because it converts
+an unexamined change into an apparently examined one.
+
+## What to check
+
+**1. References.** Every PMID or DOI introduced must be real, correctly
+transcribed, and actually about the subject it is cited for. Verify them
+against PubMed rather than trusting that a plausible-looking id exists — a
+transposed digit yields a real paper about something else, which is the
+failure mode that survives casual reading. Check ORCIDs and GOC ids are not
+invented. Fabricated references are always CRITICAL.
+
+**2. Logical axioms.** This is where the most damaging errors hide, because
+they are invisible in the term's rendered form and only surface later as
+misclassification.
+
+- `intersection_of` asserts necessary AND sufficient conditions. Flag
+  over-specification: axioms where the intersection admits things that are
+  not instances of the term. CLAUDE.md's keratinization example is the
+  canonical anti-pattern — a multicellular organismal process occurring in an
+  epidermal cell is not thereby a keratinization.
+- Label, text definition, and logical definition must all describe the same
+  thing. If the label does not read as a name for the logical definition,
+  that is the tell.
+- `is_a` should not be over-asserted. The reasoner infers the most specific
+  parent, so redundant or multiple asserted `is_a` is usually wrong.
+- Check that `part_of` / `regulates` / `occurs_in` are used where a
+  relationship suffices and an equivalence axiom would overreach. Reaching
+  for `intersection_of` to express a link to an external ontology term is a
+  common and specific mistake.
+
+**3. Design patterns.** For compositional terms, confirm name, definition, and
+logical definition conform to the documented pattern. Prior art is strong
+evidence: find sibling terms with `obo-grep.pl` and compare. A new term that
+looks unlike its siblings is either wrong or is revealing that the siblings
+are wrong — either way it is worth raising.
+
+**4. Metadata conventions.**
+
+- `namespace` present, and one of `biological_process`, `molecular_function`,
+  `cellular_component`.
+- Definition present, with at least one xref.
+- `created_by` / `creation_date` on NEW terms only. Adding or modifying
+  either on a pre-existing term is an error, and a common one.
+- `term_tracker_item` exactly as:
+  `property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/N" xsd:anyURI`
+- Synonym scopes correct; no synonym duplicating the label.
+
+**5. Obsoletions.** Verify the full procedure: no remaining references to the
+obsoleted term from other terms, `replaced_by` / `consider` populated
+appropriately, axioms stripped back, and the impact on existing annotations
+considered.
+
+**6. Chemicals.** CHEBI terms should use ph7.3 forms where applicable.
+
+**7. Scope discipline.** Changes should match the linked issue and form a
+coherent unit. Flag unrelated drive-by edits. Flag especially any stanza that
+looks accidentally clobbered — the checkout/checkin workflow can damage
+neighbouring terms silently, and the resulting diff looks like an intentional
+edit.
+
+## Severity
+
+- **CRITICAL** — wrong or fabricated data. Hallucinated PMIDs, incorrect
+  biology, axioms that would misclassify terms, damaged stanzas.
+- **IMPORTANT** — convention violations with real consequences. Design pattern
+  nonconformance, over-specified equivalence axioms, metadata on the wrong
+  terms, incomplete obsoletion.
+- **SUGGESTION** — genuinely optional improvements.
+
+## Tone
+
+Most PR authors here are expert GO curators with decades of domain knowledge.
+Be specific and technical: cite the term id and the convention being violated.
+Skip anything you cannot substantiate. No praise padding, no restating the
+diff back at them, no style nitpicks.
+
+If you are unsure whether something is wrong, ask rather than assert. Three
+real findings are worth more than twenty speculative ones — and on a shared
+repository, a reviewer with a high false-positive rate gets ignored, then
+switched off.
+
+## Report coverage, not just findings
+
+Open the review with what you actually verified, so a reader can distinguish
+coverage from silence:
+
+- Scope of review (full or sampled, and why)
+- References checked: N verified, M unverifiable
+- Logical axioms reviewed
+- Design pattern conformance checked against: *sibling terms consulted*
+- Metadata conventions checked
+- Obsoletion procedure checked, or N/A
+
+Silence on a dimension you did not examine reads as a clean bill of health.
+Say which ones you skipped.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -13,7 +13,8 @@ concerns.
 CLAUDE.md is the authoritative statement of this project's editing
 conventions, and most of what you are checking is specified there. Read it
 first. Consult `design-pattern`, `term-obsoletion`, `chemical-entity`,
-`reaction`, and `taxon-constraint` when the diff touches those areas.
+`reaction`, `taxon-constraint`, and `mapping` when the diff touches those
+areas.
 
 ## Do not re-derive what CI already covers
 
@@ -79,6 +80,10 @@ are wrong — either way it is worth raising.
 - `term_tracker_item` exactly as:
   `property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/N" xsd:anyURI`
 - Synonym scopes correct; no synonym duplicating the label.
+- New ids minted by an agent are in the `GO:777xxxx` range, and no new id
+  collides with an existing `id:` or `alt_id:` anywhere in go-edit.obo.
+  Review is the natural place to catch this: a collision is invisible in the
+  diff and only surfaces later as two terms sharing an identifier.
 
 **5. Obsoletions.** Verify the full procedure: no remaining references to the
 obsoleted term from other terms, `replaced_by` / `consider` populated

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,10 +9,15 @@
 # Fork PRs cannot be reviewed automatically (no access to secrets); use the
 # workflow_dispatch trigger, or comment /review, for those.
 #
+# The review substance lives in the `pr-review` skill
+# (.claude/skills/pr-review/SKILL.md), not in the prompt below, so the same
+# criteria apply when a human reviews a PR locally. The prompt here carries
+# only what is specific to running in CI: what is installed on the runner, and
+# how to submit the verdict.
+#
 # This does NOT re-run ontology validation. The `ontology_qc` required status
-# check already runs the full ODK build, so this job stays on bare
-# ubuntu-latest and reviews what CI cannot see: reference validity, design
-# pattern conformance, axiom appropriateness, and metadata conventions.
+# check already runs the full ODK build, so the job stays on bare
+# ubuntu-latest.
 #
 # Required secrets: CLAUDE_CODE_OAUTH_TOKEN, AI4C_REVIEWER_APP_ID,
 #                   AI4C_REVIEWER_PRIVATE_KEY
@@ -116,95 +121,26 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ env.PR_NUMBER }}
 
-            You are reviewing a pull request against the Gene Ontology. Read
-            CLAUDE.md in the repo root first -- it is the authoritative statement
-            of this project's editing conventions, and most of what you are
-            checking is specified there. Consult the relevant skills in
-            .claude/skills/ (design-pattern, term-obsoletion, chemical-entity,
-            reaction, taxon-constraint) when the diff touches those areas.
+            Review this pull request using the `pr-review` skill in
+            .claude/skills/pr-review/. It defines what to check, how to grade
+            severity, and how to report coverage. Follow it.
 
-            SCOPE -- what NOT to spend effort on:
-            The `ontology_qc` required check already runs the full ODK build:
-            OBO syntax, ELK reasoning, unsatisfiable classes, and the SPARQL QC
-            suite. Do not re-derive any of that, and do not run ROBOT (it is not
-            installed here). Review what CI cannot see.
-
-            Start by sizing the change: `gh pr diff ${{ env.PR_NUMBER }} --patch | wc -l`.
-            If the diff is very large (>2000 lines) or is an obviously mechanical
-            bulk update, do not attempt a stanza-by-stanza review. Say so plainly,
-            spot-check a representative sample, and scope your verdict to what you
-            actually examined. Never imply coverage you did not achieve.
-
-            WHAT TO CHECK:
-
-            1. References. Every PMID/DOI introduced must be real, correctly
-               transcribed, and actually about the subject it is cited for. Verify
-               them (WebFetch against PubMed or `gh api`); do not trust that a
-               plausible-looking PMID exists. A fabricated or mis-transcribed
-               reference is always CRITICAL. Check ORCIDs and GOC ids are not
-               invented.
-
-            2. Logical axioms. This is where the most damaging errors hide.
-               - `intersection_of` asserts necessary AND sufficient conditions.
-                 Flag over-specification: axioms where the intersection admits
-                 things that are not instances of the term. CLAUDE.md's
-                 keratinization example is the canonical anti-pattern.
-               - Label, text definition, and logical definition must all describe
-                 the same thing. If the label does not read as a name for the
-                 logical definition, that is a red flag.
-               - `is_a` should not be over-asserted: the reasoner infers the most
-                 specific parent, so redundant or multiple asserted `is_a` is
-                 usually wrong.
-               - Check `part_of` / `regulates` / `occurs_in` are used where a
-                 relationship suffices and an equivalence axiom would overreach.
-
-            3. Design patterns. For compositional terms, confirm name, definition,
-               and logical definition conform to the documented pattern. Compare
-               against sibling terms found with `obo-grep.pl` -- prior art in the
-               ontology is strong evidence for what the pattern should be.
-
-            4. Metadata conventions.
-               - `namespace` present, and one of biological_process,
-                 molecular_function, cellular_component.
-               - Definition present with at least one xref.
-               - `created_by` / `creation_date` on NEW terms only. Adding or
-                 modifying either on a pre-existing term is an error.
-               - `term_tracker_item` exactly as:
-                 `property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/N" xsd:anyURI`
-               - Synonym scopes correct; no synonym duplicating the label.
-
-            5. Obsoletions. Verify the full procedure: no remaining references to
-               the obsoleted term from other terms, `replaced_by` / `consider`
-               populated appropriately, axioms stripped down, and the impact on
-               existing annotations considered.
-
-            6. Chemicals. CHEBI terms should use ph7.3 forms where applicable.
-
-            7. Scope discipline. Changes should match the linked issue and form a
-               coherent unit. Flag unrelated drive-by edits, and especially flag
-               any stanza that looks accidentally clobbered -- the checkout/checkin
-               workflow can silently damage neighbouring terms.
-
-            TONE:
-            Most PR authors here are expert GO curators with decades of domain
-            knowledge. Be specific and technical, cite the term id and the
-            convention being violated, and skip anything you cannot substantiate.
-            No praise padding, no restating the diff back at them, no style
-            nitpicks. If you are unsure whether something is wrong, say so as a
-            question rather than asserting a defect. A short review with three
-            real findings is far more valuable than a long one with twenty
-            speculative ones.
-
-            SEVERITY:
-            - CRITICAL: wrong or fabricated data -- hallucinated PMIDs, incorrect
-              biology, axioms that would misclassify terms, damaged stanzas.
-            - IMPORTANT: convention violations with real consequences -- design
-              pattern nonconformance, over-specified equivalence axioms, metadata
-              on the wrong terms, incomplete obsoletion.
-            - SUGGESTION: improvements that are genuinely optional.
+            THIS ENVIRONMENT:
+            - ROBOT, owltools and the ODK toolchain are NOT installed on this
+              runner, and the `ontology_qc` required check already covers
+              everything they would tell you. Do not attempt to run them.
+            - `obo-grep.pl` IS available, for stanza-aware search of
+              src/ontology/go-edit.obo when checking prior art.
+            - Get the diff with `gh pr diff ${{ env.PR_NUMBER }}`, and size it
+              first with `gh pr diff ${{ env.PR_NUMBER }} --patch | wc -l`.
+            - Read the linked issue (`gh issue view`) to judge scope discipline.
+            - You have web access; use it to verify PMIDs against PubMed rather
+              than assuming a plausible-looking id is real.
 
             VERDICT:
-            After reviewing, submit a GitHub review.
+            After reviewing, submit a GitHub review. Use inline comments for
+            findings anchored to specific lines, and the review body for the
+            summary.
 
             If there are any CRITICAL or IMPORTANT findings:
             ```
@@ -216,14 +152,8 @@ jobs:
             gh pr review ${{ env.PR_NUMBER }} --approve --body "<summary>"
             ```
 
-            Open your review body with what you actually verified, so a reader can
-            tell coverage from silence:
-            - Scope of review (full / sampled, and why)
-            - References checked: N verified, M unverifiable
-            - Logical axioms reviewed
-            - Design pattern conformance checked against: <sibling terms consulted>
-            - Metadata conventions checked
-            - Obsoletion procedure checked / N/A
+            The review body must open with the coverage report the skill
+            specifies -- a reader has to be able to tell coverage from silence.
 
       # claude-code-action exits 0 even when the agent run itself errored,
       # producing no posted review and a green check -- a phantom pass. Two

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,6 +125,17 @@ jobs:
             .claude/skills/pr-review/. It defines what to check, how to grade
             severity, and how to report coverage. Follow it.
 
+            LOADING THE SKILL:
+            This action restores `.claude/` and CLAUDE.md from the BASE branch
+            before you start, so a PR that edits the skill is reviewed under the
+            old copy, and a newly added skill file is absent entirely. If
+            `pr-review` is not in your skill list, read it directly:
+            `git show HEAD:.claude/skills/pr-review/SKILL.md`, or from
+            `.claude-pr/.claude/skills/pr-review/SKILL.md` if that snapshot
+            exists. If you cannot obtain the criteria by any route, say so
+            prominently and stop -- do not review against no criteria and emit
+            something shaped like a review anyway.
+
             THIS ENVIRONMENT:
             - ROBOT, owltools and the ODK toolchain are NOT installed on this
               runner, and the `ontology_qc` required check already covers
@@ -137,23 +148,28 @@ jobs:
             - You have web access; use it to verify PMIDs against PubMed rather
               than assuming a plausible-looking id is real.
 
-            VERDICT:
-            After reviewing, submit a GitHub review. Use inline comments for
-            findings anchored to specific lines, and the review body for the
-            summary.
+            WRITE THE REPORT EXACTLY ONCE:
+            Your final response is posted as the PR tracking comment. That is
+            the single home for the full review -- the coverage report the skill
+            specifies, every finding, and all supporting detail. Anchor findings
+            to specific lines with inline comments.
 
+            The `gh pr review` body is NOT a second copy. It is a stub of at
+            most three lines: the verdict, finding counts by severity, and a
+            link to the tracking comment. Curators see both, so restating the
+            report there doubles what they have to read, and the two copies
+            drift as you condense.
+
+            VERDICT:
             If there are any CRITICAL or IMPORTANT findings:
             ```
-            gh pr review ${{ env.PR_NUMBER }} --request-changes --body "<summary>"
+            gh pr review ${{ env.PR_NUMBER }} --request-changes --body "<stub>"
             ```
 
             If there are only SUGGESTIONs, or nothing to report:
             ```
-            gh pr review ${{ env.PR_NUMBER }} --approve --body "<summary>"
+            gh pr review ${{ env.PR_NUMBER }} --approve --body "<stub>"
             ```
-
-            The review body must open with the coverage report the skill
-            specifies -- a reader has to be able to tell coverage from silence.
 
       # claude-code-action exits 0 even when the agent run itself errored,
       # producing no posted review and a green check -- a phantom pass. Two

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       # Auto-generated diff reports; reviewing them is pure cost.
       - 'docs/status/**'
@@ -62,7 +62,7 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
-          github.event.comment.body == '/review' &&
+          startsWith(github.event.comment.body, '/review') &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       }}
@@ -72,7 +72,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
@@ -90,11 +89,19 @@ jobs:
         run: gh pr checkout ${{ env.PR_NUMBER }}
 
       # Needed so the reviewer can check prior art in go-edit.obo stanza-wise
-      # rather than with plain grep. Cheap: a shallow clone, no Docker.
+      # rather than with plain grep. Cheap: a small clone, no Docker.
+      # Cloned into RUNNER_TEMP, not the workspace: an untracked tools/ dir
+      # inside the checkout shows up as a stray file, which the review criteria
+      # now instruct the agent to flag -- the workflow was generating its own
+      # false positive. Pinned, since it executes inside a job holding tokens.
       - name: Add obo-scripts to PATH
+        env:
+          OBO_SCRIPTS_SHA: cb38971ce39654bc9e4e96efcd22e950c3561f5d
         run: |
-          git clone --depth 1 https://github.com/cmungall/obo-scripts.git "${{ github.workspace }}/tools/obo-scripts"
-          echo "${{ github.workspace }}/tools/obo-scripts" >> $GITHUB_PATH
+          set -euo pipefail
+          git clone --quiet https://github.com/cmungall/obo-scripts.git "$RUNNER_TEMP/obo-scripts"
+          git -C "$RUNNER_TEMP/obo-scripts" checkout --quiet "$OBO_SCRIPTS_SHA"
+          echo "$RUNNER_TEMP/obo-scripts" >> $GITHUB_PATH
 
       - name: Mint reviewer app token
         id: reviewer-token
@@ -108,6 +115,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Fallback when the OAuth token hits its quota. Without this, an
+          # exhausted token red-Xes every open PR at once; the secret already
+          # exists in this repo and ai-agent.yml passes both.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.reviewer-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
           # ai4c-agent must be listed, or PRs opened by the editing agent --
@@ -115,7 +126,7 @@ jobs:
           allowed_bots: 'claude,github-actions,ai4c-agent'
           claude_args: |
             --model ${{ env.REVIEW_MODEL }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api repos/:*),Bash(gh api /repos/:*),Bash(gh api users/:*),Bash(gh api /users/:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
 
           prompt: |
             REPO: ${{ github.repository }}
@@ -176,8 +187,11 @@ jobs:
       # failure modes seen in practice: a Claude usage limit on the OAuth token
       # (silently no-ops every agent workflow account-wide), and an invalid or
       # retired --model id. Inspect the execution log and fail loudly instead.
+      # Not `always()`: concurrency cancels superseded runs mid-flight, and an
+      # unconditional check turns every one of those into a spurious
+      # "review failed" error.
       - name: Verify the review agent actually ran
-        if: always()
+        if: '!cancelled()'
         env:
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
         run: |
@@ -222,11 +236,17 @@ jobs:
               print(f"Claude review completed cleanly: {stats}")
               sys.exit(0)
 
-          reason = str(r.get("error") or "").strip()
+          # The result event carries no top-level "error" key -- the error kind
+          # is in "subtype" (e.g. error_max_turns, error_during_execution). The
+          # original version keyed the usage-limit branch off r["error"] alone,
+          # so it could never fire. Read both, and include subtype in the text
+          # searched for limit wording.
+          subtype = str(r.get("subtype") or "").strip()
+          reason = str(r.get("error") or "").strip() or subtype
           detail = str(r.get("result") or "").strip()
-          haystack = f"{reason} {detail}".lower()
+          haystack = f"{reason} {subtype} {detail}".lower()
 
-          if reason == "rate_limit" or "usage limit" in haystack or "weekly limit" in haystack:
+          if "rate_limit" in haystack or "usage limit" in haystack or "weekly limit" in haystack:
               msg = (f"Claude USAGE LIMIT reached -- NO review ran ({detail!r}). This is an "
                      "account-quota issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this "
                      "PR. Fix: wait for the limit to reset, rotate the token to an account with "

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,7 +63,9 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
           (github.event.comment.body == '/review' ||
-           startsWith(github.event.comment.body, '/review ')) &&
+           startsWith(github.event.comment.body, '/review ') ||
+           startsWith(github.event.comment.body, fromJSON('"/review\n"')) ||
+           startsWith(github.event.comment.body, fromJSON('"/review\r\n"'))) &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       }}
@@ -160,7 +162,11 @@ jobs:
             - `obo-grep.pl` IS available, for stanza-aware search of
               src/ontology/go-edit.obo when checking prior art.
             - Get the diff with `gh pr diff ${{ env.PR_NUMBER }}`, and size it
-              first with `gh pr diff ${{ env.PR_NUMBER }} --patch | wc -l`.
+              first with `gh pr diff ${{ env.PR_NUMBER }} --patch | wc -l`. The
+              checkout is shallow, so there is no merge base: `git diff
+              origin/master...HEAD` will fail. Use `gh pr diff`. `git show
+              HEAD:<path>` does work, which is how to read a file the
+              `.claude/` restore removed.
             - Read the linked issue (`gh issue view`) to judge scope discipline.
             - You have web access; use it to verify PMIDs against PubMed rather
               than assuming a plausible-looking id is real.
@@ -170,10 +176,6 @@ jobs:
             the single home for the full review -- the coverage report the skill
             specifies, every finding, and all supporting detail. Anchor findings
             to specific lines with inline comments.
-
-            End the report with this line verbatim, so the comment is
-            identifiable as yours and as belonging to this run:
-            `<!-- ai4c-reviewer run ${{ github.run_id }} -->`
 
             If no tracking comment exists (this happens on workflow_dispatch,
             which runs in agent mode), post the report yourself instead:
@@ -193,20 +195,26 @@ jobs:
             After your new report is posted, minimize your previous ones as
             outdated. List your own comments:
 
-            gh api repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments --jq '.[] | select(.user.login == "ai4c-reviewer[bot]") | "\(.id) \(.node_id) \(.created_at)"'
+            gh api --paginate repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments --jq '.[] | select(.user.login == "ai4c-reviewer[bot]") | "\(.id) \(.node_id) \(.created_at)"'
 
-            Your current report is the one whose body contains
-            `run ${{ github.run_id }}`. Minimize every OTHER comment in that
-            list -- note the GraphQL argument separator below is a SPACE, not a
-            comma: a comma inside braces reads as bash brace expansion and the
-            command is refused before it runs.
+            Identify your current tracking comment by its id if you were given
+            one. Otherwise select it by the run link the action itself puts in
+            every tracking comment body -- do NOT rely on any marker you add,
+            since comment bodies are sanitized and HTML comments are stripped:
+
+            gh api --paginate repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments --jq '.[] | select(.body | contains("actions/runs/${{ github.run_id }}")) | .node_id'
+
+            Minimize every OTHER comment of yours in the list. Note the GraphQL
+            argument separator below is a SPACE, not a comma: a comma inside
+            braces reads as bash brace expansion and the command is refused
+            before it runs.
 
             gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id classifier:OUTDATED}){clientMutationId}}' -F id=<node_id>
 
-            Minimize ONLY comments authored by you, and never the one carrying
-            this run's marker. A human's comment is never yours to hide. If you
-            cannot identify which comment is your current report, minimize
-            nothing and say so in the report.
+            Minimize ONLY comments authored by you, and never this run's own.
+            A human's comment is never yours to hide. If you cannot identify
+            which comment is your current report, minimize nothing and say so
+            in the report.
 
             VERDICT:
             If there are any CRITICAL or IMPORTANT findings:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,299 @@
+# AI review of pull requests, by the `ai4c-reviewer` GitHub App.
+#
+# Runs automatically on every same-repo PR except those authored by `ontobot`
+# (the automated refresh/update workflows produce large mechanical diffs that
+# are not worth reviewing). PRs authored by `ai4c-agent[bot]` ARE reviewed --
+# self-review of agent work is the highest-value case, since it catches
+# hallucinated PMIDs and bogus axioms before a curator spends time on them.
+#
+# Fork PRs cannot be reviewed automatically (no access to secrets); use the
+# workflow_dispatch trigger, or comment /review, for those.
+#
+# This does NOT re-run ontology validation. The `ontology_qc` required status
+# check already runs the full ODK build, so this job stays on bare
+# ubuntu-latest and reviews what CI cannot see: reference validity, design
+# pattern conformance, axiom appropriateness, and metadata conventions.
+#
+# Required secrets: CLAUDE_CODE_OAUTH_TOKEN, AI4C_REVIEWER_APP_ID,
+#                   AI4C_REVIEWER_PRIVATE_KEY
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths-ignore:
+      # Auto-generated diff reports; reviewing them is pure cost.
+      - 'docs/status/**'
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review (use for fork PRs, where secrets are unavailable on the pull_request event)'
+        required: true
+        type: number
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  # NOTE: deliberately newer than the `claude-opus-4-7` pinned in ai-agent.yml.
+  # If this id is wrong the "Verify the review agent actually ran" step below
+  # fails loudly rather than silently posting nothing.
+  REVIEW_MODEL: claude-opus-5
+
+jobs:
+  claude-review:
+    if: >-
+      ${{
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.draft == false &&
+          github.event.pull_request.user.login != 'ontobot'
+        ) ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          github.event.comment.body == '/review' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout PR branch (manual and /review triggers)
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ env.PR_NUMBER }}
+
+      # Needed so the reviewer can check prior art in go-edit.obo stanza-wise
+      # rather than with plain grep. Cheap: a shallow clone, no Docker.
+      - name: Add obo-scripts to PATH
+        run: |
+          git clone --depth 1 https://github.com/cmungall/obo-scripts.git "${{ github.workspace }}/tools/obo-scripts"
+          echo "${{ github.workspace }}/tools/obo-scripts" >> $GITHUB_PATH
+
+      - name: Mint reviewer app token
+        id: reviewer-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.reviewer-token.outputs.token }}
+          track_progress: ${{ github.event_name == 'pull_request' }}
+          # ai4c-agent must be listed, or PRs opened by the editing agent --
+          # the main reason this workflow exists -- would be ignored as bot noise.
+          allowed_bots: 'claude,github-actions,ai4c-agent'
+          claude_args: |
+            --model ${{ env.REVIEW_MODEL }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ env.PR_NUMBER }}
+
+            You are reviewing a pull request against the Gene Ontology. Read
+            CLAUDE.md in the repo root first -- it is the authoritative statement
+            of this project's editing conventions, and most of what you are
+            checking is specified there. Consult the relevant skills in
+            .claude/skills/ (design-pattern, term-obsoletion, chemical-entity,
+            reaction, taxon-constraint) when the diff touches those areas.
+
+            SCOPE -- what NOT to spend effort on:
+            The `ontology_qc` required check already runs the full ODK build:
+            OBO syntax, ELK reasoning, unsatisfiable classes, and the SPARQL QC
+            suite. Do not re-derive any of that, and do not run ROBOT (it is not
+            installed here). Review what CI cannot see.
+
+            Start by sizing the change: `gh pr diff ${{ env.PR_NUMBER }} --patch | wc -l`.
+            If the diff is very large (>2000 lines) or is an obviously mechanical
+            bulk update, do not attempt a stanza-by-stanza review. Say so plainly,
+            spot-check a representative sample, and scope your verdict to what you
+            actually examined. Never imply coverage you did not achieve.
+
+            WHAT TO CHECK:
+
+            1. References. Every PMID/DOI introduced must be real, correctly
+               transcribed, and actually about the subject it is cited for. Verify
+               them (WebFetch against PubMed or `gh api`); do not trust that a
+               plausible-looking PMID exists. A fabricated or mis-transcribed
+               reference is always CRITICAL. Check ORCIDs and GOC ids are not
+               invented.
+
+            2. Logical axioms. This is where the most damaging errors hide.
+               - `intersection_of` asserts necessary AND sufficient conditions.
+                 Flag over-specification: axioms where the intersection admits
+                 things that are not instances of the term. CLAUDE.md's
+                 keratinization example is the canonical anti-pattern.
+               - Label, text definition, and logical definition must all describe
+                 the same thing. If the label does not read as a name for the
+                 logical definition, that is a red flag.
+               - `is_a` should not be over-asserted: the reasoner infers the most
+                 specific parent, so redundant or multiple asserted `is_a` is
+                 usually wrong.
+               - Check `part_of` / `regulates` / `occurs_in` are used where a
+                 relationship suffices and an equivalence axiom would overreach.
+
+            3. Design patterns. For compositional terms, confirm name, definition,
+               and logical definition conform to the documented pattern. Compare
+               against sibling terms found with `obo-grep.pl` -- prior art in the
+               ontology is strong evidence for what the pattern should be.
+
+            4. Metadata conventions.
+               - `namespace` present, and one of biological_process,
+                 molecular_function, cellular_component.
+               - Definition present with at least one xref.
+               - `created_by` / `creation_date` on NEW terms only. Adding or
+                 modifying either on a pre-existing term is an error.
+               - `term_tracker_item` exactly as:
+                 `property_value: term_tracker_item "https://github.com/geneontology/go-ontology/issues/N" xsd:anyURI`
+               - Synonym scopes correct; no synonym duplicating the label.
+
+            5. Obsoletions. Verify the full procedure: no remaining references to
+               the obsoleted term from other terms, `replaced_by` / `consider`
+               populated appropriately, axioms stripped down, and the impact on
+               existing annotations considered.
+
+            6. Chemicals. CHEBI terms should use ph7.3 forms where applicable.
+
+            7. Scope discipline. Changes should match the linked issue and form a
+               coherent unit. Flag unrelated drive-by edits, and especially flag
+               any stanza that looks accidentally clobbered -- the checkout/checkin
+               workflow can silently damage neighbouring terms.
+
+            TONE:
+            Most PR authors here are expert GO curators with decades of domain
+            knowledge. Be specific and technical, cite the term id and the
+            convention being violated, and skip anything you cannot substantiate.
+            No praise padding, no restating the diff back at them, no style
+            nitpicks. If you are unsure whether something is wrong, say so as a
+            question rather than asserting a defect. A short review with three
+            real findings is far more valuable than a long one with twenty
+            speculative ones.
+
+            SEVERITY:
+            - CRITICAL: wrong or fabricated data -- hallucinated PMIDs, incorrect
+              biology, axioms that would misclassify terms, damaged stanzas.
+            - IMPORTANT: convention violations with real consequences -- design
+              pattern nonconformance, over-specified equivalence axioms, metadata
+              on the wrong terms, incomplete obsoletion.
+            - SUGGESTION: improvements that are genuinely optional.
+
+            VERDICT:
+            After reviewing, submit a GitHub review.
+
+            If there are any CRITICAL or IMPORTANT findings:
+            ```
+            gh pr review ${{ env.PR_NUMBER }} --request-changes --body "<summary>"
+            ```
+
+            If there are only SUGGESTIONs, or nothing to report:
+            ```
+            gh pr review ${{ env.PR_NUMBER }} --approve --body "<summary>"
+            ```
+
+            Open your review body with what you actually verified, so a reader can
+            tell coverage from silence:
+            - Scope of review (full / sampled, and why)
+            - References checked: N verified, M unverifiable
+            - Logical axioms reviewed
+            - Design pattern conformance checked against: <sibling terms consulted>
+            - Metadata conventions checked
+            - Obsoletion procedure checked / N/A
+
+      # claude-code-action exits 0 even when the agent run itself errored,
+      # producing no posted review and a green check -- a phantom pass. Two
+      # failure modes seen in practice: a Claude usage limit on the OAuth token
+      # (silently no-ops every agent workflow account-wide), and an invalid or
+      # retired --model id. Inspect the execution log and fail loudly instead.
+      - name: Verify the review agent actually ran
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          file="${EXECUTION_FILE:-}"
+          if [[ -z "$file" || ! -f "$file" ]]; then
+            file="${RUNNER_TEMP}/claude-execution-output.json"
+          fi
+          if [[ ! -f "$file" ]]; then
+            echo "::error title=Claude review failed::No execution log found; the review agent did not run."
+            exit 1
+          fi
+          python3 - "$file" <<'PY'
+          import json, os, sys
+
+          def summary(md):
+              path = os.environ.get("GITHUB_STEP_SUMMARY")
+              if path:
+                  with open(path, "a", encoding="utf-8") as fh:
+                      fh.write(md + "\n")
+
+          raw = open(sys.argv[1], encoding="utf-8").read().strip()
+          try:
+              events = json.loads(raw)
+              if not isinstance(events, list):
+                  events = [events]
+          except json.JSONDecodeError:
+              events = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+          results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
+          if not results:
+              print("::error title=Claude review failed::No result event in the execution "
+                    "log; the agent did not complete.")
+              summary("### Claude review failed\nNo result event -- the agent did not complete.")
+              sys.exit(1)
+
+          r = results[-1]
+          stats = (f"num_turns={r.get('num_turns')} cost=${r.get('total_cost_usd')} "
+                   f"subtype={r.get('subtype')}")
+
+          if not r.get("is_error"):
+              print(f"Claude review completed cleanly: {stats}")
+              sys.exit(0)
+
+          reason = str(r.get("error") or "").strip()
+          detail = str(r.get("result") or "").strip()
+          haystack = f"{reason} {detail}".lower()
+
+          if reason == "rate_limit" or "usage limit" in haystack or "weekly limit" in haystack:
+              msg = (f"Claude USAGE LIMIT reached -- NO review ran ({detail!r}). This is an "
+                     "account-quota issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this "
+                     "PR. Fix: wait for the limit to reset, rotate the token to an account with "
+                     "headroom, or set ANTHROPIC_API_KEY (pay-per-use) on the workflow. "
+                     "Re-run this check afterward.")
+              print(f"::error title=Claude review skipped: usage limit::{msg}")
+              summary("### Claude review skipped -- usage limit reached\n\n" + msg)
+              sys.exit(1)
+
+          msg = (f"Review agent errored (is_error=true); NO review was posted. "
+                 f"error={reason!r} detail={detail!r} {stats}. Common causes: an "
+                 "invalid/retired --model, a bad CLAUDE_CODE_OAUTH_TOKEN, or an aborted run.")
+          print(f"::error title=Claude review errored::{msg}")
+          summary("### Claude review errored\n\n" + msg)
+          sys.exit(1)
+          PY

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,7 +62,8 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
-          startsWith(github.event.comment.body, '/review') &&
+          (github.event.comment.body == '/review' ||
+           startsWith(github.event.comment.body, '/review ')) &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       }}
@@ -120,13 +121,18 @@ jobs:
           # exists in this repo and ai-agent.yml passes both.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.reviewer-token.outputs.token }}
-          track_progress: ${{ github.event_name == 'pull_request' }}
+          # Not just pull_request: workflow_dispatch is the documented route for
+          # fork PRs, and with no tracking comment there the full report has
+          # nowhere to go and the collapse step has no anchor. Agent mode on
+          # dispatch still yields no tracking comment, so the prompt carries a
+          # gh pr comment fallback.
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           # ai4c-agent must be listed, or PRs opened by the editing agent --
           # the main reason this workflow exists -- would be ignored as bot noise.
           allowed_bots: 'claude,github-actions,ai4c-agent'
           claude_args: |
             --model ${{ env.REVIEW_MODEL }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api repos/:*),Bash(gh api /repos/:*),Bash(gh api users/:*),Bash(gh api /users/:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
 
           prompt: |
             REPO: ${{ github.repository }}
@@ -165,6 +171,16 @@ jobs:
             specifies, every finding, and all supporting detail. Anchor findings
             to specific lines with inline comments.
 
+            End the report with this line verbatim, so the comment is
+            identifiable as yours and as belonging to this run:
+            `<!-- ai4c-reviewer run ${{ github.run_id }} -->`
+
+            If no tracking comment exists (this happens on workflow_dispatch,
+            which runs in agent mode), post the report yourself instead:
+            `gh pr comment ${{ env.PR_NUMBER }} --body-file <file>`. Check
+            before assuming -- a report with no home is a review that did not
+            happen.
+
             The `gh pr review` body is NOT a second copy. It is a stub of at
             most three lines: the verdict, finding counts by severity, and a
             link to the tracking comment. Curators see both, so restating the
@@ -179,13 +195,18 @@ jobs:
 
             gh api repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments --jq '.[] | select(.user.login == "ai4c-reviewer[bot]") | "\(.id) \(.node_id) \(.created_at)"'
 
-            and for each one older than your current report:
+            Your current report is the one whose body contains
+            `run ${{ github.run_id }}`. Minimize every OTHER comment in that
+            list -- note the GraphQL argument separator below is a SPACE, not a
+            comma: a comma inside braces reads as bash brace expansion and the
+            command is refused before it runs.
 
-            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){clientMutationId}}' -F id=<node_id>
+            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id classifier:OUTDATED}){clientMutationId}}' -F id=<node_id>
 
-            Minimize ONLY comments authored by you, and never your current one.
-            A human's comment is never yours to hide. If you cannot identify
-            which comment is your current report, minimize nothing.
+            Minimize ONLY comments authored by you, and never the one carrying
+            this run's marker. A human's comment is never yours to hide. If you
+            cannot identify which comment is your current report, minimize
+            nothing and say so in the report.
 
             VERDICT:
             If there are any CRITICAL or IMPORTANT findings:
@@ -265,9 +286,9 @@ jobs:
           if "rate_limit" in haystack or "usage limit" in haystack or "weekly limit" in haystack:
               msg = (f"Claude USAGE LIMIT reached -- NO review ran ({detail!r}). This is an "
                      "account-quota issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this "
-                     "PR. Fix: wait for the limit to reset, rotate the token to an account with "
-                     "headroom, or set ANTHROPIC_API_KEY (pay-per-use) on the workflow. "
-                     "Re-run this check afterward.")
+                     "PR. ANTHROPIC_API_KEY is already wired as a fallback, so if this fired "
+                     "that key is missing or also exhausted. Fix: wait for the limit to reset, "
+                     "or rotate either credential to an account with headroom, then re-run.")
               print(f"::error title=Claude review skipped: usage limit::{msg}")
               summary("### Claude review skipped -- usage limit reached\n\n" + msg)
               sys.exit(1)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -126,7 +126,7 @@ jobs:
           allowed_bots: 'claude,github-actions,ai4c-agent'
           claude_args: |
             --model ${{ env.REVIEW_MODEL }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api repos/:*),Bash(gh api /repos/:*),Bash(gh api users/:*),Bash(gh api /users/:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api repos/:*),Bash(gh api /repos/:*),Bash(gh api users/:*),Bash(gh api /users/:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(obo-grep.pl:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*)"
 
           prompt: |
             REPO: ${{ github.repository }}
@@ -170,6 +170,22 @@ jobs:
             link to the tracking comment. Curators see both, so restating the
             report there doubles what they have to read, and the two copies
             drift as you condense.
+
+            THEN COLLAPSE YOUR OWN EARLIER REPORTS:
+            A new tracking comment is opened per run, so on an active PR your
+            reports stack up and a curator has to work out which is current.
+            After your new report is posted, minimize your previous ones as
+            outdated. List your own comments:
+
+            gh api repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments --jq '.[] | select(.user.login == "ai4c-reviewer[bot]") | "\(.id) \(.node_id) \(.created_at)"'
+
+            and for each one older than your current report:
+
+            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){clientMutationId}}' -F id=<node_id>
+
+            Minimize ONLY comments authored by you, and never your current one.
+            A human's comment is never yours to hide. If you cannot identify
+            which comment is your current report, minimize nothing.
 
             VERDICT:
             If there are any CRITICAL or IMPORTANT findings:


### PR DESCRIPTION
Adds `.github/workflows/claude-code-review.yml` — an AI reviewer authenticated as the `ai4c-reviewer` GitHub App (app id `4388239`, bot user `308941448`).

Adapted from [monarch-initiative/dismech](https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude-code-review.yml), with the review substance rewritten for GO.

## Scope

Runs on every same-repo PR **except** those authored by `ontobot` — the ten automated refresh/update workflows produce large mechanical diffs where a review is pure cost. PRs opened by `ai4c-agent[bot]` **are** reviewed; that's the highest-value case, catching hallucinated PMIDs and bad axioms before a curator spends time on them. It requires `ai4c-agent` in `allowed_bots`, or the action would discard those PRs as bot noise.

Drafts are skipped until marked ready. Fork PRs can't be reviewed automatically (no secrets on the `pull_request` event) — use `workflow_dispatch` with a PR number, or comment `/review`.

Verdict is full `--request-changes` / `--approve`, per discussion.

## Where the criteria live

The review substance is in **`.claude/skills/pr-review/SKILL.md`**, not in the workflow prompt. The skill owns what to check, severity grading, tone, the size guard, and the coverage report, and says nothing about how a review is delivered — so the same criteria apply when a human reviews a PR from a local checkout, and they sit alongside `design-pattern`, `term-obsoletion` and the rest rather than being buried in YAML.

The prompt keeps only what is true of the CI context: what is and isn't installed on the runner, how to get the diff, and the mapping from severity to a GitHub review verdict. 90 lines down to 36.

## What it deliberately does *not* do

No ODK container, no ROBOT. `ontology_qc` is already a required status check running the full ODK build, so the prompt tells the reviewer explicitly not to re-derive syntax, reasoning, or SPARQL QC results. That keeps the job on bare `ubuntu-latest`.

Instead it covers what CI structurally cannot see:

- **References** — PMIDs real, correctly transcribed, and actually about what they're cited for. Fabrication is always CRITICAL.
- **Logical axioms** — `intersection_of` overreach (CLAUDE.md's keratinization anti-pattern is named directly), label/definition/logical-definition alignment, over-asserted `is_a`.
- **Design patterns** — conformance checked against sibling terms found via `obo-grep.pl`, which is cloned in for stanza-aware search.
- **Metadata** — namespace, definition xrefs, `created_by`/`creation_date` on new terms *only*, `term_tracker_item` format, synonym scopes.
- **Obsoletion** — dangling references, `replaced_by`/`consider`, axiom stripping, annotation impact.
- **Scope discipline** — unrelated drive-by edits, and accidentally clobbered neighbouring stanzas, which the checkout/checkin workflow can cause silently.

## Two additions worth calling out

**Size guard.** The prompt requires the reviewer to measure the diff first and, on anything very large or mechanical, state plainly that it sampled rather than imply full coverage. A review that looks thorough but silently skipped 80% of the diff is worse than no review.

**Tone guidance.** Most PR authors here are expert curators. The prompt bans praise padding, diff restatement, and style nitpicks, and instructs it to phrase uncertain findings as questions. Explicitly: three real findings beat twenty speculative ones. Given this now runs on every human PR, false-positive rate is the thing that determines whether the team keeps it switched on.

Also retains dismech's execution-log verification step, which turns a silently errored agent run into a red X instead of a phantom green check.

## Before merging — setup required

- [ ] Install `ai4c-reviewer` on `geneontology/go-ontology` with Contents **read**, Pull requests **write**, Issues **read**
- [ ] Add secret `AI4C_REVIEWER_APP_ID` (`4388239`)
- [ ] Add secret `AI4C_REVIEWER_PRIVATE_KEY` (full PEM)
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` has quota headroom — it is shared with `ai-agent.yml`, and exhausting it silently no-ops *both* workflows account-wide

## Things to verify rather than assume

- **`REVIEW_MODEL: claude-opus-5`** is newer than the `claude-opus-4-7` pinned in `ai-agent.yml`. I did not verify the id resolves on your account. If it doesn't, the verify step fails loudly with the reason rather than posting nothing.
- **Bot `--request-changes` may block human merges.** `master` has `required_approving_review_count: 0`, so a bot *approval* unlocks nothing — but I could not confirm whether a change-request from the app blocks merging while branch protection is enabled at all. Worth testing on a throwaway PR before this lands, otherwise a false positive could wedge a curator.
- **Cost.** ~50 PRs per cycle from human curators now get an Opus review each. No budget cap is enforced in the workflow.
- Unlike dismech, this does not pin the Claude Code CLI version or pre-install it; the action manages its own. If the action's default CLI misbehaves, restoring dismech's explicit install step is the fix.
- `actionlint` was **not** run (not installed locally). Validation here is YAML parse, embedded-Python AST parse, and review of the job `if` expression — no Actions-schema check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)