### PR TITLE
recover PMC full text that linkml-reference-validator silently drops

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -46,15 +46,44 @@ deep-research-client research --provider cyberian ....
 
 ## Caching PMIDs and DOIs
 
-You can use `linkml-reference-validator` to cache references. This is in your path. Note that this will not always work for full texts.
+Use `src/util/cache-references.py`, not `linkml-reference-validator` directly:
 
-Example:
-`linkml-reference-validator cache reference PMID:28318978`
+```
+./src/util/cache-references.py PMID:28318978 PMID:21423649
+./src/util/cache-references.py --from RESEARCH.md     # every PMID the draft cites
+./src/util/cache-references.py --recheck              # retry abstract-only entries
+```
+
 ==> writes to `references_cache/PMID_28318978.md`
 
-Always use this to check that there are no typos or hallucinations with reference IDs. If the title or abstract doesn't match with what the reference is purportedly supporting, there is likely a typo or hallucination.
+The wrapper runs `linkml-reference-validator cache reference` and then recovers
+the full text the validator silently drops. The validator's own PMC HTML
+fallback searches for markup PMC retired, so when a publisher restricts the
+Entrez XML you get `content_type: abstract_only` with no indication that full
+text existed. The wrapper tries Europe PMC's JATS XML, then the rendered PMC
+page for articles Europe PMC does not carry, and appends what it finds under
+`## Full Text` -- inside the region the validator reads back, so quotes from
+Methods and Results validate exactly as abstract quotes do.
 
-Note that `references_cache` should NOT be checked back in to git.
+Check `content_type` in the cached file to know what you are quoting from:
+
+- `full_text_xml` / `full_text_pmc` -- whole paper is searchable
+- `abstract_only` with `no_pmc` reported -- there is no PMC copy; if the
+  abstract does not support the claim, use the `NO_FULL_TEXT:` form below
+  rather than quoting something you cannot verify
+
+Always cache before citing, to check for typos and hallucinations in reference
+IDs. If the title or abstract doesn't match what the reference is purportedly
+supporting, there is likely a typo or hallucination. A PMID that does not exist
+at all makes the validation run exit non-zero -- that is deliberate, see the
+comments in `.linkml-reference-validator.yaml`.
+
+That config sits at the repo root and is auto-discovered, so **run the
+validator and this wrapper from the repo root**. From elsewhere the tool falls
+back to its defaults: a placeholder NCBI email, and no `skip_prefixes`, which
+makes every `GOC:`/`GO_REF:`/`RHEA:` xref look like an unfetchable reference.
+
+`references_cache` and `RESEARCH.md` are gitignored; do not check them in.
 
 ## Incorporating research results back into your work
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,10 @@ src/ontology/qc-unexpected-violations.tsv
 src/ontology/qc-unexpected-checks.tsv
 src/ontology/qc-unregistered-checks.tsv
 src/ontology/qc-selftest-violations.tsv
+
+# Reference caching and research notes (/research skill, src/util/cache-references.py).
+# Both are regenerable and neither belongs in the repo: the cache can reach
+# hundreds of KB per full-text paper, and RESEARCH.md is posted to the issue.
+references_cache/
+RESEARCH.md
+RESEARCH_*.md

--- a/.linkml-reference-validator.yaml
+++ b/.linkml-reference-validator.yaml
@@ -1,0 +1,107 @@
+# Configuration for linkml-reference-validator, used by the /research skill.
+#
+# The tool auto-discovers this file when run from the repo root, so the
+# commands in .claude/skills/research/SKILL.md pick it up with no --config flag.
+# Always run the validator from the repo root, or the defaults apply instead.
+
+# Where cached publications land. This is the tool's default, but it is stated
+# explicitly so a run from a subdirectory does not scatter a second cache.
+# References_cache is gitignored: it is regenerable and can get large.
+cache_dir: references_cache
+
+# NCBI asks every Entrez client to identify itself; the default is a placeholder
+# address (linkml-reference-validator@example.com), which invites throttling.
+email: raymond@wormbase.org
+
+# Zenodo-style supplementary files, off by default in the tool. Useful for GO
+# where a reaction or substrate list often lives only in a supplementary table.
+download_supplementary_files: true
+
+# unknown_prefix_severity is deliberately left at its default of ERROR, which
+# is where this config parts company with ai-gene-review's. That project sets
+# WARNING so flaky NCBI connectivity cannot fail CI. Here the point of the
+# REFERENCE-VALIDATION step is catching a PMID that does not exist, and WARNING
+# defeats it: a fabricated PMID:99999999 reports "Could not fetch reference"
+# and the run still exits 0. At the default it exits 1. A skip_prefixes entry
+# is the right way to silence a prefix; severity is not.
+#
+# The cost is that a genuine NCBI outage also fails the run. That is acceptable
+# because this is run by an editor who can read the message, not as a CI gate.
+
+# Prefixes to skip silently. GO definition xrefs are dominated by
+# non-literature identifiers -- 52k GOC, 4k ISBN, 3.8k GO_REF, 3.2k RHEA
+# against 21.6k PMID -- and snippet validation does not apply to any of them.
+# Matching is case-insensitive, so one entry covers Wikipedia/WIKIPEDIA/WIki.
+# Derived from the prefixes actually present on def: lines in go-edit.obo;
+# PMID, DOI and PMC are deliberately absent, as those are the fetchable ones.
+skip_prefixes:
+  - GOC
+  - GO
+  - GO_REF
+  - GOA
+  - GOCL
+  - ISBN
+  - ISSN
+  - RHEA
+  - EC
+  - MetaCyc
+  - RESID
+  - Wikipedia
+  - Wiki
+  - CL
+  - TC
+  - UniPathway
+  - UM-BBD_reactionID
+  - UM-BBD_pathwayID
+  - UM-BBD_enzymeID
+  - UM-BBD_ruleID
+  - VZ
+  - NIF_Subcellular
+  - InterPro
+  - PO
+  - PO_REF
+  - UniProtKB
+  - UniProtKB-KW
+  - UniProt
+  - UBERON
+  - MITRE
+  - MA
+  - ZFA
+  - ZFIN
+  - KEGG_REACTION
+  - CHEBI
+  - IUPHAR_GPCR
+  - IUPHAR_RECEPTOR
+  - Pfam
+  - MSH
+  - MeSH
+  - FBbt
+  - FB
+  - SO
+  - MP
+  - PDB
+  - XAO
+  - PubChem_Compound
+  - Prosite
+  - POC
+  - FMA
+  - WB_REF
+  - OMIM
+  - JSTOR
+  - Intact
+  - IMG
+  - RNAmods
+  - MEROPS
+  - MEROPS_fam
+  - PSI-MOD
+  - PATO
+  - LIGAND
+  - HEA
+  - GPC
+  - GOV
+  - DDANAT
+  - CORUM
+  - http
+  - https
+  - url
+  - file

--- a/src/util/cache-references.py
+++ b/src/util/cache-references.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Cache literature references, recovering full text the validator misses.
+
+`linkml-reference-validator cache reference PMID:N` resolves a PMC id and then
+tries PMC full text twice: the Entrez XML API, and, when a publisher restricts
+that, an HTML scrape of the article page. The HTML fallback is dead against the
+current PMC site -- it looks for `div.article-body` / `div.tsec`, retired
+markup, where the live page serves `<section class="body main-article-body">`
+(linkml_reference_validator/etl/sources/pmid.py, still the same in 0.2.1). The
+failure is silent: the cache entry is written with `content_type: abstract_only`
+and nothing says full text was available.
+
+This wrapper runs the validator first, then for anything left abstract-only
+with a PMC id it tries two sources in turn: Europe PMC's JATS XML, which
+serves most articles as clean structured XML with no publisher restriction and
+no markup to scrape; and, for articles deposited in PMC without an open-access
+licence (those 404 on Europe PMC), the rendered PMC page, scraped with the
+selector the live site actually uses. Recovered text is appended to the cached
+file under a `## Full Text` heading, inside the region the validator reads back
+as content, so `validate text-file` matches quotes against it unchanged.
+
+Usage:
+    src/util/cache-references.py PMID:21423649 PMID:37013624
+    src/util/cache-references.py --from RESEARCH.md
+    src/util/cache-references.py --recheck        # retry every abstract-only entry
+
+Run from the repo root so .linkml-reference-validator.yaml is picked up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+CACHE_DIR = Path("references_cache")
+CONFIG = Path(".linkml-reference-validator.yaml")
+
+EUROPEPMC = "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
+PMC_HTML = "https://pmc.ncbi.nlm.nih.gov/articles/{pmcid}/"
+ELINK = (
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
+    "?dbfrom=pubmed&db=pmc&linkname=pubmed_pmc&retmode=json&id={pmid}&email={email}"
+)
+
+# Below this, a "full text" is a headings-only fragment or a stub page, not
+# something worth overwriting an honest abstract_only marker for.
+MIN_FULLTEXT_CHARS = 3000
+
+REQUEST_DELAY = 0.5
+TIMEOUT = 60
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def config_email() -> str:
+    """Read the Entrez contact address out of the repo config."""
+    if CONFIG.exists():
+        for line in CONFIG.read_text(encoding="utf-8").splitlines():
+            if line.startswith("email:"):
+                return line.split(":", 1)[1].strip()
+    return "linkml-reference-validator@example.com"
+
+
+def get(url: str, email: str) -> bytes | None:
+    """Fetch a URL, returning None rather than raising on any HTTP failure."""
+    time.sleep(REQUEST_DELAY)
+    req = urllib.request.Request(
+        url, headers={"User-Agent": f"go-ontology-cache-references (+{email})"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.read()
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        log(f"    fetch failed: {url} -- {exc}")
+        return None
+
+
+def cache_path(ref: str) -> Path:
+    return CACHE_DIR / (ref.replace(":", "_") + ".md")
+
+
+def split_cached(text: str) -> tuple[dict[str, str], str]:
+    """Split a cached entry into frontmatter fields and the markdown body.
+
+    Only the scalar fields this script reads or rewrites are parsed; list
+    values (keywords, authors) are left alone in the raw text.
+    """
+    fields: dict[str, str] = {}
+    if not text.startswith("---"):
+        return fields, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return fields, text
+    for line in text[3:end].splitlines():
+        m = re.match(r"^([a-z_]+):\s*(.*)$", line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip()
+    return fields, text[end + 4 :]
+
+
+def find_pmcid(pmid: str, body: str, email: str) -> str | None:
+    """Recover the PMC id, preferring the one Entrez already put in the body."""
+    m = re.search(r"PMCID:\s*(PMC\d+)", body)
+    if m:
+        return m.group(1)
+
+    raw = get(ELINK.format(pmid=pmid, email=email), email)
+    if not raw:
+        return None
+    try:
+        linksets = json.loads(raw).get("linksets", [])
+        for ls in linksets:
+            for db in ls.get("linksetdbs", []):
+                # pubmed_pmc is the PMC copy of this article; pubmed_pmc_refs
+                # would be articles citing it, which is a different thing.
+                if db.get("linkname") == "pubmed_pmc" and db.get("links"):
+                    return "PMC" + str(db["links"][0])
+    except (ValueError, KeyError, TypeError) as exc:
+        log(f"    could not read elink response: {exc}")
+    return None
+
+
+def jats_to_text(xml_bytes: bytes) -> str | None:
+    """Flatten the <body> of a JATS article into headings and paragraphs.
+
+    Only <body> is walked, which leaves out <back> -- the reference list,
+    acknowledgements and competing-interest statements. Bibliographic xref
+    markers are dropped: they interrupt sentences mid-quote and a curator
+    quoting the paper will not have copied them.
+    """
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError as exc:
+        log(f"    JATS parse error: {exc}")
+        return None
+
+    body = root.find(".//body")
+    if body is None:
+        return None
+
+    for xref in body.iter("xref"):
+        if xref.get("ref-type") == "bibr":
+            # Drop the marker text only. clear() would also discard the tail --
+            # the rest of the sentence after the citation -- silently losing
+            # most of the prose in a densely cited paragraph.
+            xref.text = ""
+
+    parts: list[str] = []
+    for el in body.iter():
+        if el.tag not in ("title", "p"):
+            continue
+        text = re.sub(r"\s+", " ", "".join(el.itertext())).strip()
+        if not text:
+            continue
+        parts.append(f"### {text}" if el.tag == "title" else text)
+
+    # dict.fromkeys dedupes boilerplate repeated across sections while keeping order
+    return "\n\n".join(dict.fromkeys(parts)) if parts else None
+
+
+def pmc_html_to_text(html_bytes: bytes) -> str | None:
+    """Extract body text from a current PMC article page.
+
+    This is the fallback the validator gets wrong. It looks for
+    `div.article-body` / `div.tsec`, markup PMC has retired; the live page
+    serves `<section class="body main-article-body">`. Europe PMC covers most
+    articles, but not those deposited in PMC without an open-access licence,
+    which 404 on its fullTextXML endpoint while still rendering here.
+    """
+    # Imported here rather than at module scope: bs4 is only needed for this
+    # second-tier fallback, and most runs never reach it.
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html_bytes, "html.parser")
+    article = (
+        soup.select_one("section.body.main-article-body")
+        or soup.select_one("section[aria-label='Article content']")
+        or soup.find("article")
+    )
+    if article is None:
+        return None
+
+    parts: list[str] = []
+    for el in article.find_all(["h2", "h3", "h4", "p"]):
+        if el.find_parent(["figcaption", "table", "nav", "aside", "footer"]):
+            continue
+        text = re.sub(r"\s+", " ", el.get_text(separator=" ", strip=True)).strip()
+        if not text:
+            continue
+        if el.name != "p":
+            parts.append(f"### {text}")
+        elif len(text) > 30:
+            parts.append(text)
+
+    return "\n\n".join(dict.fromkeys(parts)) if parts else None
+
+
+def run_validator(ref: str) -> bool:
+    """Let the validator do the metadata fetch and write the cache entry."""
+    proc = subprocess.run(
+        ["linkml-reference-validator", "cache", "reference", ref],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        log(f"    validator failed: {proc.stderr.strip().splitlines()[-1:] or proc.stdout}")
+        return False
+    return True
+
+
+def augment(ref: str, email: str, force: bool = False) -> str:
+    """Return a one-word status: full_text, recovered, no_pmc, unavailable, error."""
+    path = cache_path(ref)
+    if not path.exists():
+        if not run_validator(ref):
+            return "error"
+    if not path.exists():
+        return "error"
+
+    text = path.read_text(encoding="utf-8")
+    fields, body = split_cached(text)
+
+    if fields.get("content_type", "").startswith("full_text") and not force:
+        return "full_text"
+
+    pmid = ref.split(":", 1)[1]
+    pmcid = find_pmcid(pmid, body, email)
+    if not pmcid:
+        return "no_pmc"
+
+    # Tier 1: Europe PMC JATS. Clean structured XML, no markup to scrape, and
+    # no publisher restriction on the endpoint -- but it 404s for articles
+    # deposited in PMC without an open-access licence.
+    full_text, source = None, pmcid
+    xml_bytes = get(EUROPEPMC.format(pmcid=pmcid), email)
+    if xml_bytes:
+        full_text = jats_to_text(xml_bytes)
+
+    # Tier 2: the rendered PMC page, which still carries those articles.
+    if not full_text or len(full_text) < MIN_FULLTEXT_CHARS:
+        html_bytes = get(PMC_HTML.format(pmcid=pmcid), email)
+        if html_bytes:
+            html_text = pmc_html_to_text(html_bytes)
+            if html_text and len(html_text) > len(full_text or ""):
+                full_text, source = html_text, f"{pmcid} (HTML)"
+
+    if not full_text or len(full_text) < MIN_FULLTEXT_CHARS:
+        got = len(full_text) if full_text else 0
+        log(f"    only {got} chars available from PMC; keeping abstract")
+        return "unavailable"
+
+    # Rewrite in place, idempotently: drop anything a previous run of this
+    # script added first, so --force does not stack a second full_text_source
+    # key (which makes the frontmatter invalid YAML) or a second body copy.
+    text = re.sub(r"^full_text_source: .*\n", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\n## Full Text\n.*\Z", "", text, flags=re.DOTALL)
+    text = re.sub(r"^content_type: full_text_(europepmc|pmc)$", "content_type: abstract_only",
+                  text, count=1, flags=re.MULTILINE)
+
+    # The heading sits inside the region the validator reads back (everything
+    # after "## Content"), so the recovered text is searched for quotes
+    # exactly as the abstract is.
+    text = re.sub(
+        r"^content_type: .*$",
+        f"content_type: full_text_pmc\nfull_text_source: {source}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(r"\n*\Z", "\n", text)
+    text += f"\n## Full Text\n\nRetrieved from PMC ({source}).\n\n{full_text}\n"
+    path.write_text(text, encoding="utf-8")
+    return "recovered"
+
+
+def refs_from_file(path: Path) -> list[str]:
+    """Pull every PMID mentioned in a file, in first-seen order."""
+    found = re.findall(r"\bPMID:\s?(\d{4,9})\b", path.read_text(encoding="utf-8"))
+    return list(dict.fromkeys(f"PMID:{p}" for p in found))
+
+
+def abstract_only_in_cache() -> list[str]:
+    refs = []
+    for path in sorted(CACHE_DIR.glob("PMID_*.md")):
+        fields, _ = split_cached(path.read_text(encoding="utf-8"))
+        if fields.get("content_type") == "abstract_only":
+            refs.append(path.stem.replace("_", ":", 1))
+    return refs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("refs", nargs="*", help="reference IDs, e.g. PMID:21423649")
+    parser.add_argument("--from", dest="from_file", type=Path,
+                        help="read every PMID mentioned in this file (e.g. RESEARCH.md)")
+    parser.add_argument("--recheck", action="store_true",
+                        help="retry full text for every abstract-only entry already cached")
+    parser.add_argument("--force", action="store_true",
+                        help="re-fetch full text even for entries that already have it")
+    args = parser.parse_args()
+
+    if not CONFIG.exists():
+        log(f"warning: {CONFIG} not found -- run from the repo root, "
+            "or the tool's defaults (placeholder NCBI email) apply")
+
+    refs = list(args.refs)
+    if args.from_file:
+        refs += refs_from_file(args.from_file)
+    if args.recheck:
+        refs += abstract_only_in_cache()
+    refs = list(dict.fromkeys(refs))
+
+    if not refs:
+        parser.error("no references given; pass IDs, --from FILE, or --recheck")
+
+    non_pmid = [r for r in refs if not r.startswith("PMID:")]
+    if non_pmid:
+        log(f"note: full-text recovery is PMID-only; caching without it: {', '.join(non_pmid)}")
+
+    email = config_email()
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    counts: dict[str, int] = {}
+    for i, ref in enumerate(refs, 1):
+        log(f"[{i}/{len(refs)}] {ref}")
+        if not ref.startswith("PMID:"):
+            status = "full_text" if run_validator(ref) else "error"
+        else:
+            status = augment(ref, email, force=args.force)
+        counts[status] = counts.get(status, 0) + 1
+        log(f"    {status}")
+
+    log("")
+    log(f"  recovered   full text newly pulled from PMC:     {counts.get('recovered', 0)}")
+    log(f"  full_text   already had full text:               {counts.get('full_text', 0)}")
+    log(f"  no_pmc      no PMC copy exists; abstract only:   {counts.get('no_pmc', 0)}")
+    log(f"  unavailable PMC copy exists but no full text:    {counts.get('unavailable', 0)}")
+    log(f"  error       fetch failed:                        {counts.get('error', 0)}")
+
+    return 1 if counts.get("error") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
[Written by Claude]

Tooling only -- no ontology content changes. Recovers PMC full text that
`linkml-reference-validator` drops without saying so, and adds a repo config
for it.

## The problem

The `/research` workflow uses `linkml-reference-validator cache reference` for
both reference checking and publication text. It resolves a PMC id, then tries
full text twice: Entrez XML, and an HTML scrape of the article page when a
publisher restricts the XML.

The HTML fallback is dead against the current PMC site. It looks for
`div.article-body` / `div.tsec` (`etl/sources/pmid.py`), markup PMC has
retired; the live page serves `<section class="body main-article-body">`.
`tsec` appears zero times in the current HTML. Same code in 0.2.0 and 0.2.1,
so upgrading does not fix it.

The failure is silent -- the entry is written `content_type: abstract_only`
with nothing to indicate full text was available. Measured on four PMIDs that
all resolve a PMC id, three came back abstract-only despite full text existing.

## The fix

`src/util/cache-references.py` runs the validator, then for anything left
abstract-only with a PMC id tries two further sources:

1. **Europe PMC JATS XML** -- clean structured text, no publisher restriction,
   no markup to scrape.
2. **The rendered PMC page**, for articles deposited in PMC without an
   open-access licence (those 404 on Europe PMC), scraped with the selector
   the site actually uses.

Recovered text is appended under `## Full Text`, inside the region the
validator reads back as content, so `validate text-file` matches quotes from
Methods and Results with no other change. Rewrites are idempotent.

```
./src/util/cache-references.py PMID:28318978 PMID:21423649
./src/util/cache-references.py --from RESEARCH.md     # every PMID a draft cites
./src/util/cache-references.py --recheck              # retry abstract-only entries
```

## Measured effect

Run over an existing 133-entry cache:

| | before | after |
|---|---|---|
| abstract only | 115 | 60 |
| full text | 18 | 73 |

Of the 60 that remain, 52 have no PMC copy at all and 8 return too little text
to be worth overwriting an honest `abstract_only` marker. Those cases are
reported as `no_pmc` / `unavailable` rather than silently passed.

End-to-end check: a Methods-section quote that exists *only* in recovered text
validates; a fabricated quote fails; `GOC:`/`RHEA:` xrefs skip silently; a
nonexistent PMID exits 1.

## The config

`.linkml-reference-validator.yaml` sits at the repo root and is auto-discovered,
so existing `/research` commands pick it up with no `--config` flag. It:

- points `cache_dir` at `references_cache`
- sets a real NCBI contact address (the tool's default is a placeholder,
  `linkml-reference-validator@example.com`, which invites throttling)
- enables supplementary-file download (off by default)
- skips the 70 non-literature prefixes that actually occur on `def:` lines in
  `go-edit.obo` -- 52k `GOC`, 4k `ISBN`, 3.8k `GO_REF`, 3.2k `RHEA` against
  21.6k `PMID`. The list is derived from the file, not guessed.

**It deliberately does not set `unknown_prefix_severity: WARNING`.** The
equivalent config in `ai4curation/ai-gene-review` does, so flaky NCBI
connectivity cannot fail CI. Here that would defeat the REFERENCE-VALIDATION
step: with `WARNING`, a fabricated `PMID:99999999` reports "Could not fetch
reference" and the run still **exits 0**; at the default it exits 1. Verified
both ways. `skip_prefixes` is the right tool for silencing a prefix.

The cost is that a genuine NCBI outage also fails the run, which is acceptable
for something an editor runs and reads rather than a CI gate.

I also left out `literal_bracket_patterns`, which that project's config
carries: the key does not exist in the installed validator and is silently
ignored, so committing it would be dead config.

## Other changes

- `.gitignore`: `references_cache/`, `RESEARCH.md`, `RESEARCH_*.md`. All
  regenerable, and a full-text cache entry can reach hundreds of KB.
- `.claude/skills/research/SKILL.md`: the caching section now points at the
  wrapper and tells the reader to check `content_type` before quoting, and to
  run from the repo root so the config is found.

## Worth reporting upstream

The retired-selector bug degrades full text for every consumer of
`linkml-reference-validator`, including ai-gene-review's own pipeline. Worth a
ticket against that project; this PR works around it rather than fixing it.

## Notes for review

- No ontology files touched; `go-edit.obo` is untouched by this branch.
- Rebased onto master after #32589 merged.
- The script is stdlib-only except `bs4`, imported lazily inside the
  second-tier fallback so most runs never need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
