### PR TITLE
Cache Scala CLI dependencies in Docker and CI

### DIFF
--- a/.claude/skills/odk-make/odk-run.sh
+++ b/.claude/skills/odk-make/odk-run.sh
@@ -34,4 +34,4 @@ if [ -z "$IMG" ]; then
 fi
 
 # Same memory limit and mounts as run.sh, but no -ti.
-exec docker run --rm -m 12g -v "$REPO:/work" -v go-ontology-coursier:/root/.cache/coursier -w /work/src/ontology "$IMG" "$@"
+exec docker run --rm -m 12g -v "$REPO:/work" -v go-ontology-coursier:/root/.cache/coursier -e COURSIER_CACHE=/root/.cache/coursier -w /work/src/ontology "$IMG" "$@"

--- a/.claude/skills/odk-make/odk-run.sh
+++ b/.claude/skills/odk-make/odk-run.sh
@@ -33,5 +33,5 @@ if [ -z "$IMG" ]; then
   exit 1
 fi
 
-# Same memory limit and mount as run.sh, but no -ti.
-exec docker run --rm -m 12g -v "$REPO:/work" -w /work/src/ontology "$IMG" "$@"
+# Same memory limit and mounts as run.sh, but no -ti.
+exec docker run --rm -m 12g -v "$REPO:/work" -v go-ontology-coursier:/root/.cache/coursier -w /work/src/ontology "$IMG" "$@"

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -295,6 +295,15 @@ jobs:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Cache Scala CLI dependencies
+        if: fromJSON(needs.check-mention.outputs.result).useOdkContainer
+        uses: coursier/cache-action@v7
+        with:
+          path: ${{ github.workspace }}/.coursier-cache
+          extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          ignoreJob: true
+          ignoreAmmonite: true
+
       - name: Configure Git
         run: |
           git config --global user.name "${{ env.AGENT_LOGIN }}"

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -299,8 +299,9 @@ jobs:
         if: fromJSON(needs.check-mention.outputs.result).useOdkContainer
         uses: coursier/cache-action@v7
         with:
-          path: ${{ github.workspace }}/.coursier-cache
+          path: /tools/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          extraKey: ${{ github.workflow }}
           ignoreJob: true
 
       - name: Configure Git

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -302,7 +302,6 @@ jobs:
           path: ${{ github.workspace }}/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
           ignoreJob: true
-          ignoreAmmonite: true
 
       - name: Configure Git
         run: |

--- a/.github/workflows/design-patterns.yml
+++ b/.github/workflows/design-patterns.yml
@@ -21,7 +21,6 @@ jobs:
         path: ${{ github.workspace }}/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
         ignoreJob: true
-        ignoreAmmonite: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/design-patterns.yml
+++ b/.github/workflows/design-patterns.yml
@@ -18,8 +18,9 @@ jobs:
     - name: Cache Scala CLI dependencies
       uses: coursier/cache-action@v7
       with:
-        path: ${{ github.workspace }}/.coursier-cache
+        path: /tools/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        extraKey: ${{ github.workflow }}
         ignoreJob: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170

--- a/.github/workflows/design-patterns.yml
+++ b/.github/workflows/design-patterns.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+
+    - name: Cache Scala CLI dependencies
+      uses: coursier/cache-action@v7
+      with:
+        path: ${{ github.workspace }}/.coursier-cache
+        extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        ignoreJob: true
+        ignoreAmmonite: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/inference_diff.yml
+++ b/.github/workflows/inference_diff.yml
@@ -25,7 +25,6 @@ jobs:
           path: ${{ github.workspace }}/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
           ignoreJob: true
-          ignoreAmmonite: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn
       - name: Upload PR reasoned.ofn
@@ -47,7 +46,6 @@ jobs:
           path: ${{ github.workspace }}/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
           ignoreJob: true
-          ignoreAmmonite: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn
       - name: Upload master reasoned.ofn

--- a/.github/workflows/inference_diff.yml
+++ b/.github/workflows/inference_diff.yml
@@ -19,6 +19,13 @@ jobs:
     container: obolibrary/odkfull:${{ vars.ODK_VERSION }}
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Scala CLI dependencies
+        uses: coursier/cache-action@v7
+        with:
+          path: ${{ github.workspace }}/.coursier-cache
+          extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          ignoreJob: true
+          ignoreAmmonite: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn
       - name: Upload PR reasoned.ofn
@@ -34,6 +41,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: master
+      - name: Cache Scala CLI dependencies
+        uses: coursier/cache-action@v7
+        with:
+          path: ${{ github.workspace }}/.coursier-cache
+          extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          ignoreJob: true
+          ignoreAmmonite: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn
       - name: Upload master reasoned.ofn
@@ -85,4 +99,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: "../../comment.md"
-

--- a/.github/workflows/inference_diff.yml
+++ b/.github/workflows/inference_diff.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Cache Scala CLI dependencies
         uses: coursier/cache-action@v7
         with:
-          path: ${{ github.workspace }}/.coursier-cache
+          path: /tools/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          extraKey: ${{ github.workflow }}
           ignoreJob: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn
@@ -43,8 +44,9 @@ jobs:
       - name: Cache Scala CLI dependencies
         uses: coursier/cache-action@v7
         with:
-          path: ${{ github.workspace }}/.coursier-cache
+          path: /tools/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          extraKey: ${{ github.workflow }}
           ignoreJob: true
       - name: Classify ontology
         run: cd src/ontology; make -j 4 ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' reasoned.ofn

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -36,7 +36,6 @@ jobs:
           path: ${{ github.workspace }}/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
           ignoreJob: true
-          ignoreAmmonite: true
 
       - name: Run ontology QC checks
         run: cd src/ontology; make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx14G' travis_test

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Cache Scala CLI dependencies
         uses: coursier/cache-action@v7
         with:
-          path: ${{ github.workspace }}/.coursier-cache
+          path: /tools/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          extraKey: ${{ github.workflow }}
           ignoreJob: true
 
       - name: Run ontology QC checks

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -30,5 +30,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
+      - name: Cache Scala CLI dependencies
+        uses: coursier/cache-action@v7
+        with:
+          path: ${{ github.workspace }}/.coursier-cache
+          extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          ignoreJob: true
+          ignoreAmmonite: true
+
       - name: Run ontology QC checks
         run: cd src/ontology; make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx14G' travis_test

--- a/.github/workflows/refresh-rhea-relationships.yml
+++ b/.github/workflows/refresh-rhea-relationships.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Cache Scala CLI dependencies
         uses: coursier/cache-action@v7
         with:
-          path: ${{ github.workspace }}/.coursier-cache
+          path: /tools/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          extraKey: ${{ github.workflow }}
           ignoreJob: true
 
       - name: Refresh Rhea relationships TSV

--- a/.github/workflows/refresh-rhea-relationships.yml
+++ b/.github/workflows/refresh-rhea-relationships.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Cache Scala CLI dependencies
+        uses: coursier/cache-action@v7
+        with:
+          path: ${{ github.workspace }}/.coursier-cache
+          extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+          ignoreJob: true
+          ignoreAmmonite: true
+
       - name: Refresh Rhea relationships TSV
         run: cd src/ontology && rm ../resources/rhea-relationships.tsv && make ../resources/rhea-relationships.tsv && cd ../..
 

--- a/.github/workflows/refresh-rhea-relationships.yml
+++ b/.github/workflows/refresh-rhea-relationships.yml
@@ -20,7 +20,6 @@ jobs:
           path: ${{ github.workspace }}/.coursier-cache
           extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
           ignoreJob: true
-          ignoreAmmonite: true
 
       - name: Refresh Rhea relationships TSV
         run: cd src/ontology && rm ../resources/rhea-relationships.tsv && make ../resources/rhea-relationships.tsv && cd ../..

--- a/.github/workflows/update-diff-status.yml
+++ b/.github/workflows/update-diff-status.yml
@@ -20,6 +20,14 @@ jobs:
         ref: master
         fetch-depth: 0   # REQUIRED to switch branches later
 
+    - name: Cache Scala CLI dependencies
+      uses: coursier/cache-action@v7
+      with:
+        path: ${{ github.workspace }}/.coursier-cache
+        extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        ignoreJob: true
+        ignoreAmmonite: true
+
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/update-diff-status.yml
+++ b/.github/workflows/update-diff-status.yml
@@ -26,7 +26,6 @@ jobs:
         path: ${{ github.workspace }}/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
         ignoreJob: true
-        ignoreAmmonite: true
 
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/update-diff-status.yml
+++ b/.github/workflows/update-diff-status.yml
@@ -23,8 +23,9 @@ jobs:
     - name: Cache Scala CLI dependencies
       uses: coursier/cache-action@v7
       with:
-        path: ${{ github.workspace }}/.coursier-cache
+        path: /tools/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        extraKey: ${{ github.workflow }}
         ignoreJob: true
 
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170

--- a/.github/workflows/update_reaction_participants.yml
+++ b/.github/workflows/update_reaction_participants.yml
@@ -21,7 +21,6 @@ jobs:
         path: ${{ github.workspace }}/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
         ignoreJob: true
-        ignoreAmmonite: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/update_reaction_participants.yml
+++ b/.github/workflows/update_reaction_participants.yml
@@ -18,8 +18,9 @@ jobs:
     - name: Cache Scala CLI dependencies
       uses: coursier/cache-action@v7
       with:
-        path: ${{ github.workspace }}/.coursier-cache
+        path: /tools/.coursier-cache
         extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        extraKey: ${{ github.workflow }}
         ignoreJob: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170

--- a/.github/workflows/update_reaction_participants.yml
+++ b/.github/workflows/update_reaction_participants.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+
+    - name: Cache Scala CLI dependencies
+      uses: coursier/cache-action@v7
+      with:
+        path: ${{ github.workspace }}/.coursier-cache
+        extraFiles: '["src/ontology/Makefile", "src/util/*.sc"]'
+        ignoreJob: true
+        ignoreAmmonite: true
       
     - name: Work around https://github.com/peter-evans/create-pull-request/issues/1170
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -3,4 +3,5 @@
 # Any updates to the odkfull version MUST be coordinated with geneontology/pipeline.
 # When updating the odkfull version, remember to also update the GitHub Actions workflows.
 
-docker run -m 12g  -v $PWD/../../:/work -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.6.1 "$@"
+# Keep Scala CLI/Coursier downloads across disposable containers.
+docker run -m 12g -v $PWD/../../:/work -v go-ontology-coursier:/root/.cache/coursier -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.6.1 "$@"

--- a/src/ontology/run.sh
+++ b/src/ontology/run.sh
@@ -4,4 +4,4 @@
 # When updating the odkfull version, remember to also update the GitHub Actions workflows.
 
 # Keep Scala CLI/Coursier downloads across disposable containers.
-docker run -m 12g -v $PWD/../../:/work -v go-ontology-coursier:/root/.cache/coursier -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.6.1 "$@"
+docker run -m 12g -v $PWD/../../:/work -v go-ontology-coursier:/root/.cache/coursier -e COURSIER_CACHE=/root/.cache/coursier -w /work/src/ontology --rm -ti obolibrary/odkfull:v1.6.1 "$@"


### PR DESCRIPTION
Mount a Docker-managed Coursier volume at the standard cache location in both the interactive ODK runner and the non-interactive agent wrapper. This lets disposable local containers reuse downloaded Scala and Maven artifacts.

Add coursier/cache-action to GitHub Actions jobs whose ontology Makefile targets transitively invoke Scala CLI, as well as the direct Rhea Scala workflow and ODK-backed agent job. Share the cache across jobs and invalidate exact entries when the Makefile or Scala scripts change.