### PR TITLE
Add noctua-allowed ChEBI subset

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -392,6 +392,10 @@ imports/pr_terms_combined.txt: imports/pr_terms.txt seed.txt
 imports/opl_terms_combined.txt: imports/opl_terms.txt seed.txt
 	cat $^ | grep 'OPL_' > $@
 
+# Include the generated ChEBI subset property in ChEBI module extractions.
+imports/chebi_terms_combined.txt: imports/chebi_terms.txt seed.txt
+	cat $^ > $@ && echo 'http://purl.obolibrary.org/obo/go#noctua_allowed' >> $@
+
 imports/%_terms_combined.txt: imports/%_terms.txt seed.txt
 	cat $^ > $@
 
@@ -465,7 +469,7 @@ imports/%_import.owl: imports/%_import_pre.owl
 	cp $< $@
 
 imports/chebi_import.owl: bio-chebi.owl imports/chebi_terms_combined.txt $(SRC)
-	$(ROBOT) extract -i bio-chebi.owl -T imports/chebi_terms_combined.txt --method BOT remove --term 'http://www.w3.org/2000/01/rdf-schema#label' --term 'http://www.geneontology.org/formats/oboInOwl#inSubset' --term 'http://purl.obolibrary.org/obo/go#chebi_ph7_3' --select complement --select annotation-properties --signature true annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
+	$(ROBOT) extract -i bio-chebi.owl -T imports/chebi_terms_combined.txt --method BOT remove --term 'http://www.w3.org/2000/01/rdf-schema#label' --term 'http://www.geneontology.org/formats/oboInOwl#inSubset' --term 'http://purl.obolibrary.org/obo/go#chebi_ph7_3' --term 'http://purl.obolibrary.org/obo/go#noctua_allowed' --select complement --select annotation-properties --signature true annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 .PRECIOUS: imports/chebi_import.owl
 
 imports/%_import.obo: imports/%_import.owl
@@ -573,9 +577,9 @@ mirror/groups.ttl:
 	curl -L -o ../resources/enzyme.rdf 'https://ftp.expasy.org/databases/enzyme/enzyme.rdf' &&\
 	arq -q --data=../resources/enzyme.rdf --query=../sparql/query-obsolete-ec.sparql --results=tsv | tail -n +2 | sort >$@
 
-# bio-chebi.owl imports chebi and injects GCI axioms to conflate conjugate bases. See Hill et al
-bio-chebi.owl: mirror/chebi.owl chebi-ph7_3-slim.ofn biochebi_gcis.ofn imports/substance_by_role.owl
-	$(ROBOT) merge -i $< -i chebi-ph7_3-slim.ofn -i biochebi_gcis.ofn -i imports/substance_by_role.owl annotate --ontology-iri $(BASE)/extensions/$@ -V $(RELEASE_URIBASE)/extensions/$@ -o $@.tmp.owl && mv $@.tmp.owl $@
+# bio-chebi.owl imports ChEBI and injects subset annotations and GCI axioms to conflate conjugate bases. See Hill et al
+bio-chebi.owl: mirror/chebi.owl chebi-ph7_3-slim.ofn noctua-allowed-slim.ofn biochebi_gcis.ofn imports/substance_by_role.owl
+	$(ROBOT) merge -i $< -i chebi-ph7_3-slim.ofn -i noctua-allowed-slim.ofn -i biochebi_gcis.ofn -i imports/substance_by_role.owl annotate --ontology-iri $(BASE)/extensions/$@ -V $(RELEASE_URIBASE)/extensions/$@ -o $@.tmp.owl && mv $@.tmp.owl $@
 
 ../biochebi/chebi_pH7_3_mapping.tsv:
 	wget 'ftp://ftp.expasy.org/databases/rhea/tsv/chebi_pH7_3_mapping.tsv' $(WGET_OUT)
@@ -599,10 +603,10 @@ chebi-ph7_3-slim.ofn: ../biochebi/chebi_pH7_3_mapping.tsv
 noctua-allowed-slim.ofn: ../biochebi/noctua-allowed-terms.txt
 	echo 'Ontology(<http://purl.obolibrary.org/obo/go/extensions/noctua-allowed-slim.ofn>' >$@.tmp &&\
 	echo 'Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#SubsetProperty>))' >>$@.tmp &&\
-	echo 'Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/go#noctua-allowed>))' >>$@.tmp &&\
-	echo 'SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/go#noctua-allowed> <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)' >>$@.tmp &&\
-	echo 'AnnotationAssertion(<http://www.w3.org/2000/01/rdf-schema#comment> <http://purl.obolibrary.org/obo/go#noctua-allowed> "ChEBI terms allowed for use in Noctua, comprising the Rhea pH 7.3 subset and the GO ChEBI allow-list.")' >>$@.tmp &&\
-	sed 's|^|AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <|' $< | sed 's|$$|> <http://purl.obolibrary.org/obo/go#noctua-allowed>)|' >>$@.tmp
+	echo 'Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/go#noctua_allowed>))' >>$@.tmp &&\
+	echo 'SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/go#noctua_allowed> <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)' >>$@.tmp &&\
+	echo 'AnnotationAssertion(<http://www.w3.org/2000/01/rdf-schema#comment> <http://purl.obolibrary.org/obo/go#noctua_allowed> "ChEBI terms allowed for use in Noctua, comprising the Rhea pH 7.3 subset and the GO ChEBI allow-list.")' >>$@.tmp &&\
+	sed 's|^|AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <|' $< | sed 's|$$|> <http://purl.obolibrary.org/obo/go#noctua_allowed>)|' >>$@.tmp
 	echo ')' >>$@.tmp && mv $@.tmp $@
 
 biochebi_gcis.tsv: ../biochebi/chebi_pH7_3_mapping.tsv ../biochebi/biochebi_excludes.txt
@@ -615,8 +619,8 @@ biochebi_gcis.ofn: biochebi_gcis.tsv ../biochebi/biochebi_gcis.yaml
 ../biochebi/go-lego-chebi-import-terms.txt: imports/chebi_terms_combined.txt ../biochebi/noctua-allowed-terms.txt
 	cat $^ >$@
 
-imports/go-lego-chebi-import.owl: bio-chebi.owl ../biochebi/go-lego-chebi-import-terms.txt noctua-allowed-slim.ofn
-	$(ROBOT) extract -i $< -T ../biochebi/go-lego-chebi-import-terms.txt --method BOT merge -i noctua-allowed-slim.ofn annotate -O $(BASE)/imports/go-lego-chebi-import.owl -V $(RELEASE_URIBASE)/imports/go-lego-chebi-import.owl -o $@
+imports/go-lego-chebi-import.owl: bio-chebi.owl ../biochebi/go-lego-chebi-import-terms.txt
+	$(ROBOT) extract -i $< -T ../biochebi/go-lego-chebi-import-terms.txt --method BOT annotate -O $(BASE)/imports/go-lego-chebi-import.owl -V $(RELEASE_URIBASE)/imports/go-lego-chebi-import.owl -o $@
 
 .PRECIOUS: mirror/uberon.owl
 

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -259,8 +259,8 @@ $(GO_GAF).owl: extensions/go-gaf-edit.ofn $(GO_PLUS).owl extensions/gorel.owl mi
 
 # NOTE - the beginning 'annotate' command is used only to work around this ROBOT bug when merge is the first command: 
 # https://github.com/ontodev/robot/issues/1250
-$(GO_AMIGO).owl: extensions/go-amigo-edit.ofn $(GO_GAF).owl extensions/go-modules-annotations.owl extensions/go-taxon-subsets.owl mirror/eco.owl mirror/pato.owl mirror/po.owl mirror/chebi.owl mirror/uberon.owl mirror/wbbt.owl
-	$(ROBOT) annotate -i $< -O $(BASE)/$@ merge --collapse-import-closure true --include-annotations false reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
+$(GO_AMIGO).owl: extensions/go-amigo-edit.ofn $(GO_GAF).owl extensions/go-modules-annotations.owl extensions/go-taxon-subsets.owl mirror/eco.owl mirror/pato.owl mirror/po.owl mirror/chebi.owl mirror/uberon.owl mirror/wbbt.owl noctua-allowed-slim.ofn
+	$(ROBOT) annotate -i $< -O $(BASE)/$@ merge --collapse-import-closure true --include-annotations false merge -i noctua-allowed-slim.ofn reason -r ELK --exclude-duplicate-axioms true --remove-redundant-subclass-axioms true --exclude-tautologies structural annotate -O $(BASE)/$@ -V $(RELEASE_URIBASE)/$@ -o $@
 
 # Not all imports are being pre-mirrored; the ones that are should be dependencies
 # NOTE - the beginning 'annotate' command is used only to work around this ROBOT bug when merge is the first command: 
@@ -591,6 +591,20 @@ chebi-ph7_3-slim.ofn: ../biochebi/chebi_pH7_3_mapping.tsv
 	tail -n +2 $< | cut -f 2 | sort -n -u | sed 's/^/AnnotationAssertion(<http:\/\/www.geneontology.org\/formats\/oboInOwl#inSubset> <http:\/\/purl.obolibrary.org\/obo\/CHEBI_/' | sed 's/$$/> <http:\/\/purl.obolibrary.org\/obo\/go#chebi_ph7_3>)/' >>$@.tmp
 	echo ')' >>$@.tmp && mv $@.tmp $@
 
+../biochebi/noctua-allowed-terms.txt: ../biochebi/chebi_pH7_3_terms.txt ../biochebi/chebi-allow.txt
+	cat ../biochebi/chebi_pH7_3_terms.txt >$@.tmp &&\
+	sed -n 's|^CHEBI:|http://purl.obolibrary.org/obo/CHEBI_|p' ../biochebi/chebi-allow.txt >>$@.tmp &&\
+	sort -u $@.tmp >$@ && rm $@.tmp
+
+noctua-allowed-slim.ofn: ../biochebi/noctua-allowed-terms.txt
+	echo 'Ontology(<http://purl.obolibrary.org/obo/go/extensions/noctua-allowed-slim.ofn>' >$@.tmp &&\
+	echo 'Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#SubsetProperty>))' >>$@.tmp &&\
+	echo 'Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/go#noctua-allowed>))' >>$@.tmp &&\
+	echo 'SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/go#noctua-allowed> <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)' >>$@.tmp &&\
+	echo 'AnnotationAssertion(<http://www.w3.org/2000/01/rdf-schema#comment> <http://purl.obolibrary.org/obo/go#noctua-allowed> "ChEBI terms allowed for use in Noctua, comprising the Rhea pH 7.3 subset and the GO ChEBI allow-list.")' >>$@.tmp &&\
+	sed 's|^|AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <|' $< | sed 's|$$|> <http://purl.obolibrary.org/obo/go#noctua-allowed>)|' >>$@.tmp
+	echo ')' >>$@.tmp && mv $@.tmp $@
+
 biochebi_gcis.tsv: ../biochebi/chebi_pH7_3_mapping.tsv ../biochebi/biochebi_excludes.txt
 	echo 'source_chem	standard_chem' >$@.tmp &&\
 	tail -n +2 ../biochebi/chebi_pH7_3_mapping.tsv | awk -v FS='\t' -v OFS='\t' '{ if ($$1 != $$2) { print "CHEBI:"$$1, "CHEBI:"$$2} }' | grep -v -f ../biochebi/biochebi_excludes.txt >> $@.tmp && mv $@.tmp $@
@@ -598,11 +612,11 @@ biochebi_gcis.tsv: ../biochebi/chebi_pH7_3_mapping.tsv ../biochebi/biochebi_excl
 biochebi_gcis.ofn: biochebi_gcis.tsv ../biochebi/biochebi_gcis.yaml
 	$(DOSDP_TOOLS) generate --obo-prefixes=true --generate-defined-class=true --template=../biochebi/biochebi_gcis.yaml --infile=$< --outfile=$@.tmp.ofn && mv $@.tmp.ofn $@
 
-../biochebi/go-lego-chebi-import-terms.txt: imports/chebi_terms_combined.txt ../biochebi/chebi_pH7_3_terms.txt
+../biochebi/go-lego-chebi-import-terms.txt: imports/chebi_terms_combined.txt ../biochebi/noctua-allowed-terms.txt
 	cat $^ >$@
 
-imports/go-lego-chebi-import.owl: bio-chebi.owl ../biochebi/go-lego-chebi-import-terms.txt
-	$(ROBOT) extract -i $< -T ../biochebi/go-lego-chebi-import-terms.txt --method BOT annotate -O $(BASE)/imports/go-lego-chebi-import.owl -V $(RELEASE_URIBASE)/imports/go-lego-chebi-import.owl -o $@
+imports/go-lego-chebi-import.owl: bio-chebi.owl ../biochebi/go-lego-chebi-import-terms.txt noctua-allowed-slim.ofn
+	$(ROBOT) extract -i $< -T ../biochebi/go-lego-chebi-import-terms.txt --method BOT merge -i noctua-allowed-slim.ofn annotate -O $(BASE)/imports/go-lego-chebi-import.owl -V $(RELEASE_URIBASE)/imports/go-lego-chebi-import.owl -o $@
 
 .PRECIOUS: mirror/uberon.owl
 


### PR DESCRIPTION
Generate the Noctua allow-list as the union of Rhea pH 7.3 terms and the GO ChEBI allow-list. Include the union in the GO-LEGO ChEBI extraction, annotate each selected class, and merge the same subset annotations into go-amigo after its full ChEBI import closure.

See [geneontology/noctua#1100](https://github.com/geneontology/noctua/issues/1100)