### PR TITLE
Stop the reviewer from cancelling itself

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,8 +38,24 @@ on:
         required: true
         type: number
 
+# Concurrency is claimed at the workflow level, BEFORE the job's `if` is
+# evaluated. A run that will be skipped entirely still takes the group, and
+# cancel-in-progress then kills the incumbent. Two consequences, both observed
+# live on #32379:
+#
+#   * Grouping by PR number alone put pull_request and issue_comment runs in the
+#     same group, so any comment during a review aborted it.
+#   * Worse: the reviewer's own "Claude Code is working..." progress comment is
+#     itself an issue_comment event, so the review cancelled the run that had
+#     just posted it. Every review self-destructed.
+#
+# The group therefore has to be unique per triggering comment, not per PR.
+# event_name separates the trigger paths, and comment.id gives each
+# comment-triggered run its own group. pull_request still groups by PR number,
+# so a synchronize push cancels the previous review -- the one cancellation
+# worth keeping.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.comment.id || github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
**The reviewer is currently non-functional on `master`.** Every review aborts mid-run, leaving an orphaned "Claude Code is working…" comment and no review. Observed on #32379 across three separate attempts, including two explicit re-runs.

## Cause

Concurrency is claimed at the **workflow** level, *before* the job's `if` is evaluated. A run destined to skip entirely still takes the group, and `cancel-in-progress: true` then kills the incumbent.

The group was keyed on PR number alone, and `github.event.issue.number` resolves to the same number on `issue_comment`. So two things followed:

1. `pull_request` and `issue_comment` runs shared one group — any comment during a review aborted it, including this repo's routine `diff_classification` bot comment.
2. **Worse: the reviewer's own progress comment is an `issue_comment` event.** So each review cancelled the run that had just posted it. Self-destruction, on every PR.

Evidence from #32379:

```
20:49:24  event=pull_request   CANCELLED  branch=mito-fission-def-detail
20:49:32  event=issue_comment  skipped
20:49:53  event=issue_comment  CANCELLED
20:49:54  event=issue_comment  skipped
```

Two `ai4c-reviewer[bot]` comments on that PR, both exactly 320 chars — the "working…" stub, twice, with no review either time.

## Why #32365 passed six times and this still shipped

`issue_comment` events always run the workflow from the **default branch**. Before #32365 merged, `master` had no `claude-code-review.yml` at all — `git show 8c0456775:.github/workflows/claude-code-review.yml` fails. So those events had nothing to trigger, and the reviewer ran cleanly on its own PR six times.

The bug was unobservable until the thing that triggers it existed on `master`. No amount of pre-merge testing on that PR would have surfaced it.

## Fix

Group uniquely per **triggering comment**, not per PR:

```yaml
group: claude-review-${{ github.event_name }}-${{ github.event.comment.id || github.event.pull_request.number || github.event.inputs.pr_number }}
```

`event_name` separates the trigger paths; `comment.id` gives each comment-triggered run its own group. `pull_request` still groups by PR number, so a `synchronize` push cancels the previous review — the one cancellation worth keeping.

## Correction to my first attempt

The initial version of this PR added only `github.event_name`, which is what upstream [dismech](https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude-code-review.yml) does and what I dropped during the original port. That fixes the `pull_request` path but **not** the `/review` path: a `/review` run posts a progress comment, which is another `issue_comment` event in the same group, so it would still self-cancel. dismech is likely exposed to that variant.

## Severity

There is no error, no failed check, and a progress comment that reads as though a review is still coming. This presents as the reviewer being sporadically unreliable, with the cause nowhere near the symptom — the fastest route to the team disabling it.

One thing that behaved correctly throughout: the `!cancelled()` guard on the verify step (added in #32365) meant none of these cancellations produced a phantom "review failed" annotation.

## Verification

- YAML parses; group expression confirmed
- Diagnosis is from run metadata — event name, conclusion, branch — not inference
- Expect this PR's own review to self-cancel, since `issue_comment` runs still use `master`'s copy until this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)