### PR TITLE
Slim travis_build to PR integrity, drop release shaping

### DIFF
--- a/.claude/skills/odk-make/SKILL.md
+++ b/.claude/skills/odk-make/SKILL.md
@@ -42,7 +42,7 @@ skill instead. It mirrors `run.sh` exactly (same image tag — read live from
 works from any directory in the repo:
 
 ```sh
-.claude/skills/odk-make/odk-run.sh make travis_build
+.claude/skills/odk-make/odk-run.sh make travis_test
 .claude/skills/odk-make/odk-run.sh make reasoned.ofn
 .claude/skills/odk-make/odk-run.sh robot --version
 ```
@@ -60,25 +60,30 @@ If you're unsure which environment you're in: `robot --version` succeeding on th
 bare PATH and a `/work` working directory are signs you're already inside ODK.
 Otherwise assume you need `odk-run.sh`.
 
-> Note on CLAUDE.md: the project guide writes validation as
-> `cd src/ontology && make travis_build`. That shorthand assumes the ODK
+> Note on the project guide: it writes validation as
+> `cd src/ontology && make travis_test`. That shorthand assumes the ODK
 > environment is already active (as in CI). On a local machine, run the
 > equivalent through the wrapper:
-> `.claude/skills/odk-make/odk-run.sh make travis_build`.
+> `.claude/skills/odk-make/odk-run.sh make travis_test`.
 
 ## Common targets
 
 | Goal | Command (local) |
 | --- | --- |
-| Full validation (CI gate) | `.claude/skills/odk-make/odk-run.sh make travis_build` |
+| Full validation (CI gate) | `.claude/skills/odk-make/odk-run.sh make travis_test` |
+| Reasoning + SPARQL only (part of the above) | `.claude/skills/odk-make/odk-run.sh make travis_build` |
 | Test suite | `.claude/skills/odk-make/odk-run.sh make test` |
 | Reason the edit file | `.claude/skills/odk-make/odk-run.sh make reasoned.ofn` |
 | Regenerate an import | `.claude/skills/odk-make/odk-run.sh make imports/<name>.owl` |
 | Regenerate all imports | `.claude/skills/odk-make/odk-run.sh make all_imports` |
 | Simulate a release build | `.claude/skills/odk-make/odk-run.sh make` |
 
-`make travis_build` is the primary post-edit validation gate. **Allow at least
-~10 minutes** for it to run; don't kill it early. If it times out, you can run
+`make travis_test` is the primary post-edit validation gate, and is exactly
+what CI runs. **Allow at least ~10 minutes** for it to run; don't kill it
+early. Don't substitute `make travis_build`: that is only the ROBOT half
+(pre-reasoning SPARQL, ELK reasoning, post-reasoning SPARQL) and skips the
+Datalog QC program, the QC self-test, the perl OBO check, the
+taxon-constraint column checks, and the ChEBI pH 7.3 check. If it times out, you can run
 the SPARQL verification checks and the ELK reasoning step on their own (see the
 AUTOMATED-VALIDATION section of CLAUDE.md) — those are also Makefile-derived
 commands, so run them through `odk-run.sh` too, e.g.:

--- a/.claude/skills/odk-make/SKILL.md
+++ b/.claude/skills/odk-make/SKILL.md
@@ -81,9 +81,17 @@ Otherwise assume you need `odk-run.sh`.
 `make travis_test` is the primary post-edit validation gate, and is exactly
 what CI runs. **Allow at least ~10 minutes** for it to run; don't kill it
 early. Don't substitute `make travis_build`: that is only the ROBOT half
-(pre-reasoning SPARQL, ELK reasoning, post-reasoning SPARQL) and skips the
-Datalog QC program, the QC self-test, the perl OBO check, the
-taxon-constraint column checks, and the ChEBI pH 7.3 check. If it times out, you can run
+(pre-reasoning SPARQL, ELK reasoning, post-reasoning SPARQL) and skips all
+seven of its siblings -- `check_taxon_constraint_idspaces`,
+`check_all_taxon_constraints_columns`, the perl OBO check, `qc-selftest`,
+`datalog-check`, `chebi_pH_7_3_check`, and `change-report.txt` (the gate on
+dropped or renumbered GO ids and missing labels).
+
+`travis_test` also needs network access, where `travis_build` does not: both
+`GO.xrf_abbs` and `go-lastrelease.owl` are rebuilt whenever `go-edit.obo`
+changes, so each run re-fetches the db-xrefs metadata and the released
+`go.owl`. In a sandbox without egress it fails at `wget`, which is not an
+ontology defect. If it times out, you can run
 the SPARQL verification checks and the ELK reasoning step on their own (see the
 AUTOMATED-VALIDATION section of CLAUDE.md) — those are also Makefile-derived
 commands, so run them through `odk-run.sh` too, e.g.:

--- a/.claude/skills/odk-make/odk-run.sh
+++ b/.claude/skills/odk-make/odk-run.sh
@@ -12,7 +12,7 @@
 # path) and reads the pinned ODK image tag straight from run.sh so it never
 # drifts from what console users / CI use.
 #
-#   .claude/skills/odk-make/odk-run.sh make travis_build
+#   .claude/skills/odk-make/odk-run.sh make travis_test
 #   .claude/skills/odk-make/odk-run.sh robot --version
 #   .claude/skills/odk-make/odk-run.sh make reasoned.ofn
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,15 +405,26 @@ Ensure that full validation is performed, using `cd src/ontology && make travis_
 
 `travis_test` is exactly what CI runs. Run it, not one of its prerequisites.
 In particular `travis_build` is only the ROBOT half -- the pre-reasoning SPARQL
-checks, reasoning, and the post-reasoning SPARQL checks. It does not cover the
-Datalog QC program, the QC self-test, the perl OBO check, the taxon-constraint
-column checks, or the ChEBI pH 7.3 check, all of which are siblings of
-`travis_build` under `travis_test`.
+checks, reasoning, and the post-reasoning SPARQL checks. Seven other
+prerequisites sit beside it under `travis_test` and are all skipped if you run
+`travis_build` alone: `check_taxon_constraint_idspaces`,
+`check_all_taxon_constraints_columns`, the perl OBO check (`go-edit.obo-check`),
+`qc-selftest`, `datalog-check`, `chebi_pH_7_3_check`, and `change-report.txt`.
+That last one is the `owltools --verify-changes` gate that catches a dropped or
+renumbered GO id and terms left without a label, which is exactly what you want
+to hear about after a checkin.
 
 `travis_build` covers pull-request integrity only. It does not build any release
 artifact, and it is deliberately not kept in sync with the
 `enhanced.ofn` -> `reasoned.ofn` release pipeline -- see the comment on the
 target in `src/ontology/Makefile`.
+
+`travis_test` needs network access, where `travis_build` does not. Both
+`GO.xrf_abbs` and `go-lastrelease.owl` list `go-edit.obo` as a prerequisite, so
+every edit to the edit file re-fetches the db-xrefs metadata and the full
+released `go.owl` on the next run. With no egress the run fails at `wget`, which
+reads as a validation failure but is not one -- there is no ontology defect
+behind it.
 
 IMPORTANT: Allow at least 10 mins for travis_test to run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ For a local editor-driven Claude Code session:
 
 ```bash
 .claude/skills/odk-make/odk-run.sh robot --version
-.claude/skills/odk-make/odk-run.sh make travis_build
+.claude/skills/odk-make/odk-run.sh make travis_test
 ```
 
 The wrapper uses the same image tag as `src/ontology/run.sh` (the canonical console invocation), so the version of `robot` you run matches the one CI uses. See the `/odk-make` skill for details and common targets.
@@ -89,7 +89,7 @@ Create a plan for addressing the issue. The plan MUST have the following compone
     - /reaction skill; for any request involving RHEA, EC, or the catalytic activity branch of GO
     - /taxon-constraint skill; for any request involving restricting usage of a term or branch to a taxon/clade
 - [ ] METADATA: The metadata for the changes is correct
-- [ ] AUTOMATED-VALIDATION: The ontology validates correctly using `make travis_build` after changes have been made
+- [ ] AUTOMATED-VALIDATION: The ontology validates correctly using `make travis_test` after changes have been made
 - [ ] REFERENCE-VALIDATION: All references (eg PMIDs) introduced have been validated, and are relevant, and not typos or hallucinations; always use /research for this
 - [ ] CHANGES-COMMITTED
     - [ ] RELEVANT-FILES: changes to src/ontology/go-edit.obo and any other content file are committed with detailed messages and signatures
@@ -175,7 +175,7 @@ The general procedure is:
 - checking in will update the edit file and remove the file from `terms/`
 - Commits are then made on src/ontology/go-edit.obo as appropriate
 - `obo-checkout.pl` and `obo-checkin.pl` come from the same obo-scripts tooling (`cmungall/obo-scripts` / the `editing-obo-ontologies` skill) and are likewise only on PATH once it's installed/loaded. If not found, install/locate them and call by full path — don't work around their absence by editing the megafile directly; the checkin/checkout procedure is required.
-- Always validate after checkin via `cd src/ontology && make travis_build` (this must run in the ODK Docker image — see the /odk-make skill)
+- Always validate after checkin via `cd src/ontology && make travis_test` (this must run in the ODK Docker image — see the /odk-make skill)
 
 ### Creation of new terms
 
@@ -399,16 +399,28 @@ property_value: term_tracker_item "https://github.com/geneontology/go-ontology/i
 
 This ontology uses standard ODK/ROBOT tests plus custom tests to ensure the ontology is logically, syntactically, and stylistically valid.
 
-IMPORTANT: every `make` target and every one-off `robot`/`owltools` command in this section must run inside the pinned ODK Docker image (`obolibrary/odkfull`), NOT against host tools — otherwise results won't match CI. Use the /odk-make skill, which explains this and provides a non-interactive runner (`.claude/skills/odk-make/odk-run.sh make travis_build`, etc). The bare `cd src/ontology && make ...`/`robot ...` forms shown below assume you are already inside the ODK environment (as in GitHub Actions); locally, wrap them via /odk-make.
+IMPORTANT: every `make` target and every one-off `robot`/`owltools` command in this section must run inside the pinned ODK Docker image (`obolibrary/odkfull`), NOT against host tools — otherwise results won't match CI. Use the /odk-make skill, which explains this and provides a non-interactive runner (`.claude/skills/odk-make/odk-run.sh make travis_test`, etc). The bare `cd src/ontology && make ...`/`robot ...` forms shown below assume you are already inside the ODK environment (as in GitHub Actions); locally, wrap them via /odk-make.
 
-Ensure that full validation is performed, using `cd src/ontology && make travis_build` (being sure you are in the right folder)
+Ensure that full validation is performed, using `cd src/ontology && make travis_test` (being sure you are in the right folder)
 
-IMPORTANT: Allow at least 10 mins for travis_build to run
+`travis_test` is exactly what CI runs. Run it, not one of its prerequisites.
+In particular `travis_build` is only the ROBOT half -- the pre-reasoning SPARQL
+checks, reasoning, and the post-reasoning SPARQL checks. It does not cover the
+Datalog QC program, the QC self-test, the perl OBO check, the taxon-constraint
+column checks, or the ChEBI pH 7.3 check, all of which are siblings of
+`travis_build` under `travis_test`.
+
+`travis_build` covers pull-request integrity only. It does not build any release
+artifact, and it is deliberately not kept in sync with the
+`enhanced.ofn` -> `reasoned.ofn` release pipeline -- see the comment on the
+target in `src/ontology/Makefile`.
+
+IMPORTANT: Allow at least 10 mins for travis_test to run
 
 If the build times out you can run tests separately; SPARQL-QC checks:
 
 ```
-cd src/ontology && robot verify -i go-edit.obo --queries ../sparql/equivalent-classes-violation.sparql  ../sparql/trailing-whitespace-violation.sparql  ../sparql/owldef-self-reference-violation.sparql  ../sparql/synonym-label-match-violation.sparql  ../sparql/replacedby-obsolete-violation.sparql  ../sparql/replacedby-namespace-violation.sparql  ../sparql/missing-namespace-violation.sparql  ../sparql/duplicate-exact-synonym-violation.sparql  ../sparql/duplicate-synonym-violation.sparql  ../sparql/non-IRI-value-violation.sparql  ../sparql/non-anyURI-value-violation.sparql  ../sparql/obsolete-definition-violation.sparql  ../sparql/definition-constraints-violation.sparql  ../sparql/one-to-one-xrefs-by-subject-violation.sparql  ../sparql/one-to-one-xrefs-by-value-violation.sparql  ../sparql/xref-syntax-violation.sparql
+cd src/ontology && robot verify -i go-edit.obo --queries ../sparql/equivalent-classes-violation.sparql  ../sparql/trailing-whitespace-violation.sparql  ../sparql/owldef-self-reference-violation.sparql  ../sparql/synonym-label-match-violation.sparql  ../sparql/duplicate-exact-synonym-violation.sparql  ../sparql/duplicate-synonym-violation.sparql  ../sparql/non-IRI-value-violation.sparql  ../sparql/non-anyURI-value-violation.sparql  ../sparql/one-to-one-xrefs-by-subject-violation.sparql  ../sparql/one-to-one-xrefs-by-value-violation.sparql  ../sparql/xref-syntax-violation.sparql  ../sparql/xref-annotation-violation.sparql
 ```
 
 Reasoning:
@@ -424,10 +436,13 @@ To debug syntax errors, try: `cd src/ontology && robot convert -vvv -i go-edit.o
 ### Datalog QC checks
 
 Some checks are Soufflé Datalog programs rather than SPARQL: `datalog-check`
-(the ontology QC program, `src/util/ontology-qc.dl` plus `src/util/qc/`) and
-`basic-cycles.tsv`, both part of `test` and `travis_test`. Taxon-constraint
-materialization also runs a Datalog step. These QC targets fail the build when
-their output file is non-empty.
+(the ontology QC program, `src/util/ontology-qc.dl` plus `src/util/qc/`), which
+runs in both `test` and `travis_test`, and `basic-cycles.tsv`, which runs only
+in `test`. The cycle check is release-only on purpose: it reads `go-basic.ofn`,
+so reaching it means building the whole release-shaping chain (a `materialize`
+over nine relations plus two `reduce` passes), which is far too slow for a pull
+request. Taxon-constraint materialization also runs a Datalog step. These QC
+targets fail the build when their output file is non-empty.
 
 Each QC check registers itself, and every arm of every check must be triggered
 by a control term in `src/util/qc/control.dl` that declares it with an

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -271,48 +271,44 @@ imports/reactome_xrefs_import.owl: ../resources/Reactions2GoTerms_human.txt ../r
 # GO MODULES vs EXTERNAL IMPORTS
 # ----------------------------------------
 #
-# go-edit.obo's `import:` list holds two different kinds of thing, and telling
-# them apart explains most of the merge/strip/unmerge choreography below.
+# go-edit.obo's `import:` list holds two kinds of thing, and telling them apart
+# explains the strip-then-merge below.
 #
-#   External imports -- chebi_import.owl, cl_import.owl, ncbitaxon_import.owl,
-#       uberon_import.owl, and the rest of the *_import.owl extractions.
-#       Content owned by another ontology. GO releases reference these terms but
-#       do not ship their axioms, so every release product strips them:
-#       `remove --select imports` in $(ONT)-pre.ofn and go-base.owl.
+#   External imports -- the *_import.owl extractions (chebi, cl, ncbitaxon,
+#       uberon, ...). Another ontology's content. The go.owl line of products
+#       does not ship their axioms: $(ONT)-pre.ofn drops them with
+#       `remove --select imports`, and go-base.owl drops what remains by base
+#       IRI with `remove --axioms external`. go-plus.owl is the deliberate
+#       exception -- it does `merge --collapse-import-closure true` and ships
+#       the external closure, which is much of its point.
 #
-#   GO modules -- go-taxon-constraint-classes.ofn, reactome_xrefs_import.owl,
+#   GO modules -- go-taxon-constraint-classes.ofn,
 #       go-catalytic-activities-participants.owl, go-taxon-groupings.owl,
 #       go-pattern-conformance.ttl, x-disjoint.ofn, extensions/go-*.owl.
 #       GO's own content, in separate files because it is generated rather than
-#       hand-edited. It is GO ontology content that happens not to live in
-#       go-edit.obo.
+#       hand-edited. A GO module sits on the import list only so go-edit.obo is
+#       self-contained for an editor -- without go-taxon-constraint-classes.ofn
+#       there, `is_a: neverin:4896` dangles in Protege. That is an editing
+#       convenience, not a claim that the content is foreign.
 #
-# A GO module appears on the `import:` list only so that go-edit.obo is
-# self-contained for an editor: without go-taxon-constraint-classes.ofn there,
-# `is_a: neverin:4896` dangles when the file is opened in Protege. That
-# declaration is an editing convenience, not a claim that the content is foreign.
+# Being a generated GO module does not imply being imported. reactome_xrefs_import.owl
+# and ../taxon_constraints/present_in_taxon.ofn are never declared as imports;
+# targets that want them merge them directly.
 #
-# Hence the strip-then-merge below. ROBOT cannot promote a file out of the
-# import closure -- merging a file that is still imported leaves its axioms
-# reachable from both places -- so deleting the `import:` line is the only way to
-# say "these axioms live in the main graph and nowhere else." A GO module needs
-# that whenever its axioms must be individually addressable downstream, and the
-# two stripped here need it for opposite reasons:
-#
-#   reactome_xrefs_import.owl        must SURVIVE. Its xrefs reach the release
-#       only through the merge; left as an import, `remove --select imports` in
-#       $(ONT)-pre.ofn would drop every one of them.
-#
-#   go-taxon-constraint-classes.ofn  must be REMOVABLE. $(GO_PLUS).ofn unmerges
-#       it before collapsing the remaining import closure, and `unmerge` only
-#       bites on main-graph axioms -- with the import declaration still present
-#       the unmerge would be a no-op and the very next merge would pull the
-#       scaffolding straight back in.
-#
-# A GO module whose content is discarded downstream anyway does not need the
-# strip. That is why go-catalytic-activities-participants.owl is merged in
-# several targets while remaining a plain import: $(ONT)-pre.ofn removes every
-# non-GO class, which takes its CHEBI-facing participant restrictions with it.
+# The strip below is for the imported case only. ROBOT cannot promote a file out
+# of the import closure -- merging a file that is still imported leaves its
+# axioms reachable from both places -- so deleting the `import:` line is the only
+# way to give them single residency in the main graph.
+# go-taxon-constraint-classes.ofn needs that: $(GO_PLUS).ofn unmerges it before
+# collapsing the closure, and `unmerge` only bites on main-graph axioms, so with
+# the declaration still present the unmerge would be a no-op and the following
+# merge would pull the scaffolding straight back in.
+# The reactome grep is vestigial -- go-edit.obo carries no such import today --
+# and harmless: it keeps the merge correct if one is ever re-added.
+# A GO module whose content is discarded downstream needs no strip at all, which
+# is why go-catalytic-activities-participants.owl is merged in several targets
+# while remaining a plain import: $(ONT)-pre.ofn removes every non-GO class,
+# taking its CHEBI-facing participant restrictions with it.
 go-edit-trimmed-imports.obo: $(SRC)
 	grep -v '^import: http://purl.obolibrary.org/obo/go/imports/reactome_xrefs_import.owl' $< |\
 	grep -v '^import: http://purl.obolibrary.org/obo/go/imports/go-taxon-constraint-classes.ofn' >$@

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -99,15 +99,27 @@ travis_test: check_taxon_constraint_idspaces check_all_taxon_constraints_columns
 #       filtering an unknown one would strip a definition's last xref.
 #
 #   verify $(VARGS)             the pre-reasoning SPARQL checks that have not yet
-#       moved to Soufflé. Runs before the merges, so it sees go-edit.obo alone.
+#       moved to Soufflé. Runs before the merges, so it sees only the edit file
+#       (Rhea-filtered, two imports trimmed).
 #
-#   the three merged modules    present_in_taxon.ofn is the only logic-bearing
-#       input go-edit.obo does not already import: it supplies the probe classes
-#       that turn a taxon-constraint violation into an unsatisfiable class.
-#       go-taxon-constraint-classes.ofn and go-catalytic-activities-participants.owl
-#       are imported, but are merged here so that verify -- which does not see
-#       imports -- can check them, e.g. an obsoleted MF term whose participant
-#       axioms have not been regenerated.
+#   the three merged modules    all three are GO modules, not external content --
+#       see GO MODULES vs EXTERNAL IMPORTS below. They are merged for three
+#       different reasons:
+#
+#       go-taxon-constraint-classes.ofn carries the EquivalentClasses
+#       definitions of the neverin:/onlyin: classes that go-edit.obo asserts as
+#       bare is_a parents, and go-edit-trimmed-imports.obo strips its import, so
+#       this merge is what makes a taxon-constraint violation unsatisfiable at
+#       all. Drop it and the gate does not weaken, it dies: the classes lose
+#       their axioms, ELK derives nothing, and the build passes silently.
+#
+#       present_in_taxon.ofn is never imported. It supplies probe classes of the
+#       form (GO term and in_taxon some Taxon), which expose a violation for a
+#       term that carries no offending assertion of its own.
+#
+#       go-catalytic-activities-participants.owl IS still imported, and is
+#       merged only so that verify -- which does not see imports -- can check it,
+#       e.g. an obsoleted MF term whose participant axioms were not regenerated.
 #
 #   reason -e asserted-only     unsatisfiability, inconsistency, and any
 #       equivalence ELK infers that an editor did not assert. Dropping the flag
@@ -255,7 +267,52 @@ imports/reactome_xrefs_import.owl: ../resources/Reactions2GoTerms_human.txt ../r
 	$(DOSDP_TOOLS) generate --template=xref_dosdp_yaml/reactome_xref.yaml --infile=reactome-tmp/combined.txt --outfile=reactome-tmp/reactome_xrefs.ofn --obo-prefixes=true
 	$(ROBOT) convert --input reactome-tmp/reactome_xrefs.ofn --output imports/reactome_xrefs_import.owl annotate --ontology-iri $(BASE)/imports/reactome_xrefs_import.owl -V $(RELEASE_URIBASE)/$@ -o $@
 
-# Remove reactome_xrefs_import.owl, and go-taxon-constraint-classes.ofn from imports. These are merged in directly in enhanced.ofn
+# ----------------------------------------
+# GO MODULES vs EXTERNAL IMPORTS
+# ----------------------------------------
+#
+# go-edit.obo's `import:` list holds two different kinds of thing, and telling
+# them apart explains most of the merge/strip/unmerge choreography below.
+#
+#   External imports -- chebi_import.owl, cl_import.owl, ncbitaxon_import.owl,
+#       uberon_import.owl, and the rest of the *_import.owl extractions.
+#       Content owned by another ontology. GO releases reference these terms but
+#       do not ship their axioms, so every release product strips them:
+#       `remove --select imports` in $(ONT)-pre.ofn and go-base.owl.
+#
+#   GO modules -- go-taxon-constraint-classes.ofn, reactome_xrefs_import.owl,
+#       go-catalytic-activities-participants.owl, go-taxon-groupings.owl,
+#       go-pattern-conformance.ttl, x-disjoint.ofn, extensions/go-*.owl.
+#       GO's own content, in separate files because it is generated rather than
+#       hand-edited. It is GO ontology content that happens not to live in
+#       go-edit.obo.
+#
+# A GO module appears on the `import:` list only so that go-edit.obo is
+# self-contained for an editor: without go-taxon-constraint-classes.ofn there,
+# `is_a: neverin:4896` dangles when the file is opened in Protege. That
+# declaration is an editing convenience, not a claim that the content is foreign.
+#
+# Hence the strip-then-merge below. ROBOT cannot promote a file out of the
+# import closure -- merging a file that is still imported leaves its axioms
+# reachable from both places -- so deleting the `import:` line is the only way to
+# say "these axioms live in the main graph and nowhere else." A GO module needs
+# that whenever its axioms must be individually addressable downstream, and the
+# two stripped here need it for opposite reasons:
+#
+#   reactome_xrefs_import.owl        must SURVIVE. Its xrefs reach the release
+#       only through the merge; left as an import, `remove --select imports` in
+#       $(ONT)-pre.ofn would drop every one of them.
+#
+#   go-taxon-constraint-classes.ofn  must be REMOVABLE. $(GO_PLUS).ofn unmerges
+#       it before collapsing the remaining import closure, and `unmerge` only
+#       bites on main-graph axioms -- with the import declaration still present
+#       the unmerge would be a no-op and the very next merge would pull the
+#       scaffolding straight back in.
+#
+# A GO module whose content is discarded downstream anyway does not need the
+# strip. That is why go-catalytic-activities-participants.owl is merged in
+# several targets while remaining a plain import: $(ONT)-pre.ofn removes every
+# non-GO class, which takes its CHEBI-facing participant restrictions with it.
 go-edit-trimmed-imports.obo: $(SRC)
 	grep -v '^import: http://purl.obolibrary.org/obo/go/imports/reactome_xrefs_import.owl' $< |\
 	grep -v '^import: http://purl.obolibrary.org/obo/go/imports/go-taxon-constraint-classes.ofn' >$@

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -82,11 +82,58 @@ test: check_taxon_constraint_idspaces qc-selftest datalog-check $(SRC)-check bas
 
 travis_test: check_taxon_constraint_idspaces check_all_taxon_constraints_columns $(SRC)-check qc-selftest datalog-check chebi_pH_7_3_check travis_build change-report.txt
 
-# This target combines features from reasoned.ofn, enhanced.ofn, sparql_test into a faster mode for Travis/GitHub Actions.
-# These must be kept in sync.
-# The convert step is here only to work around https://github.com/ontodev/robot/issues/1250
+# The pull-request gate: everything that must hold for a change to go-edit.obo,
+# and nothing whose only purpose is to shape a release artifact.
+#
+# This deliberately does NOT mirror the enhanced.ofn -> reasoned.ofn pipeline,
+# and must not be "resynced" with it. The release-shaping it used to carry --
+# the reactome xref merge, the three skos xref updates, editor-annotation
+# removal, the source-annotation drop, version annotation, prefix handling, and
+# two full serializations of GO -- cannot fail a build. That work belongs to
+# `test` / `stage_release`, which exercise it on the way to an actual release.
+#
+# What is load-bearing here, and why:
+#
+#   go-edit-filtered-xrefs.ofn  ../util/filter-rhea-xrefs.sc exits non-zero when
+#       an xref or definition xref cites an obsolete Rhea reaction, or when
+#       filtering an unknown one would strip a definition's last xref.
+#
+#   verify $(VARGS)             the pre-reasoning SPARQL checks that have not yet
+#       moved to Soufflé. Runs before the merges, so it sees go-edit.obo alone.
+#
+#   the three merged modules    present_in_taxon.ofn is the only logic-bearing
+#       input go-edit.obo does not already import: it supplies the probe classes
+#       that turn a taxon-constraint violation into an unsatisfiable class.
+#       go-taxon-constraint-classes.ofn and go-catalytic-activities-participants.owl
+#       are imported, but are merged here so that verify -- which does not see
+#       imports -- can check them, e.g. an obsoleted MF term whose participant
+#       axioms have not been regenerated.
+#
+#   reason -e asserted-only     unsatisfiability, inconsistency, and any
+#       equivalence ELK infers that an editor did not assert. Dropping the flag
+#       would silently accept the third.
+#
+#   relax                       multiple-class-links matches restrictions, which
+#       relax derives from logical definitions. Without it the check still
+#       passes -- against almost nothing.
+#
+#   reduce                      reachability-preserving, so it cannot hide a
+#       violation, but it collapses one bad cross-namespace parent from a row
+#       per descendant to a single row.
+#
+# Starting the chain on `verify --input` rather than `convert -i ... -o` keeps
+# merge off the front of the chain (https://github.com/ontodev/robot/issues/1250)
+# without serializing the whole ontology to a file that is then discarded.
 travis_build: go-edit-filtered-xrefs.ofn
-	$(ROBOT) convert -i go-edit-filtered-xrefs.ofn -o travis_build_dummy_out.ofn verify --queries $(VARGS) -O reports/ merge --collapse-import-closure false -i imports/go-taxon-constraint-classes.ofn -i imports/reactome_xrefs_import.owl -i ../taxon_constraints/present_in_taxon.ofn -i imports/go-catalytic-activities-participants.owl remove --term 'IAO:0000116' --axioms annotation --signature true query --update ../sparql/add-skos-xrefs.ru --update ../sparql/remove-broad-xrefs.ru --update ../sparql/remove-related-xrefs.ru remove --select 'complement' --drop-axiom-annotations 'oboInOwl:source' reason -r ELK -e asserted-only --exclude-duplicate-axioms true --exclude-tautologies structural relax reduce annotate -V $(RELEASE_URIBASE)/$(ONT).owl --annotation owl:versionInfo $(RELEASEDATE) convert --add-prefixes prefixes.jsonld -o travis_build_dummy_out.ofn verify --queries $(SPARQLDIR)/multiple-class-links-violation.sparql $(SPARQLDIR)/obsolete-reference-violation.sparql $(SPARQLDIR)/missing_superclass-violation.sparql $(SPARQLDIR)/different-namespace-violation.sparql -O reports/
+	$(ROBOT) verify --input go-edit-filtered-xrefs.ofn --queries $(VARGS) -O reports/ \
+	  merge --collapse-import-closure false \
+	    -i imports/go-taxon-constraint-classes.ofn \
+	    -i imports/go-catalytic-activities-participants.owl \
+	    -i ../taxon_constraints/present_in_taxon.ofn \
+	  reason -r ELK -e asserted-only --exclude-duplicate-axioms true --exclude-tautologies structural \
+	  relax \
+	  reduce \
+	  verify --queries $(RARGS) -O reports/
 
 unsatisfiable: $(GO_GAF).owl
 	$(ROBOT) reason --reasoner ELK --input extensions/go-gaf.owl -D $(RELEASEDIR)/core_dump.owl || true
@@ -759,16 +806,32 @@ imports/go-taxon-groupings.obo: imports/go-taxon-groupings.owl
 # obsolete-definition and definition-constraints moved to Soufflé -- see
 # ../util/qc/checks/. They ran pre-reasoning here, as they do there, and both
 # implementations were confirmed to report the same (empty) result before the
-# move. The four checks below that run against reasoned.ofn are NOT duplicated
-# by the Datalog versions, which see only asserted axioms.
+# move.
+#
+# VCHECKS run pre-reasoning, on asserted axioms only, so every one of them is a
+# candidate to follow those five into ../util/qc/checks/.
 VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference synonym-label-match duplicate-exact-synonym duplicate-synonym non-IRI-value non-anyURI-value one-to-one-xrefs-by-subject one-to-one-xrefs-by-value xref-syntax xref-annotation
 
 # run all violation checks
 VARGS = $(foreach V,$(VCHECKS), $(SPARQLDIR)/$V-violation.sparql)
+
+# RCHECKS need the reasoned product, so they are not straightforward Soufflé
+# candidates. missing_superclass, different-namespace and obsolete-reference do
+# have Datalog counterparts, but those see only asserted (plus relax-derived)
+# axioms; running here additionally covers what ELK infers -- a logical
+# definition that lands a term under a differently-namespaced parent through a
+# chain is invisible to both ELK and the fact file. multiple-class-links has no
+# Datalog counterpart at all.
+#
+# Both users of this list run it against a graph where the GO-produced modules
+# have been merged rather than imported, because verify does not see imports.
+RCHECKS = multiple-class-links obsolete-reference missing_superclass different-namespace
+RARGS = $(foreach V,$(RCHECKS), $(SPARQLDIR)/$V-violation.sparql)
+
 sparql_test: go-edit-filtered-xrefs.ofn reasoned.ofn
 	$(ROBOT) verify --input $< --queries $(VARGS) -O reports/
 	# These purposely aren't checking problems in imports
-	$(ROBOT) verify --input reasoned.ofn --queries $(SPARQLDIR)/multiple-class-links-violation.sparql $(SPARQLDIR)/obsolete-reference-violation.sparql $(SPARQLDIR)/missing_superclass-violation.sparql $(SPARQLDIR)/different-namespace-violation.sparql -O reports/
+	$(ROBOT) verify --input reasoned.ofn --queries $(RARGS) -O reports/
 
 # use this to run tests on an individual basis
 reports/%-violation.csv: $(SRC)


### PR DESCRIPTION
travis_build was carrying the whole enhanced.ofn -> reasoned.ofn release pipeline in order to reach three failure gates. The shaping steps between those gates cannot fail a build, so they were costing every pull request time to produce an artifact that is immediately discarded.

Removed: the reactome xref merge (annotation-only), removal of IAO:0000116 editor notes, the three skos xref SPARQL updates, the oboInOwl:source axiom-annotation drop, version annotation, prefix injection, and two full serializations of GO to travis_build_dummy_out.ofn. All of this still runs on the way to a release via test / stage_release.

Kept, with the reasoning recorded on the target: the Rhea xref gate (filter-rhea-xrefs.sc), the pre-reasoning SPARQL checks, the three merged GO modules, reason -e asserted-only, and relax/reduce -- relax because multiple-class-links matches restrictions that only relax derives, reduce because it collapses a bad cross-namespace parent from a row per descendant to a single row.

The chain now opens on `verify --input` instead of `convert -i ... -o`, which keeps merge off the front (ROBOT #1250) without serializing.

Also factors the post-reasoning query list into RCHECKS/RARGS so travis_build and sparql_test cannot drift as checks migrate to Souffle, and rewrites the "must be kept in sync" comment, which is now the opposite of the intent.

Measured locally in the pinned ODK image, prerequisites warm: 2m51s -> 1m31s, with all 16 checks still running and passing. Verified the reasoning gate still fires by merging a probe class asserting GO:0000011 in_taxon NCBITaxon:4896, which its never_in_taxon constraint forbids: reason reports it unsatisfiable and the target exits 1.

Docs: CLAUDE.md and the odk-make skill told agents that `make travis_build` was the validation gate. It never was -- it is one prerequisite of travis_test, and running it alone skips datalog-check, qc-selftest, the perl OBO check, the taxon-constraint column checks and the ChEBI pH 7.3 check. Both now point at travis_test. Also corrects the claim that basic-cycles.tsv runs in travis_test (it is test-only, because it needs go-basic.ofn) and drops five queries from the fallback SPARQL command that had already moved to Souffle.